### PR TITLE
Changed Information Menu item to match window title

### DIFF
--- a/src/core/controller.cpp
+++ b/src/core/controller.cpp
@@ -210,7 +210,7 @@ Controller::enableTrayIcon()
   QAction* configAction = new QAction(tr("&Configuration"), this);
   connect(
     configAction, &QAction::triggered, this, &Controller::openConfigWindow);
-  QAction* infoAction = new QAction(tr("&Information"), this);
+  QAction* infoAction = new QAction(tr("&About"), this);
   connect(infoAction, &QAction::triggered, this, &Controller::openInfoWindow);
   QAction* quitAction = new QAction(tr("&Quit"), this);
   connect(quitAction, &QAction::triggered, qApp, &QCoreApplication::quit);


### PR DESCRIPTION
Changed the string "Information" to "About" to match window title. 

Closes: #847 