### PR TITLE
prototype of undo fix

### DIFF
--- a/src/tools/abstractactiontool.h
+++ b/src/tools/abstractactiontool.h
@@ -36,6 +36,9 @@ public:
   void paintMousePreview(QPainter& painter,
                          const CaptureContext& context) override;
 
+protected:
+  virtual ToolType nameID() const = 0;
+
 public slots:
   void drawEnd(const QPoint& p) override;
   void drawMove(const QPoint& p) override;

--- a/src/tools/abstractpathtool.h
+++ b/src/tools/abstractpathtool.h
@@ -42,6 +42,8 @@ protected:
   void updateBackup(const QPixmap& pixmap);
   void addPoint(const QPoint& point);
 
+  virtual ToolType nameID() const = 0;
+
   QPixmap m_pixmapBackup;
   QRect m_backupArea;
   QColor m_color;

--- a/src/tools/abstracttwopointtool.cpp
+++ b/src/tools/abstracttwopointtool.cpp
@@ -77,6 +77,9 @@ AbstractTwoPointTool::undo(QPixmap& pixmap)
 {
   QPainter p(&pixmap);
   p.drawPixmap(backupRect(pixmap.rect()).topLeft(), m_pixmapBackup);
+  if (this->nameID() == ToolType::CIRCLECOUNT) {
+    emit requestAction(REQ_DECREMENT_CIRCLE_COUNT);
+  }
 }
 
 void

--- a/src/tools/abstracttwopointtool.h
+++ b/src/tools/abstracttwopointtool.h
@@ -53,6 +53,8 @@ protected:
   bool m_supportsOrthogonalAdj = false;
   bool m_supportsDiagonalAdj = false;
 
+  virtual ToolType nameID() const = 0;
+
 private:
   QPoint adjustedVector(QPoint v) const;
 };

--- a/src/tools/arrow/arrowtool.cpp
+++ b/src/tools/arrow/arrowtool.cpp
@@ -92,10 +92,10 @@ ArrowTool::name() const
   return tr("Arrow");
 }
 
-QString
-ArrowTool::nameID()
+ToolType
+ArrowTool::nameID() const
 {
-  return QLatin1String("");
+  return ToolType::ARROW;
 }
 
 QString

--- a/src/tools/arrow/arrowtool.h
+++ b/src/tools/arrow/arrowtool.h
@@ -29,7 +29,6 @@ public:
 
   QIcon icon(const QColor& background, bool inEditor) const override;
   QString name() const override;
-  static QString nameID();
   QString description() const override;
 
   CaptureTool* copy(QObject* parent = nullptr) override;
@@ -38,6 +37,9 @@ public:
                bool recordUndo = false) override;
   void paintMousePreview(QPainter& painter,
                          const CaptureContext& context) override;
+
+protected:
+  ToolType nameID() const override;
 
 public slots:
   void drawStart(const CaptureContext& context) override;

--- a/src/tools/capturetool.h
+++ b/src/tools/capturetool.h
@@ -23,6 +23,30 @@
 #include <QIcon>
 #include <QPainter>
 
+enum class ToolType
+{
+  ARROW,
+  CIRCLE,
+  CIRCLECOUNT,
+  COPY,
+  EXIT,
+  IMGUR,
+  LAUNCHER,
+  LINE,
+  MARKER,
+  MOVE,
+  PENCIL,
+  PIN,
+  PIXELATE,
+  RECTANGLE,
+  REDO,
+  SAVE,
+  SELECTION,
+  SIZEINDICATOR,
+  TEXT,
+  UNDO
+};
+
 class CaptureTool : public QObject
 {
   Q_OBJECT
@@ -66,6 +90,8 @@ public:
     REQ_ADD_EXTERNAL_WIDGETS,
 
     REQ_INCREMENT_CIRCLE_COUNT,
+
+    REQ_DECREMENT_CIRCLE_COUNT,
   };
 
   explicit CaptureTool(QObject* parent = nullptr)
@@ -91,7 +117,7 @@ public:
   virtual QString name() const = 0;
   // Codename for the tool, this hsouldn't change as it is used as ID
   // for the tool in the internals of Flameshot
