### PR TITLE
Fix more url metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,14 +16,14 @@
     <a href="https://ci.appveyor.com/project/lupoDharkael/flameshot">
       <img src="https://img.shields.io/appveyor/ci/lupoDharkael/flameshot.svg?style=flat-square&label=windows" alt="Windows Build Status" />
     </a>
-    <a href="https://github.com/lupoDharkael/flameshot/releases">
-      <img src="https://img.shields.io/github/release/lupoDharkael/flameshot.svg?style=flat-square" alt="Latest Stable Release" />
+    <a href="https://github.com/flameshot-org/flameshot/releases">
+      <img src="https://img.shields.io/github/release/flameshot-org/flameshot.svg?style=flat-square" alt="Latest Stable Release" />
     </a>
-    <a href="https://github.com/lupoDharkael/flameshot/releases">
-      <img src="https://img.shields.io/github/downloads/lupoDharkael/flameshot/total.svg?style=flat-square" alt="Total Downloads" />
+    <a href="https://github.com/flameshot-org/flameshot/releases">
+      <img src="https://img.shields.io/github/downloads/flameshot-org/flameshot/total.svg?style=flat-square" alt="Total Downloads" />
     </a>
-    <a href="https://github.com/lupoDharkael/flameshot/blob/master/LICENSE">
-      <img src="https://img.shields.io/github/license/lupoDharkael/flameshot.svg?style=flat-square" alt="License" />
+    <a href="https://github.com/flameshot-org/flameshot/blob/master/LICENSE">
+      <img src="https://img.shields.io/github/license/flameshot-org/flameshot.svg?style=flat-square" alt="License" />
     </a>
     <a href="https://github.com/flameshotapp/flameshotapp.github.io">
       <img src="https://img.shields.io/github/release/lupoDharkael/flameshot.svg?style=flat-square&label=docs" alt="Docs" />
@@ -196,7 +196,7 @@ Steps for using the configuration:
 
     ```shell
     cd ~/Desktop
-    wget https://raw.githubusercontent.com/lupoDharkael/flameshot/master/docs/shortcuts-config/flameshot-shortcuts-kde
+    wget https://raw.githubusercontent.com/flameshot-org/flameshot/master/docs/shortcuts-config/flameshot-shortcuts-kde
     ```
 3. Go to _System Settings_ → _Shortcuts_ → _Custom Shortcuts_.
 4. If there's one, you'll need to disable an entry for Spectacle, the default KDE screenshot utility first because its shortcuts might collide with Flameshot's ones; so, just uncheck the _Spectacle_ entry.

--- a/docs/appdata/flameshot.appdata.xml
+++ b/docs/appdata/flameshot.appdata.xml
@@ -14,12 +14,12 @@
   </description>
   <screenshots>
     <screenshot type="default">
-      <image>https://raw.githubusercontent.com/lupoDharkael/flameshot/master/img/preview/usageStatic.png</image>
+      <image>https://raw.githubusercontent.com/flameshot-org/flameshot/master/data/img/preview/usageStatic.png</image>
     </screenshot>
     <screenshot>
-      <image>https://raw.githubusercontent.com/lupoDharkael/flameshot/master/img/preview/animatedUsage.gif</image>
+      <image>https://raw.githubusercontent.com/flameshot-org/flameshot/master/data/img/preview/animatedUsage.gif</image>
     </screenshot>
   </screenshots>
-  <url type="homepage">https://github.com/lupoDharkael/flameshot</url>
-  <update_contact>https://github.com/lupoDharkael</update_contact>
+  <url type="homepage">https://github.com/flameshot-org/flameshot</url>
+  <update_contact>https://github.com/flameshot-org/flameshot/issues/new</update_contact>
 </component>


### PR DESCRIPTION
This PR updates more URLs within README.md as well as the AppData XML file.

This is a partial fix; the badges related to Travis CI or AppVeyor are not fixed since we need more work on CI/CD.