### PR TITLE
imgur: make uploader to be compliant with w3c recommendations

### DIFF
--- a/src/tools/imgur/imguruploader.cpp
+++ b/src/tools/imgur/imguruploader.cpp
@@ -111,7 +111,7 @@ void ImgurUploader::upload() {
 
     QHttpPart titlePart;
     titlePart.setHeader(QNetworkRequest::ContentDispositionHeader, QVariant("form-data; name=\"title\""));
-    titlePart.setBody(QStringLiteral("flameshot_screenshot"));
+    titlePart.setBody("flameshot_screenshot");
 
     QHttpPart descPart;
     descPart.setHeader(QNetworkRequest::ContentDispositionHeader, QVariant("form-data; name=\"description\""));


### PR DESCRIPTION
application/x-www-form-urlencoded is inefficient for binary uploads, instead
we should use multipart/form-data POST requests. Imgur API support this.