-  static QString nameID();
+  virtual ToolType nameID() const = 0;
   // Short description of the tool.
   virtual QString description() const = 0;
 

--- a/src/tools/circle/circletool.cpp
+++ b/src/tools/circle/circletool.cpp
@@ -40,10 +40,10 @@ CircleTool::name() const
   return tr("Circle");
 }
 
-QString
-CircleTool::nameID()
+ToolType
+CircleTool::nameID() const
 {
-  return QLatin1String("");
+  return ToolType::CIRCLE;
 }
 
 QString

--- a/src/tools/circle/circletool.h
+++ b/src/tools/circle/circletool.h
@@ -27,7 +27,6 @@ public:
 
   QIcon icon(const QColor& background, bool inEditor) const override;
   QString name() const override;
-  static QString nameID();
   QString description() const override;
 
   CaptureTool* copy(QObject* parent = nullptr) override;
@@ -36,6 +35,9 @@ public:
                bool recordUndo = false) override;
   void paintMousePreview(QPainter& painter,
                          const CaptureContext& context) override;
+
+protected:
+  ToolType nameID() const override;
 
 public slots:
   void drawStart(const CaptureContext& context) override;

--- a/src/tools/circlecount/circlecounttool.cpp
+++ b/src/tools/circlecount/circlecounttool.cpp
@@ -39,10 +39,10 @@ CircleCountTool::name() const
   return tr("Circle Counter");
 }
 
-QString
-CircleCountTool::nameID()
+ToolType
+CircleCountTool::nameID() const
 {
-  return QLatin1String("");
+  return ToolType::CIRCLECOUNT;
 }
 
 QString

--- a/src/tools/circlecount/circlecounttool.h
+++ b/src/tools/circlecount/circlecounttool.h
@@ -27,7 +27,6 @@ public:
 
   QIcon icon(const QColor& background, bool inEditor) const override;
   QString name() const override;
-  static QString nameID();
   QString description() const override;
 
   CaptureTool* copy(QObject* parent = nullptr) override;
@@ -36,6 +35,9 @@ public:
                bool recordUndo = false) override;
   void paintMousePreview(QPainter& painter,
                          const CaptureContext& context) override;
+
+protected:
+  ToolType nameID() const override;
 
 private:
   unsigned int m_count;

--- a/src/tools/copy/copytool.cpp
+++ b/src/tools/copy/copytool.cpp
@@ -41,10 +41,10 @@ CopyTool::name() const
   return tr("Copy");
 }
 
-QString
-CopyTool::nameID()
+ToolType
+CopyTool::nameID() const
 {
-  return QLatin1String("");
+  return ToolType::COPY;
 }
 
 QString

--- a/src/tools/copy/copytool.h
+++ b/src/tools/copy/copytool.h
@@ -29,10 +29,12 @@ public:
 
   QIcon icon(const QColor& background, bool inEditor) const override;
   QString name() const override;
-  static QString nameID();
   QString description() const override;
 
   CaptureTool* copy(QObject* parent = nullptr) override;
+
+protected:
+  ToolType nameID() const override;
 
 public slots:
   void pressed(const CaptureContext& context) override;

--- a/src/tools/exit/exittool.cpp
+++ b/src/tools/exit/exittool.cpp
@@ -40,10 +40,10 @@ ExitTool::name() const
   return tr("Exit");
 }
 
-QString
-ExitTool::nameID()
+ToolType
+ExitTool::nameID() const
 {
-  return QLatin1String("");
+  return ToolType::EXIT;
 }
 
 QString

--- a/src/tools/exit/exittool.h
+++ b/src/tools/exit/exittool.h
@@ -29,10 +29,12 @@ public:
 
   QIcon icon(const QColor& background, bool inEditor) const override;
   QString name() const override;
-  static QString nameID();
   QString description() const override;
 
   CaptureTool* copy(QObject* parent = nullptr) override;
+
+protected:
+  ToolType nameID() const override;
 
 public slots:
   void pressed(const CaptureContext& context) override;

