### PR TITLE
 - Implement screenshot history widget

### DIFF
--- a/flameshot.pro
+++ b/flameshot.pro
@@ -77,6 +77,7 @@ DEFINES += QAPPLICATION_CLASS=QApplication
 SOURCES += src/main.cpp \
     src/widgets/capture/buttonhandler.cpp \
     src/widgets/infowindow.cpp \
+    src/widgets/historywindow.cpp \
     src/config/configwindow.cpp \
     src/widgets/capture/capturewidget.cpp \
     src/widgets/capture/colorpicker.cpp \
@@ -149,6 +150,7 @@ SOURCES += src/main.cpp \
 
 HEADERS  += src/widgets/capture/buttonhandler.h \
     src/widgets/infowindow.h \
+    src/widgets/historywindow.h \
     src/config/configwindow.h \
     src/widgets/capture/capturewidget.h \
     src/widgets/capture/colorpicker.h \

--- a/src/core/controller.h
+++ b/src/core/controller.h
@@ -27,6 +27,7 @@
 
 class CaptureWidget;
 class ConfigWindow;
+class HistoryWindow;
 class InfoWindow;
 class QSystemTrayIcon;
 
@@ -51,6 +52,7 @@ public slots:
     void requestCapture(const CaptureRequest &request);
 
     void openConfigWindow();
+    void openHistoryWindow();
     void openInfoWindow();
     void openLauncherWindow();
     void enableTrayIcon();
@@ -79,6 +81,7 @@ private:
 
     QMap<uint, CaptureRequest> m_requestMap;
     QPointer<CaptureWidget> m_captureWindow;
+    QPointer<HistoryWindow> m_historyWindow;
     QPointer<InfoWindow> m_infoWindow;
     QPointer<ConfigWindow> m_configWindow;
     QPointer<QSystemTrayIcon> m_trayIcon;

--- a/src/widgets/capture/capturewidget.h
+++ b/src/widgets/capture/capturewidget.h
@@ -53,6 +53,7 @@ public:
     explicit CaptureWidget(const uint id = 0,
                            const QString &savePath = QString(),
                            bool fullScreen = true,
+                           QPixmap editPixmap = QPixmap(),
                            QWidget *parent = nullptr);
     ~CaptureWidget();
 
@@ -124,7 +125,7 @@ protected:
 
 private:
     void initContext(const QString &savePath, bool fullscreen);
-    void initPanel();
+    void initPanel(QRect inputRect = QRect());
     void initSelection();
     void initShortcuts();
     void updateSizeIndicator();
@@ -141,6 +142,7 @@ private:
     QPointer<CaptureButton> m_activeButton;
     QPointer<CaptureTool> m_activeTool;
     QPointer<QWidget> m_toolWidget;
+    QPixmap m_editPixmap;
 
     ButtonHandler *m_buttonHandler;
     UtilityPanel *m_panel;

--- a/src/widgets/capture/selectionwidget.cpp
+++ b/src/widgets/capture/selectionwidget.cpp
@@ -21,7 +21,7 @@
 #include <QPropertyAnimation>
 
 SelectionWidget::SelectionWidget(const QColor &c, QWidget *parent) :
