### PR TITLE
dbus/org.dharkael.Flameshot.xml: Mark id as uint

### DIFF
--- a/dbus/org.dharkael.Flameshot.xml
+++ b/dbus/org.dharkael.Flameshot.xml
@@ -14,7 +14,7 @@
     <method name="graphicCapture">
       <arg name="path" type="s" direction="in"/>
       <arg name="delay" type="i" direction="in"/>
-      <arg name="id" type="i" direction="in"/>
+      <arg name="id" type="u" direction="in"/>
     </method>
 
     <!--
@@ -30,7 +30,7 @@
       <arg name="path" type="s" direction="in"/>
       <arg name="toClipboard" type="b" direction="in"/>
       <arg name="delay" type="i" direction="in"/>
-      <arg name="id" type="i" direction="in"/>
+      <arg name="id" type="u" direction="in"/>
     </method>
 
     <!--
@@ -57,7 +57,7 @@
       <arg name="path" type="s" direction="in"/>
       <arg name="toClipboard" type="b" direction="in"/>
       <arg name="delay" type="i" direction="in"/>
-      <arg name="id" type="i" direction="in"/>
+      <arg name="id" type="u" direction="in"/>
     </method>
 
     <!--
@@ -99,7 +99,7 @@
         Successful capture signal returning the image.
     -->
     <signal name="captureTaken">
-      <arg name="id" type="i" direction="out"/>
+      <arg name="id" type="u" direction="out"/>
       <arg name="rawImage" type="ay" direction="out"/>
     </signal>
 
@@ -110,7 +110,7 @@
         Whenever the capture fails.
     -->
     <signal name="captureFailed">
-      <arg name="id" type="i" direction="out"/>
+      <arg name="id" type="u" direction="out"/>
     </signal>
   </interface>
 </node>


### PR DESCRIPTION
In `src/core/flameshotdbusadapter.h` the id is marked as uint.
All other types in the xml are correct.

Took me a while to figure out that I had to use unsigned int.