### PR TITLE
Set win32 api minimum system level as Win7

### DIFF
--- a/src/tools/launcher/openwithprogram.cpp
+++ b/src/tools/launcher/openwithprogram.cpp
@@ -21,8 +21,12 @@
 #include "src/utils/filenamehandler.h"
 #include <QDir>
 #include <QMessageBox>
-#include <Shlobj.h>
 #include <windows.h>
+#ifdef _WIN32_WINNT
+#undef _WIN32_WINNT
+#define _WIN32_WINNT 0x601
+#endif
+#include <Shlobj.h>
 
 #pragma comment(lib, "Shell32.lib")
 #else


### PR DESCRIPTION
- fix https://github.com/flameshot-org/flameshot/issues/824.
- `Win7+` should be declared in the documentation what the minimum system requirements are for the flameshot Windows binary. 