--- a/src/tools/imgur/imguruploadertool.cpp
+++ b/src/tools/imgur/imguruploadertool.cpp
@@ -41,10 +41,10 @@ ImgurUploaderTool::name() const
   return tr("Image Uploader");
 }
 
-QString
-ImgurUploaderTool::nameID()
+ToolType
+ImgurUploaderTool::nameID() const
 {
-  return QLatin1String("");
+  return ToolType::IMGUR;
 }
 
 QString

--- a/src/tools/imgur/imguruploadertool.h
+++ b/src/tools/imgur/imguruploadertool.h
@@ -29,12 +29,14 @@ public:
 
   QIcon icon(const QColor& background, bool inEditor) const override;
   QString name() const override;
-  static QString nameID();
   QString description() const override;
 
   QWidget* widget() override;
 
   CaptureTool* copy(QObject* parent = nullptr) override;
+
+protected:
+  ToolType nameID() const override;
 
 public slots:
   void pressed(const CaptureContext& context) override;

--- a/src/tools/launcher/applaunchertool.cpp
+++ b/src/tools/launcher/applaunchertool.cpp
@@ -40,10 +40,10 @@ AppLauncher::name() const
   return tr("App Launcher");
 }
 
-QString
-AppLauncher::nameID()
+ToolType
+AppLauncher::nameID() const
 {
-  return QLatin1String("");
+  return ToolType::LAUNCHER;
 }
 
 QString

--- a/src/tools/launcher/applaunchertool.h
+++ b/src/tools/launcher/applaunchertool.h
@@ -29,12 +29,14 @@ public:
 
   QIcon icon(const QColor& background, bool inEditor) const override;
   QString name() const override;
-  static QString nameID();
   QString description() const override;
 
   QWidget* widget() override;
 
   CaptureTool* copy(QObject* parent = nullptr) override;
+
+protected:
+  ToolType nameID() const override;
 
 public slots:
   void pressed(const CaptureContext& context) override;

--- a/src/tools/line/linetool.cpp
+++ b/src/tools/line/linetool.cpp
@@ -43,10 +43,10 @@ LineTool::name() const
   return tr("Line");
 }
 
-QString
-LineTool::nameID()
+ToolType
+LineTool::nameID() const
 {
-  return QLatin1String("");
+  return ToolType::LINE;
 }
 
 QString

--- a/src/tools/line/linetool.h
+++ b/src/tools/line/linetool.h
@@ -27,7 +27,6 @@ public:
 
   QIcon icon(const QColor& background, bool inEditor) const override;
   QString name() const override;
-  static QString nameID();
   QString description() const override;
 
   CaptureTool* copy(QObject* parent = nullptr) override;
@@ -36,6 +35,9 @@ public:
                bool recordUndo = false) override;
   void paintMousePreview(QPainter& painter,
                          const CaptureContext& context) override;
+
+protected:
+  ToolType nameID() const override;
 
 public slots:
   void drawStart(const CaptureContext& context) override;

--- a/src/tools/marker/markertool.cpp
+++ b/src/tools/marker/markertool.cpp
@@ -43,10 +43,10 @@ MarkerTool::name() const
   return tr("Marker");
 }
 
-QString
-MarkerTool::nameID()
+ToolType
+MarkerTool::nameID() const
 {
-  return QLatin1String("");
+  return ToolType::MARKER;
 }
 
 QString

--- a/src/tools/marker/markertool.h
+++ b/src/tools/marker/markertool.h
@@ -27,7 +27,6 @@ public:
 
   QIcon icon(const QColor& background, bool inEditor) const override;
   QString name() const override;
-  static QString nameID();
   QString description() const override;
 
   CaptureTool* copy(QObject* parent = nullptr) override;
@@ -36,6 +35,9 @@ public:
                bool recordUndo = false) override;
   void paintMousePreview(QPainter& painter,
                          const CaptureContext& context) override;
+
+protected:
+  ToolType nameID() const override;
 
 public slots:
   void drawStart(const CaptureContext& context) override;

