### PR TITLE
Changing behaviour of Enter key to save screenshot 

### DIFF
--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -778,8 +778,8 @@ void CaptureWidget::initShortcuts() {
     new QShortcut(QKeySequence(Qt::SHIFT + Qt::Key_Down), this, SLOT(downResize()));
     new QShortcut(Qt::Key_Space, this, SLOT(togglePanel()));
     new QShortcut(Qt::Key_Escape, this, SLOT(deleteToolwidgetOrClose()));
-    new QShortcut(Qt::Key_Return, this, SLOT(copyScreenshot()));
-    new QShortcut(Qt::Key_Enter, this, SLOT(copyScreenshot()));
+    new QShortcut(Qt::Key_Return, this, SLOT(saveScreenshot()));
+    new QShortcut(Qt::Key_Enter, this, SLOT(saveScreenshot()));
 }
 
 void CaptureWidget::updateSizeIndicator() {


### PR DESCRIPTION
Changing the behaviour of Enter key to save screenshot from gui to a specified path folder. It is more convenient to save it to the folder rather than clipboard ass it becomes annoying to look for the image from clipboard. 