### PR TITLE
Changed enter/return key to save not copy

### DIFF
--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -778,8 +778,8 @@ void CaptureWidget::initShortcuts() {
     new QShortcut(QKeySequence(Qt::SHIFT + Qt::Key_Down), this, SLOT(downResize()));
     new QShortcut(Qt::Key_Space, this, SLOT(togglePanel()));
     new QShortcut(Qt::Key_Escape, this, SLOT(deleteToolwidgetOrClose()));
-    new QShortcut(Qt::Key_Return, this, SLOT(copyScreenshot()));
-    new QShortcut(Qt::Key_Enter, this, SLOT(copyScreenshot()));
+    new QShortcut(Qt::Key_Return, this, SLOT(saveScreenshot()));
+    new QShortcut(Qt::Key_Enter, this, SLOT(saveScreenshot()));
 }
 
 void CaptureWidget::updateSizeIndicator() {


### PR DESCRIPTION
simple change that makes the enter key save the screenshot to filesystem and not to the clipboard