--- a/src/tools/move/movetool.cpp
+++ b/src/tools/move/movetool.cpp
@@ -40,10 +40,10 @@ MoveTool::name() const
   return tr("Move");
 }
 
-QString
-MoveTool::nameID()
+ToolType
+MoveTool::nameID() const
 {
-  return QLatin1String("");
+  return ToolType::MOVE;
 }
 
 QString

--- a/src/tools/move/movetool.h
+++ b/src/tools/move/movetool.h
@@ -29,7 +29,7 @@ public:
 
   QIcon icon(const QColor& background, bool inEditor) const override;
   QString name() const override;
-  static QString nameID();
+  ToolType nameID() const override;
   QString description() const override;
 
   CaptureTool* copy(QObject* parent = nullptr) override;

--- a/src/tools/pencil/penciltool.cpp
+++ b/src/tools/pencil/penciltool.cpp
@@ -34,10 +34,10 @@ PencilTool::name() const
   return tr("Pencil");
 }
 
-QString
-PencilTool::nameID()
+ToolType
+PencilTool::nameID() const
 {
-  return QLatin1String("");
+  return ToolType::PENCIL;
 }
 
 QString

--- a/src/tools/pencil/penciltool.h
+++ b/src/tools/pencil/penciltool.h
@@ -27,7 +27,6 @@ public:
 
   QIcon icon(const QColor& background, bool inEditor) const override;
   QString name() const override;
-  static QString nameID();
   QString description() const override;
 
   CaptureTool* copy(QObject* parent = nullptr) override;
@@ -37,6 +36,9 @@ public:
                bool recordUndo = false) override;
   void paintMousePreview(QPainter& painter,
                          const CaptureContext& context) override;
+
+protected:
+  ToolType nameID() const override;
 
 public slots:
   void drawStart(const CaptureContext& context) override;

--- a/src/tools/pin/pintool.cpp
+++ b/src/tools/pin/pintool.cpp
@@ -40,10 +40,10 @@ PinTool::name() const
   return tr("Pin Tool");
 }
 
-QString
-PinTool::nameID()
+ToolType
+PinTool::nameID() const
 {
-  return QLatin1String("");
+  return ToolType::PIN;
 }
 
 QString

--- a/src/tools/pin/pintool.h
+++ b/src/tools/pin/pintool.h
@@ -29,12 +29,14 @@ public:
 
   QIcon icon(const QColor& background, bool inEditor) const override;
   QString name() const override;
-  static QString nameID();
   QString description() const override;
 
   QWidget* widget() override;
 
   CaptureTool* copy(QObject* parent = nullptr) override;
+
+protected:
+  ToolType nameID() const override;
 
 public slots:
   void pressed(const CaptureContext& context) override;

--- a/src/tools/pixelate/pixelatetool.cpp
+++ b/src/tools/pixelate/pixelatetool.cpp
@@ -39,10 +39,10 @@ PixelateTool::name() const
   return tr("Pixelate");
 }
 
-QString
-PixelateTool::nameID()
+ToolType
+PixelateTool::nameID() const
 {
-  return QLatin1String("");
+  return ToolType::PIXELATE;
 }
 
 QString

--- a/src/tools/pixelate/pixelatetool.h
+++ b/src/tools/pixelate/pixelatetool.h
@@ -27,7 +27,6 @@ public:
 
   QIcon icon(const QColor& background, bool inEditor) const override;
   QString name() const override;
-  static QString nameID();
   QString description() const override;
 
   CaptureTool* copy(QObject* parent = nullptr) override;
@@ -36,6 +35,9 @@ public:
                bool recordUndo = false) override;
   void paintMousePreview(QPainter& painter,
                          const CaptureContext& context) override;
+
+protected:
+  ToolType nameID() const override;
 
 public slots:
   void drawStart(const CaptureContext& context) override;

--- a/src/tools/rectangle/rectangletool.cpp
+++ b/src/tools/rectangle/rectangletool.cpp
@@ -40,10 +40,10 @@ RectangleTool::name() const
   return tr("Rectangle");
 }
 
