### PR TITLE
Change appveyor.yml to again include artifacts

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -62,11 +62,9 @@ after_build:
     - if "%PLATFORM%" EQU "x86" (xcopy "openssl-utils.git\win32\*.dll" "distrib\flameshot")
     - cd distrib
     - 7z a flameshot_%flameshot_version%_win_%PLATFORM%.zip flameshot
-    - appveyor-retry curl --upload-file ./flameshot_%flameshot_version%_win_%PLATFORM%.zip https://transfer.sh/flameshot_%flameshot_version%_win_%PLATFORM%.zip
 
-
-# artifacts:
-#     - path: build\distrib\flameshot_win_%PLATFORM%_portable_%flameshot_version%.zip
-#       name: portable
-#     - path: build\distrib\flameshot_win_%PLATFORM%.exe
-#       name: exe_only
+artifacts:
+    - path: build\distrib\flameshot_%flameshot_version%_win_%PLATFORM%.zip
+      name: portable
+    - path: build\distrib\flameshot_win_%PLATFORM%.exe
+      name: exe_only


### PR DESCRIPTION
In the last time the builds for windows fail because the upload to https://transfer.sh fails.  
Also for the builds where the upload succeeded the returned download link does not work or times out.

This pull request readds the artifacts used by appveyor.
Those are currently only available for 6 Month ([see Appveyor Artifacts retention policy](https://www.appveyor.com/docs/packaging-artifacts/#artifacts-retention-policy))

One could push the releases to Github releases like the linux builds in a later step