### PR TITLE
Disable Qt::BypassWindowManagerHint, workaround #583 #517

### DIFF
--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -97,8 +97,9 @@ CaptureWidget::CaptureWidget(const uint id, const QString &savePath,
         }
         move(topLeft);
 #else
-        setWindowFlags(Qt::BypassWindowManagerHint
-                       | Qt::WindowStaysOnTopHint
+        // Disable Qt::BypassWindowManagerHint. Workaround for #583 #517
+        setWindowFlags(/* Qt::BypassWindowManagerHint */
+                       Qt::WindowStaysOnTopHint
                        | Qt::FramelessWindowHint
                        | Qt::Tool);
 #endif


### PR DESCRIPTION
Workaround for previously reported screen blinking issue #583 #517 

## System
- Ubuntu 18.04
- Xorg
- Gnome Shell 3.28.4

## The bug
Basically if you hover your mouse over one of the widgets in the screenshot GUI, wait for the tooltip to pop up, then immediately move your mouse off the widget, the whole screen blinks once.

Unfortunately I can't screen record it because it doesn't reproduce if a screen recorder is running. Only option would be to record my screen with my phone.

## What does this PR improve?
- Stops the blinking
- Allows the user to switch workspaces while in the screenshot GUI. Prior to this PR the screenshot GUI would effectively freeze because the window manager would never be able to bring the screenshot GUI back into focus after switching from/to workspaces.

## Coments
I don't know why `Qt::BypassWindowManagerHint` was specified in the first place, so I don't know what kinds of unintentional side effects removing this could have.