-QString
-RectangleTool::nameID()
+ToolType
+RectangleTool::nameID() const
 {
-  return QLatin1String("");
+  return ToolType::RECTANGLE;
 }
 
 QString

--- a/src/tools/rectangle/rectangletool.h
+++ b/src/tools/rectangle/rectangletool.h
@@ -27,7 +27,6 @@ public:
 
   QIcon icon(const QColor& background, bool inEditor) const override;
   QString name() const override;
-  static QString nameID();
   QString description() const override;
 
   CaptureTool* copy(QObject* parent = nullptr) override;
@@ -36,6 +35,9 @@ public:
                bool recordUndo = false) override;
   void paintMousePreview(QPainter& painter,
                          const CaptureContext& context) override;
+
+protected:
+  ToolType nameID() const override;
 
 public slots:
   void drawStart(const CaptureContext& context) override;

--- a/src/tools/redo/redotool.cpp
+++ b/src/tools/redo/redotool.cpp
@@ -40,10 +40,10 @@ RedoTool::name() const
   return tr("Redo");
 }
 
-QString
-RedoTool::nameID()
+ToolType
+RedoTool::nameID() const
 {
-  return QLatin1String("");
+  return ToolType::REDO;
 }
 
 QString

--- a/src/tools/redo/redotool.h
+++ b/src/tools/redo/redotool.h
@@ -29,10 +29,12 @@ public:
 
   QIcon icon(const QColor& background, bool inEditor) const override;
   QString name() const override;
-  static QString nameID();
   QString description() const override;
 
   CaptureTool* copy(QObject* parent = nullptr) override;
+
+protected:
+  ToolType nameID() const override;
 
 public slots:
   void pressed(const CaptureContext& context) override;

--- a/src/tools/save/savetool.cpp
+++ b/src/tools/save/savetool.cpp
@@ -41,10 +41,10 @@ SaveTool::name() const
   return tr("Save");
 }
 
-QString
-SaveTool::nameID()
+ToolType
+SaveTool::nameID() const
 {
-  return QLatin1String("");
+  return ToolType::SAVE;
 }
 
 QString

--- a/src/tools/save/savetool.h
+++ b/src/tools/save/savetool.h
@@ -29,10 +29,12 @@ public:
 
   QIcon icon(const QColor& background, bool inEditor) const override;
   QString name() const override;
-  static QString nameID();
   QString description() const override;
 
   CaptureTool* copy(QObject* parent = nullptr) override;
+
+protected:
+  ToolType nameID() const override;
 
 public slots:
   void pressed(const CaptureContext& context) override;

--- a/src/tools/selection/selectiontool.cpp
+++ b/src/tools/selection/selectiontool.cpp
@@ -46,10 +46,10 @@ SelectionTool::name() const
   return tr("Rectangular Selection");
 }
 
-QString
-SelectionTool::nameID()
+ToolType
+SelectionTool::nameID() const
 {
-  return QLatin1String("");
+  return ToolType::SELECTION;
 }
 
 QString

--- a/src/tools/selection/selectiontool.h
+++ b/src/tools/selection/selectiontool.h
@@ -29,7 +29,6 @@ public:
 
   QIcon icon(const QColor& background, bool inEditor) const override;
   QString name() const override;
-  static QString nameID();
   QString description() const override;
 
   CaptureTool* copy(QObject* parent = nullptr) override;
@@ -38,6 +37,9 @@ public:
                bool recordUndo = false) override;
   void paintMousePreview(QPainter& painter,
                          const CaptureContext& context) override;
+
+protected:
+  ToolType nameID() const override;
 
 public slots:
   void drawStart(const CaptureContext& context) override;

--- a/src/tools/sizeindicator/sizeindicatortool.cpp
+++ b/src/tools/sizeindicator/sizeindicatortool.cpp
@@ -40,10 +40,10 @@ SizeIndicatorTool::name() const
   return tr("Selection Size Indicator");
 }
 
-QString
-SizeIndicatorTool::nameID()
+ToolType
+SizeIndicatorTool::nameID() const
 {
-  return QLatin1String("");
+  return ToolType::SIZEINDICATOR;
 }
 
 QString

