### PR TITLE
Fix "Close after capture" mode

### DIFF
--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -702,6 +702,12 @@ void CaptureWidget::handleButtonSignal(CaptureTool::Request r) {
             QWidget *w = m_activeTool->widget();
             w->setAttribute(Qt::WA_DeleteOnClose);
             w->show();
+            if (ConfigHandler().closeAfterScreenshotValue()) {
+                hide();
+                QEventLoop loop;
+                connect(w, &QWidget::destroyed, &loop, &QEventLoop::quit);
+                loop.exec();
+            }
         }
         break;
     default:


### PR DESCRIPTION
Fixed closing the application if "close after capture" mode is set

Steps:
1. Check the box "close after capture"
2. Press on the button "Choose an app to open the capture" or "Upload to Imgur" or "Pin image on the desktop"

Observed Behavior:
The application is closed

Expected Behavior:
The widget will open
When the widget will close the application will be closed