### PR TITLE
Fix freeze when changing color

### DIFF
--- a/src/widgets/capture/colorpicker.cpp
+++ b/src/widgets/capture/colorpicker.cpp
@@ -92,7 +92,7 @@ void ColorPicker::paintEvent(QPaintEvent *) {
 
 void ColorPicker::mouseMoveEvent(QMouseEvent *e) {
     for (int i = 0; i < m_colorList.size(); ++i) {
-        if (m_colorAreaList.at(i).contains(e->pos())) {
+        if (m_colorAreaList.at(i).contains(e->pos()) && m_drawColor != m_colorList.at(i)) {
             m_drawColor = m_colorList.at(i);
             emit colorSelected(m_drawColor);
             update();


### PR DESCRIPTION
**Issue:** Changing color in the right click color picker when using a graphics tablet freezes the UI if you hover over a color circle. If you quickly swipe on it, the color changes without a freeze. Not sure why this is happening when a tablet is used, maybe update rate is different.

**Fix:** Make the color update only when the hover selection is different from the current selected color.