--- a/src/tools/sizeindicator/sizeindicatortool.h
+++ b/src/tools/sizeindicator/sizeindicatortool.h
@@ -29,10 +29,12 @@ public:
 
   QIcon icon(const QColor& background, bool inEditor) const override;
   QString name() const override;
-  static QString nameID();
   QString description() const override;
 
   CaptureTool* copy(QObject* parent = nullptr) override;
+
+protected:
+  ToolType nameID() const override;
 
 public slots:
   void pressed(const CaptureContext& context) override;

--- a/src/tools/text/texttool.cpp
+++ b/src/tools/text/texttool.cpp
@@ -63,10 +63,10 @@ TextTool::name() const
   return tr("Text");
 }
 
-QString
-TextTool::nameID()
+ToolType
+TextTool::nameID() const
 {
-  return QLatin1String("");
+  return ToolType::TEXT;
 }
 
 QString

--- a/src/tools/text/texttool.h
+++ b/src/tools/text/texttool.h
@@ -36,7 +36,6 @@ public:
 
   QIcon icon(const QColor& background, bool inEditor) const override;
   QString name() const override;
-  static QString nameID();
   QString description() const override;
 
   QWidget* widget() override;
@@ -49,6 +48,9 @@ public:
                bool recordUndo = false) override;
   void paintMousePreview(QPainter& painter,
                          const CaptureContext& context) override;
+
+protected:
+  ToolType nameID() const override;
 
 public slots:
   void drawEnd(const QPoint& p) override;

--- a/src/tools/undo/undotool.cpp
+++ b/src/tools/undo/undotool.cpp
@@ -40,10 +40,10 @@ UndoTool::name() const
   return tr("Undo");
 }
 
-QString
-UndoTool::nameID()
+ToolType
+UndoTool::nameID() const
 {
-  return QLatin1String("");
+  return ToolType::UNDO;
 }
 
 QString

--- a/src/tools/undo/undotool.h
+++ b/src/tools/undo/undotool.h
@@ -29,10 +29,12 @@ public:
 
   QIcon icon(const QColor& background, bool inEditor) const override;
   QString name() const override;
-  static QString nameID();
   QString description() const override;
 
   CaptureTool* copy(QObject* parent = nullptr) override;
+
+protected:
+  ToolType nameID() const override;
 
 public slots:
   void pressed(const CaptureContext& context) override;

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -709,6 +709,10 @@ CaptureWidget::handleButtonSignal(CaptureTool::Request r)
       incrementCircleCount();
       break;
 
+    case CaptureTool::REQ_DECREMENT_CIRCLE_COUNT:
+      decrementCircleCount();
+      break;
+
     case CaptureTool::REQ_CLOSE_GUI:
       close();
       break;
@@ -794,6 +798,12 @@ void
 CaptureWidget::incrementCircleCount()
 {
   m_context.circleCount++;
+}
+
+void
+CaptureWidget::decrementCircleCount()
+{
+  m_context.circleCount--;
 }
 
 void

--- a/src/widgets/capture/capturewidget.h
+++ b/src/widgets/capture/capturewidget.h
@@ -92,6 +92,7 @@ private slots:
   void setDrawColor(const QColor& c);
   void setDrawThickness(const int& t);
   void incrementCircleCount();
+  void decrementCircleCount();
 
 protected:
   void paintEvent(QPaintEvent*);


### PR DESCRIPTION
@hosiet 

This is a first draft of fixing the issue where the counter numbers do not decrement after undoing. I saw that the nameID() function was never used anywhere in the code base, so in the Undo function I call a decrement function if the undo tool is being applied to the counter bubble tool.

If this is generally reasonable, I want to go through the code base and assign a NameID to all the child classes. Additionally I want to change it to a enum from a QString to make comparison more efficient. 

Before I do all this work I wanted to make sure this implementation seemed reasonable. I think anything else would require a larger refactor. 


![pic](https://user-images.githubusercontent.com/46930769/92414524-3b9fe600-f11a-11ea-9b2a-9dc8449d1502.gif)
