### PR TITLE
Enable WIN32 property on Windows build

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,6 +18,10 @@ add_executable(flameshot)
 
 add_executable(Flameshot::flameshot ALIAS flameshot)
 
+IF(WIN32)
+  set_property(TARGET flameshot PROPERTY WIN32_EXECUTABLE true)
+ENDIF()
+
 add_subdirectory(cli)
 add_subdirectory(config)
 add_subdirectory(core)


### PR DESCRIPTION
When building on Windows platform, this patch will set the `WIN32_EXECUTABLE` property for the build target. This helps to suppress the terminal window when running on Windows.

Details on this cmake property can be found at https://cmake.org/cmake/help/v3.13/prop_tgt/WIN32_EXECUTABLE.html .

This solves some problems discussed in issue #824.