### PR TITLE
correct position of QScreen geometry on HiDPI multi-headed setup

### DIFF
--- a/src/utils/screengrabber.cpp
+++ b/src/utils/screengrabber.cpp
@@ -90,7 +90,10 @@ QPixmap ScreenGrabber::grabEntireDesktop(bool& ok)
 
     QRect geometry;
     for (QScreen* const screen : QGuiApplication::screens()) {
-        geometry = geometry.united(screen->geometry());
+        QRect scrRect = screen->geometry();
+        scrRect.moveTo(scrRect.x() / screen->devicePixelRatio(),
+                       scrRect.y() / screen->devicePixelRatio());
+        geometry = geometry.united(scrRect);
     }
 
     QPixmap p(QApplication::primaryScreen()->grabWindow(

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -126,6 +126,8 @@ CaptureWidget::CaptureWidget(const uint id,
     if (m_context.fullscreen) {
         for (QScreen* const screen : QGuiApplication::screens()) {
             QRect r = screen->geometry();
+            r.moveTo(r.x() / screen->devicePixelRatio(),
+                     r.y() / screen->devicePixelRatio());
 #ifdef Q_OS_WIN
             r.moveTo(r.topLeft() - topLeft);
 #endif
@@ -600,6 +602,10 @@ void CaptureWidget::initPanel()
     QRect panelRect = rect();
     if (m_context.fullscreen) {
         panelRect = QGuiApplication::primaryScreen()->geometry();
+        auto devicePixelRatio =
+          QGuiApplication::primaryScreen()->devicePixelRatio();
+        panelRect.moveTo(panelRect.x() / devicePixelRatio,
+                         panelRect.y() / devicePixelRatio);
     }
 
     ConfigHandler config;


### PR DESCRIPTION
Although QT documentation claims that the property `QScreen.geometry` is
pixel instead of dip, this does not seem to be the case at least in my
setup with two 3840x2160 screens on KDE Xorg with a global pixel ratio
of 2.0. `width()` and `height()` return values in dip (1920x1080), while
`x()` and `y()` return values in px (the second screen is indicated to
be at the point (3840, 0)) as of my latest test on QT 5.13.

This weird behavior causes issues when trying to use Flameshot on such
setups because the grabbed image does not match the actual geometry of
the screens. In my case, the grabbed image is 3 times the width of each
of the screen, leaving the rightmost part black, and causing Flameshot
to show a black image on one of them in the editing state.

I am not sure if this strange behavior of QT is consistent for everyone, so
more test in similar setups might be needed. But if it is a behavior of
QT, then a fix from upstream will probably be implausible due to
possible breakages it might cause, so this patch would still be needed anyway.

If anyone has similar setups of two side-by-side HiDPI monitors, please
report if there were issues when using Flameshot, and if so, please test
if this patch fixes the problems properly. I'm not sure if this would
work properly on multiple-monitor setups, either.