-    QWidget(parent), m_color(c)
+    QWidget(parent), m_color(c), m_sizeLimit(QRect())
 {
     m_animation = new QPropertyAnimation(this, "geometry", this);
     m_animation->setEasingCurve(QEasingCurve::InOutQuad);
@@ -77,6 +77,26 @@ void SelectionWidget::setGeometryAnimated(const QRect &r) {
         m_animation->setEndValue(r);
         m_animation->start();
     }
+}
+void SelectionWidget::setGeometry(const QRect &r)
+{
+    QRect c = r;
+    if (!m_sizeLimit.isEmpty()) {
+        if (c.bottom() > m_sizeLimit.bottom())
+            c.setBottom(m_sizeLimit.bottom());
+        if (c.left() < m_sizeLimit.left())
+            c.setLeft(m_sizeLimit.left());
+        if (c.top() < m_sizeLimit.top())
+            c.setTop(m_sizeLimit.top());
+        if (c.right() > m_sizeLimit.right())
+            c.setRight(m_sizeLimit.right());
+    }
+    QWidget::setGeometry(c);
+}
+
+void SelectionWidget::setSizeLimit(const QRect &r)
+{
+    m_sizeLimit = r;
 }
 
 void SelectionWidget::saveGeometry() {

--- a/src/widgets/capture/selectionwidget.h
+++ b/src/widgets/capture/selectionwidget.h
@@ -45,6 +45,8 @@ public:
     void setGeometryAnimated(const QRect &r);
     void saveGeometry();
     QRect savedGeometry();
+    virtual void setGeometry(const QRect &r);
+    void setSizeLimit(const QRect &r);
 
 protected:
     void paintEvent(QPaintEvent *);
@@ -66,6 +68,8 @@ private:
     QPoint m_areaOffset;
     QPoint m_handleOffset;
     QRect m_geometryBackup;
+
+    QRect m_sizeLimit;
 
     // naming convention for handles
     // T top, B bottom, R Right, L left

--- a/src/widgets/historywindow.cpp
+++ b/src/widgets/historywindow.cpp
@@ -1,0 +1,149 @@
+// Copyright(c) 2020 Tobias Eliasson <arnestig@gmail.com>
+//
+// This file is part of Flameshot.
+//
+//     Flameshot is free software: you can redistribute it and/or modify
+//     it under the terms of the GNU General Public License as published by
+//     the Free Software Foundation, either version 3 of the License, or
+//     (at your option) any later version.
+//
+//     Flameshot is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//     GNU General Public License for more details.
+//
+//     You should have received a copy of the GNU General Public License
+//     along with Flameshot.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "historywindow.h"
+#include "src/core/controller.h"
+#include "src/widgets/capture/capturewidget.h"
+#include "src/widgets/imagelabel.h"
+#include <QApplication>
+#include <QClipboard>
+#include <QAction>
+#include <QIcon>
+#include <QVBoxLayout>
+#include <QTableWidget>
+#include <QHeaderView>
+#include <QLabel>
+#include <QKeyEvent>
+
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
+#include <QCursor>
+#include <QRect>
+#include <QScreen>
+#include <QGuiApplication>
+#endif
+
+// historywindow shows old snapshots taken and allows to copy utilize them again
+
+HistoryWindow::HistoryWindow(QWidget *parent) : QWidget(parent) {
+    setWindowIcon(QIcon(":img/app/flameshot.svg"));
+    setWindowTitle(tr("History"));
+
+    connect(this, &HistoryWindow::captureTaken,
+            Controller::getInstance(), &Controller::captureTaken);
+
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
+    QRect position = frameGeometry();
+    QScreen *screen = QGuiApplication::screenAt(QCursor::pos());
+    position.moveCenter(screen->availableGeometry().center());
+    move(position.topLeft());
+#endif
+
+    m_layout = new QVBoxLayout(this);
+    m_layout->setAlignment(Qt::AlignHCenter);
+    initTabWidget();
+}
+
+void HistoryWindow::initTabWidget() {
+    m_tabWidget = new QTabWidget(this);
+    m_tabWidget->setMinimumWidth(800);
+    m_tabWidget->setMinimumHeight(400);
+    m_tabWidget->setTabsClosable(true);
+    connect(m_tabWidget, SIGNAL(tabCloseRequested(int)), this, SLOT(closeTab(int)));
+    m_layout->addWidget(m_tabWidget);
+
+    // Ctrl + W for closing a tab
+    QAction *closeAction = new QAction(this);
+    closeAction->setShortcut(QKeySequence(Qt::CTRL + Qt::Key_W));
+    m_tabWidget->addAction(closeAction);
+    connect(closeAction, &QAction::triggered, this, &HistoryWindow::closeTabShortcut);
+
+    // Ctrl + C for copying an image in a tab
+    QAction *copyAction = new QAction(this);
+    copyAction->setShortcut(QKeySequence(Qt::CTRL + Qt::Key_C));
+    m_tabWidget->addAction(copyAction);
+    connect(copyAction, &QAction::triggered, this, &HistoryWindow::copyImage);
+}
+
+void HistoryWindow::copyImage()
+{
+    QWidget *tab = m_tabWidget->currentWidget();
+    if ( tab != NULL ) {
+        ImageLabel *label = tab->findChild<ImageLabel*>();
+        if ( label != NULL ) {
+            QApplication::clipboard()->setPixmap(label->getScreenshot());
+        }
+    }
+}
+
+void HistoryWindow::closeTabShortcut()
+{
+    closeTab(m_tabWidget->currentIndex());
+}
+
+void HistoryWindow::closeTab(int index)
+{
+    QString tabName = m_tabWidget->tabText(index);
+    m_historyMap.remove( tabName );
+    m_tabWidget->removeTab( index );
+}
+
+void HistoryWindow::addImage( QString tabName, QPixmap p )
+{
+    QWidget *tab;
+    ImageLabel *label;
+
+    // save screenshot with date key
+    m_historyMap[ tabName ] = p;
+    auto ity = m_historyMap.find(tabName);
+
+    // see if we can find a tab with the tabName already in our widget
+    tab = m_tabWidget->findChild<QWidget*>( tabName );
+    if ( tab != NULL ) {
+        label = tab->findChild<ImageLabel*>();
+        if ( label != NULL ) {
+            label->setScreenshot(ity.value());
+        }
+    } else {
+        tab = new QWidget();
+        QHBoxLayout *layout = new QHBoxLayout(tab);
+        label = new ImageLabel(tab);
+        label->setScreenshot(ity.value());
+        tab->setObjectName( tabName );
+
+        connect(label, &ImageLabel::historyEdit, this, &HistoryWindow::edit);
+
+        layout->addWidget(label);
+        m_tabWidget->addTab(tab, ity.key());
+        m_tabWidget->setTabText(m_tabWidget->indexOf(tab), tabName);
+        m_tabWidget->setCurrentIndex(m_tabWidget->indexOf(tab));
+    }
+}
+
+void HistoryWindow::edit()
+{
+    QString tabName = m_tabWidget->tabText(m_tabWidget->currentIndex());
+    QPixmap p = m_historyMap[ tabName ];
+    CaptureWidget *captureWidget = new CaptureWidget(m_tabWidget->currentIndex(), QString(),false,p);
+    captureWidget->show();
+    connect(captureWidget, &CaptureWidget::captureTaken, this, &HistoryWindow::editDone);
+}
+
+void HistoryWindow::editDone(uint id, QPixmap p)
+{
+    QString tabName = m_tabWidget->tabText(id);
+    addImage(tabName,p);
+}

--- a/src/widgets/historywindow.h
+++ b/src/widgets/historywindow.h
@@ -1,0 +1,48 @@
+// Copyright(c) 2020 Tobias Eliasson <arnestig@gmail.com>
+//
+// This file is part of Flameshot.
+//
+//     Flameshot is free software: you can redistribute it and/or modify
+//     it under the terms of the GNU General Public License as published by
+//     the Free Software Foundation, either version 3 of the License, or
+//     (at your option) any later version.
+//
+//     Flameshot is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//     GNU General Public License for more details.
+//
+//     You should have received a copy of the GNU General Public License
+//     along with Flameshot.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <QMap>
+#include <QWidget>
+#include <QHBoxLayout>
+#include <QTabWidget>
+
+class QVBoxLayout;
+
+class HistoryWindow : public QWidget {
+    Q_OBJECT
+public:
+    explicit HistoryWindow(QWidget *parent = nullptr);
+    void addImage( QString tabName, QPixmap p );
+signals:
+    void captureTaken(uint id, QPixmap p);
+
+private slots:
+    void edit();
+    void editDone(uint id, QPixmap p);
+    void closeTab(int index);
+    void closeTabShortcut();
+    void copyImage();
+
+private:
+    void initTabWidget();
+    QMap< QString, QPixmap > m_historyMap;
+    QVBoxLayout *m_layout;
+    QTabWidget *m_tabWidget;
+    QHBoxLayout *m_horizontalLayout;
+};

--- a/src/widgets/imagelabel.cpp
+++ b/src/widgets/imagelabel.cpp
@@ -43,6 +43,11 @@ void ImageLabel::setScreenshot(const QPixmap &pixmap) {
     setScaledPixmap();
 }
 
+QPixmap ImageLabel::getScreenshot()
+{
+    return m_pixmap;
+}
+
 void ImageLabel::setScaledPixmap() {
     const qreal scale = qApp->devicePixelRatio();
     QPixmap scaledPixmap = m_pixmap.scaled(size() * scale, Qt::KeepAspectRatio,
@@ -77,6 +82,10 @@ void ImageLabel::mouseMoveEvent(QMouseEvent *event) {
     }
     setCursor(Qt::OpenHandCursor);
     emit dragInitiated();
+}
+
+void ImageLabel::mouseDoubleClickEvent(QMouseEvent *event) {
+    emit historyEdit();
 }
 
 // resize handler

--- a/src/widgets/imagelabel.h
+++ b/src/widgets/imagelabel.h
@@ -35,12 +35,15 @@ class ImageLabel : public QLabel {
 public:
     explicit ImageLabel(QWidget *parent = nullptr);
     void setScreenshot(const QPixmap &pixmap);
+    QPixmap getScreenshot();
 
 signals:
     void dragInitiated();
+    void historyEdit();
 
 protected:
     void mousePressEvent(QMouseEvent *event) Q_DECL_OVERRIDE;
+    void mouseDoubleClickEvent(QMouseEvent *event) Q_DECL_OVERRIDE;
     void mouseReleaseEvent(QMouseEvent *event) Q_DECL_OVERRIDE;
     void mouseMoveEvent(QMouseEvent *event) Q_DECL_OVERRIDE;
     void resizeEvent(QResizeEvent *event) Q_DECL_OVERRIDE;


### PR DESCRIPTION
Screenshots taken by flameshot are automatically stored in the history
widget.
- Right-click on the tray-icon and select History to open the widget.
- Screenshots can be removed from memory by clicking on the close button
on the screenshot or by keyboard shortcut Ctrl + W.
- Screenshots can be copied to clipboard by keyboard shortcut Ctrl + C.
- Screenshots can be edited in flameshot by double-clicking on the screenshot.