### PR TITLE
Update some URLs due to project move

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <div align="center">
   <p>
     <h1>
-      <a href="https://github.com/lupoDharkael/flameshot">
-        <img src="img/app/flameshot.svg" alt="Flameshot" />
+      <a href="https://github.com/flameshot-org/flameshot">
+        <img src="data/img/app/flameshot.svg" alt="Flameshot" />
       </a>
       <br />
       Flameshot

--- a/data/debian/changelog
+++ b/data/debian/changelog
@@ -1,5 +1,5 @@
-flameshot (0.6.0-1) unstable; urgency=medium
+flameshot (0.8.0~dev0) unstable; urgency=medium
 
-  * Initial deb package.
+  * Placeholder deb package.
 
  -- Boyuan Yang <byang@debian.org>  Wed, 27 Feb 2019 13:19:39 -0500

--- a/data/debian/control
+++ b/data/debian/control
@@ -5,15 +5,16 @@ Maintainer: Juanma Navarro Mañez <juanma1980@gmail.com>
 Uploaders:
  Boyuan Yang <byang@debian.org>,
 Build-Depends:
+ cmake (>= 3.13~),
  debhelper (>= 9),
- qt5-qmake,
  qtbase5-dev,
+ qttools5-dev,
  qttools5-dev-tools,
  libqt5svg5-dev,
-Standards-Version: 4.3.0
-Homepage: https://github.com/lupoDharkael/flameshot
-Vcs-Browser: https://github.com/lupoDharkael/flameshot
-Vcs-Git: https://github.com/lupoDharkael/flameshot.git
+Standards-Version: 4.5.0
+Homepage: https://github.com/flameshot-org/flameshot
+Vcs-Browser: https://github.com/flameshot-org/flameshot
+Vcs-Git: https://github.com/flameshot-org/flameshot.git
 
 Package: flameshot
 Architecture: any

--- a/data/debian/rules
+++ b/data/debian/rules
@@ -21,4 +21,4 @@ export QT_SELECT := 5
 override_dh_auto_configure:
 	# The existence of an empty .git directory triggers syncqt.
 	mkdir .git || true
-	dh_auto_configure -- CONFIG+=packaging CONFIG-=debug CONFIG+=release
+	dh_auto_configure --

--- a/data/debian/source/format
+++ b/data/debian/source/format
@@ -1,1 +1,1 @@
-3.0 (quilt)
+3.0 (native)

--- a/data/rpm/flameshot.spec
+++ b/data/rpm/flameshot.spec
@@ -1,5 +1,5 @@
 Name: flameshot
-Version: 0.6.0
+Version: 0.8.0
 Release: 1%{?dist}
 Summary: Powerful yet simple to use screenshot software
 Summary(eu-ES): Potente pero simple de usar software de capturas
@@ -8,8 +8,8 @@ Summary(eu-ES): Potente pero simple de usar software de capturas
 
 Group: Application
 License: GPLv3
-URL: https://github.com/lupoDharkael/%{sourcename}
-Source0: https://github.com/lupoDharkael/%{sourcename}/archive/v%{version}.tar.gz
+URL: https://github.com/flameshot-org/%{sourcename}
+Source0: https://github.com/flameshot-org/%{sourcename}/archive/v%{version}.tar.gz
 
 #%%define _binaries_in_noarch_packages_terminate_build   0
 #BuildArch: noarch


### PR DESCRIPTION
Now that #770 is merged, let's make some quick changes that fixes some obvious issues and can be reviewed quickly.

* * *

This commit updates some URLs used within the project:

* Update README.md logo URL so that the flameshot logo can be shown properly.
* Update metadata used in data/debian/ directory to make placeholder Debian packaging working again.
* Some other quick URL fixes.

These fixes are not meant to be exhaustive and more work is needed.