### PR TITLE
Fix D-Bus name and organization name

### DIFF
--- a/data/debian/copyright
+++ b/data/debian/copyright
@@ -1,6 +1,6 @@
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: flameshot
-Source: https://github.com/lupoDharkael/flameshot/
+Source: https://github.com/flameshot-org/flameshot/
 
 Files: *
 Copyright: 2016-2019 lupoDharkael <izhe@hotmail.es>

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -50,7 +50,7 @@ For small fixes or incremental improvements simply fork the repo and follow the 
 ## Issues
 
 1. Do a quick search on GitHub to check if the issue has already been reported.
-2. [Open an issue](https://github.com/lupoDharkael/flameshot/issues/new) and describe the issue you are having - you could include:
+2. [Open an issue](https://github.com/flameshot-org/flameshot/issues/new) and describe the issue you are having - you could include:
      - Screenshots
      - Ways to reproduce the issue.
      - Your Flameshot version.

--- a/docs/shortcuts-config/flameshot-shortcuts-kde
+++ b/docs/shortcuts-config/flameshot-shortcuts-kde
@@ -25,7 +25,7 @@ ActionsCount=1
 [Data_1_1Actions0]
 Arguments='Pictures/Screenshots' 0 0
 Call=graphicCapture
-RemoteApp=org.dharkael.Flameshot
+RemoteApp=org.flameshot.Flameshot
 RemoteObj=/
 Type=DBUS
 
@@ -54,7 +54,7 @@ ActionsCount=1
 [Data_1_2Actions0]
 Arguments='Pictures/Screenshots' 3000 0
 Call=graphicCapture
-RemoteApp=org.dharkael.Flameshot
+RemoteApp=org.flameshot.Flameshot
 RemoteObj=/
 Type=DBUS
 
@@ -83,7 +83,7 @@ ActionsCount=1
 [Data_1_3Actions0]
 Arguments='Pictures/Screenshots' false 0 0
 Call=fullScreen
-RemoteApp=org.dharkael.Flameshot
+RemoteApp=org.flameshot.Flameshot
 RemoteObj=/
 Type=DBUS
 
@@ -112,7 +112,7 @@ ActionsCount=1
 [Data_1_4Actions0]
 Arguments='' true 0 0
 Call=fullScreen
-RemoteApp=org.dharkael.Flameshot
+RemoteApp=org.flameshot.Flameshot
 RemoteObj=/
 Type=DBUS
 

--- a/src/core/flameshotdbusadapter.h
+++ b/src/core/flameshotdbusadapter.h
@@ -23,7 +23,7 @@
 class FlameshotDBusAdapter : public QDBusAbstractAdaptor
 {
   Q_OBJECT
-  Q_CLASSINFO("D-Bus Interface", "org.dharkael.Flameshot")
+  Q_CLASSINFO("D-Bus Interface", "org.flameshot.Flameshot")
 
 public:
   explicit FlameshotDBusAdapter(QObject* parent = nullptr);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -71,7 +71,7 @@ main(int argc, char* argv[])
     app.installTranslator(&qtTranslator);
     app.setAttribute(Qt::AA_DontCreateNativeWidgetSiblings, true);
     app.setApplicationName(QStringLiteral("flameshot"));
-    app.setOrganizationName(QStringLiteral("Dharkael"));
+    app.setOrganizationName(QStringLiteral("flameshot"));
 
     auto c = Controller::getInstance();
 #if defined(Q_OS_LINUX) || defined(Q_OS_UNIX)
@@ -82,7 +82,7 @@ main(int argc, char* argv[])
         QObject::tr("Unable to connect via DBus"));
     }
     dbus.registerObject(QStringLiteral("/"), c);
-    dbus.registerService(QStringLiteral("org.dharkael.Flameshot"));
+    dbus.registerService(QStringLiteral("org.flameshot.Flameshot"));
 #endif
     // Exporting captures must be connected after the dbus interface
     // or the dbus signal gets blocked until we end the exports.
@@ -96,7 +96,7 @@ main(int argc, char* argv[])
    * ------------*/
   QCoreApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("flameshot"));
-  app.setOrganizationName(QStringLiteral("Dharkael"));
+  app.setOrganizationName(QStringLiteral("flameshot"));
   app.setApplicationVersion(qApp->applicationVersion());
   CommandLineParser parser;
   // Add description
