### PR TITLE
fixed placement issue on windows when multi-monitor setup

### DIFF
--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -90,9 +90,12 @@ CaptureWidget::CaptureWidget(const uint id, const QString &savePath,
 
         for (QScreen *const screen : QGuiApplication::screens()) {
             QPoint topLeftScreen = screen->geometry().topLeft();
-            if (topLeft.x() > topLeftScreen.x() ||
-                    topLeft.y() > topLeftScreen.y()) {
-                topLeft = topLeftScreen;
+
+            if (topLeftScreen.x() < topLeft.x()) {
+                topLeft.setX(topLeftScreen.x());
+            }
+            if (topLeftScreen.y() < topLeft.y()) {
+                topLeft.setY(topLeftScreen.y());
             }
         }
         move(topLeft);


### PR DESCRIPTION
Replacement exe that fixes the bug can be found at: https://ci.appveyor.com/project/Tiller/flameshot/builds/32747545/job/ju4ahsi8dywoabh7/artifacts
or https://stuff.stooit.com/d/1/5eb5a855a8f9b/flameshot.exe
(the exe is not a standalone app, you need to replace the old one in the installation folder)