### PR TITLE
README.md: Really fix Debian compile instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,10 +272,10 @@ Also you can open and build/debug the project in a C++ IDE. For example, in Qt C
 
 ```shell
 # Compile-time
-apt install g++ cmake build-essential qt5-default qttools5-dev-tools
+apt install g++ cmake build-essential qt5-default qttools5-dev-tools libqt5svg5-dev
 
 # Run-time
-apt install libqt5dbus5 libqt5network5 libqt5core5a libqt5widgets5 libqt5gui5 libqt5svg5-dev
+apt install libqt5dbus5 libqt5network5 libqt5core5a libqt5widgets5 libqt5gui5 libqt5svg5
 
 # Optional
 apt install git openssl ca-certificates


### PR DESCRIPTION
This commit really closes: #791 and fix the build and runtime dependency for flameshot on deb-based systems.