@@ -234,7 +234,7 @@ main(int argc, char* argv[])
   if (parser.isSet(helpOption) || parser.isSet(versionOption)) {
   } else if (parser.isSet(launcherArgument)) { // LAUNCHER
     QDBusMessage m =
-      QDBusMessage::createMethodCall(QStringLiteral("org.dharkael.Flameshot"),
+      QDBusMessage::createMethodCall(QStringLiteral("org.flameshot.Flameshot"),
                                      QStringLiteral("/"),
                                      QLatin1String(""),
                                      QStringLiteral("openLauncher"));
@@ -254,7 +254,7 @@ main(int argc, char* argv[])
 
     // Send message
     QDBusMessage m =
-      QDBusMessage::createMethodCall(QStringLiteral("org.dharkael.Flameshot"),
+      QDBusMessage::createMethodCall(QStringLiteral("org.flameshot.Flameshot"),
                                      QStringLiteral("/"),
                                      QLatin1String(""),
                                      QStringLiteral("graphicCapture"));
@@ -302,7 +302,7 @@ main(int argc, char* argv[])
 
     // Send message
     QDBusMessage m =
-      QDBusMessage::createMethodCall(QStringLiteral("org.dharkael.Flameshot"),
+      QDBusMessage::createMethodCall(QStringLiteral("org.flameshot.Flameshot"),
                                      QStringLiteral("/"),
                                      QLatin1String(""),
                                      QStringLiteral("fullScreen"));
@@ -354,7 +354,7 @@ main(int argc, char* argv[])
 
     // Send message
     QDBusMessage m =
-      QDBusMessage::createMethodCall(QStringLiteral("org.dharkael.Flameshot"),
+      QDBusMessage::createMethodCall(QStringLiteral("org.flameshot.Flameshot"),
                                      QStringLiteral("/"),
                                      QLatin1String(""),
                                      QStringLiteral("captureScreen"));
@@ -383,11 +383,11 @@ main(int argc, char* argv[])
     bool someFlagSet = (filename || tray || help || mainColor || contrastColor);
     ConfigHandler config;
     if (autostart) {
-      QDBusMessage m =
-        QDBusMessage::createMethodCall(QStringLiteral("org.dharkael.Flameshot"),
-                                       QStringLiteral("/"),
-                                       QLatin1String(""),
-                                       QStringLiteral("autostartEnabled"));
+      QDBusMessage m = QDBusMessage::createMethodCall(
+        QStringLiteral("org.flameshot.Flameshot"),
+        QStringLiteral("/"),
+        QLatin1String(""),
+        QStringLiteral("autostartEnabled"));
       if (parser.value(autostartOption) == QLatin1String("false")) {
         m << false;
       } else if (parser.value(autostartOption) == QLatin1String("true")) {
@@ -410,11 +410,11 @@ main(int argc, char* argv[])
                                .arg(fh.parsedPattern());
     }
     if (tray) {
-      QDBusMessage m =
-        QDBusMessage::createMethodCall(QStringLiteral("org.dharkael.Flameshot"),
-                                       QStringLiteral("/"),
-                                       QLatin1String(""),
-                                       QStringLiteral("trayIconEnabled"));
+      QDBusMessage m = QDBusMessage::createMethodCall(
+        QStringLiteral("org.flameshot.Flameshot"),
+        QStringLiteral("/"),
+        QLatin1String(""),
+        QStringLiteral("trayIconEnabled"));
       if (parser.value(trayOption) == QLatin1String("false")) {
         m << false;
       } else if (parser.value(trayOption) == QLatin1String("true")) {
@@ -447,11 +447,11 @@ main(int argc, char* argv[])
 
     // Open gui when no options
     if (!someFlagSet) {
-      QDBusMessage m =
-        QDBusMessage::createMethodCall(QStringLiteral("org.dharkael.Flameshot"),
-                                       QStringLiteral("/"),
-                                       QLatin1String(""),
-                                       QStringLiteral("openConfig"));
+      QDBusMessage m = QDBusMessage::createMethodCall(
+        QStringLiteral("org.flameshot.Flameshot"),
+        QStringLiteral("/"),
+        QLatin1String(""),
+        QStringLiteral("openConfig"));
       QDBusConnection sessionBus = QDBusConnection::sessionBus();
       if (!sessionBus.isConnected()) {
         SystemNotification().sendMessage(

--- a/src/utils/dbusutils.cpp
+++ b/src/utils/dbusutils.cpp
@@ -30,14 +30,14 @@ DBusUtils::connectPrintCapture(QDBusConnection& session, uint id)
 {
   m_id = id;
   // captureTaken
-  session.connect(QStringLiteral("org.dharkael.Flameshot"),
+  session.connect(QStringLiteral("org.flameshot.Flameshot"),
                   QStringLiteral("/"),
                   QLatin1String(""),
                   QStringLiteral("captureTaken"),
                   this,
                   SLOT(captureTaken(uint, QByteArray)));
   // captureFailed
-  session.connect(QStringLiteral("org.dharkael.Flameshot"),
+  session.connect(QStringLiteral("org.flameshot.Flameshot"),
                   QStringLiteral("/"),
                   QLatin1String(""),
                   QStringLiteral("captureFailed"),


### PR DESCRIPTION
Originally the App uses org.Dharkael.flameshot in D-Bus.
Since we have moved the project under organization, the name we are using now should be org.flameshot.flameshot.

This need to be kept unified across the whole project.

This fixes D-Bus invocation problem and should closes: #850 .

* * *

This patch also changes the organization name. This means the program will no longer store config files under `~/.config/Dharkael/flameshot`. It will now use `~/.config/flameshot/flameshot/`. Please let me know if such switch is favorable. If it is too abrupt, we can reverse this change for now.