### PR TITLE
All packages can now be packaged via Github Actions

### DIFF
--- a/.github/workflows/pack.yml
+++ b/.github/workflows/pack.yml
@@ -13,9 +13,10 @@ env:
   ARCH: x86_64
   # dockerfiles, see https://github.com/flameshot-org/flameshot-docker-images
   # docker images, see https://hub.docker.com/r/vitzy/flameshot
+  # vitzy/flameshot or packpack/packpack
   DOCKER_REPO: vitzy/flameshot
   # upload services: 0x0.st, file.io, transfer.sh, wetransfer.com
-  UPLOAD_SERVICE: file.io
+  UPLOAD_SERVICE: wetransfer.com
 
 jobs:
   deb-pack:
@@ -29,6 +30,7 @@ jobs:
       - name: Get packpack tool
         uses: actions/checkout@v2
         with:
+          # flameshot-org/packpack or packpack/packpack
           repository: flameshot-org/packpack
           path: tools
       - name: Pack on ${{ matrix.dist }}
@@ -47,22 +49,27 @@ jobs:
         env:
           OS: ubuntu 
           DIST: focal
-      - name: Upload ${{ matrix.dist }} package for daily build
+      - name: SHA256Sum of ${{ matrix.dist }} package(daily build)
         run: |
-          TEMP_DOWNLOAD_URL=$(sh $GITHUB_WORKSPACE/scripts/upload_services/${UPLOAD_SERVICE}.sh $GITHUB_WORKSPACE/build/${PRODUCT}_${VERSION}-${RELEASE}_amd64.deb)
-          echo Download URL is $TEMP_DOWNLOAD_URL. 
+          sha256sum $GITHUB_WORKSPACE/build/${PRODUCT}_${VERSION}-${RELEASE}_amd64.deb
+      - name: Upload ${{ matrix.dist }} package(daily build)
+        run: |
+          echo "================${{ matrix.dist }} downlod link==============="
+          echo $(sh $GITHUB_WORKSPACE/scripts/upload_services/${UPLOAD_SERVICE}.sh $GITHUB_WORKSPACE/build/${PRODUCT}_${VERSION}-${RELEASE}_amd64.deb)
+          echo "=====no operation for you can see link in the log console====="
 
   rpm-pack:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        dist: [fedora-31, fedora-32]
+        dist: [fedora-31, fedora-32, opensuse-leap-15.2]
     steps:
       - name: Checkout Source code
         uses: actions/checkout@v2
       - name: Get packpack tool
         uses: actions/checkout@v2
         with:
+          # flameshot-org/packpack or packpack/packpack
           repository: flameshot-org/packpack
           path: tools
       - name: Pack on ${{ matrix.dist }}
@@ -81,7 +88,151 @@ jobs:
         env:
           OS: fedora
           DIST: 32
-      - name: Upload ${{ matrix.dist }} package for daily build
+      - name: Pack on ${{ matrix.dist }}
+        if: matrix.dist == 'opensuse-leap-15.2'
         run: |
-          TEMP_DOWNLOAD_URL=$(sh $GITHUB_WORKSPACE/scripts/upload_services/${UPLOAD_SERVICE}.sh $GITHUB_WORKSPACE/build/${PRODUCT}-${VERSION}-${RELEASE}.fc*.${ARCH}.rpm)
-          echo Download URL is $TEMP_DOWNLOAD_URL. 
+          cp -r $GITHUB_WORKSPACE/data/rpm $GITHUB_WORKSPACE
+          bash $GITHUB_WORKSPACE/tools/packpack
+        env:
+          OS: opensuse-leap
+          DIST: 15.2
+      - name: SHA256Sum of ${{ matrix.dist }} package(daily build)
+        if: startsWith(matrix.dist, 'fedora')
+        run: |
+          sha256sum $GITHUB_WORKSPACE/build/${PRODUCT}-${VERSION}-${RELEASE}.fc*.${ARCH}.rpm
+      - name: SHA256Sum of ${{ matrix.dist }} package(daily build)
+        if: startsWith(matrix.dist, 'opensuse-leap')
+        run: |
+          sha256sum $GITHUB_WORKSPACE/build/${PRODUCT}-${VERSION}-lp*.${ARCH}.rpm
+      - name: Upload ${{ matrix.dist }} package(daily build)
+        if: startsWith(matrix.dist, 'fedora')
+        run: |
+          echo "================${{ matrix.dist }} downlod link==============="
+          echo $(sh $GITHUB_WORKSPACE/scripts/upload_services/${UPLOAD_SERVICE}.sh $GITHUB_WORKSPACE/build/${PRODUCT}-${VERSION}-${RELEASE}.fc*.${ARCH}.rpm)
+          echo "=====no operation for you can see link in the log console====="
+      - name: Upload ${{ matrix.dist }} package(daily build)
+        if: startsWith(matrix.dist, 'opensuse-leap')
+        run: |
+          echo "================${{ matrix.dist }} downlod link==============="
+          echo $(sh $GITHUB_WORKSPACE/scripts/upload_services/${UPLOAD_SERVICE}.sh $GITHUB_WORKSPACE/build/${PRODUCT}-${VERSION}-lp*.${ARCH}.rpm)
+          echo "=====no operation for you can see link in the log console====="
+
+  appimage-pack:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout Source code
+        uses: actions/checkout@v2
+      - name: Install Dependencies
+        run: |
+          sudo apt-get -y -qq update
+          sudo apt-get -y --no-install-recommends install \
+            cmake \
+            extra-cmake-modules \
+            build-essential \
+            qt5-default \
+            qt5-qmake \
+            qttools5-dev-tools \
+            qttools5-dev \
+            libqt5dbus5 \
+            libqt5network5 \
+            libqt5core5a \
+            libqt5widgets5 \
+            libqt5gui5 \
+            libqt5svg5-dev \
+            appstream \
+            fcitx-frontend-qt5 \
+            openssl \
+            ca-certificates
+      - name: Get go-appimage tool
+      # Will not use linuxdeployqt anymore, because it suopprt currently still-supported mainstream distribution, 
+      # which is glibc 2.23. For more information, please see https://github.com/probonopd/linuxdeployqt/issues/340.
+      # Will try new tool https://github.com/probonopd/go-appimage written by golang.
+        run: |
+          wget -c https://github.com/$(wget -q https://github.com/probonopd/go-appimage/releases -O - \
+          | grep "appimagetool-.*-x86_64.AppImage" | head -n 1 | cut -d '"' -f 2) -O appimagetool
+          chmod +x appimagetool
+      - name: Pack appimage
+        run: |
+          APPIMAGE_DST_PATH=$GITHUB_WORKSPACE/${PRODUCT}.AppDir
+          mkdir -p ${APPIMAGE_DST_PATH}
+
+          cd $GITHUB_WORKSPACE
+          cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=/usr
+          make -j$(nproc) DESTDIR=${APPIMAGE_DST_PATH} install
+
+          $GITHUB_WORKSPACE/appimagetool -s deploy ${APPIMAGE_DST_PATH}/usr/share/applications/flameshot.desktop
+
+          mkdir -p ${APPIMAGE_DST_PATH}/usr/plugins/platforminputcontexts
+          cp \
+            /usr/lib/x86_64-linux-gnu/qt5/plugins/platforminputcontexts/libfcitxplatforminputcontextplugin.so \
+            ${APPIMAGE_DST_PATH}/usr/plugins/platforminputcontexts/
+
+          cp \
+            $GITHUB_WORKSPACE/data/img/app/flameshot.png \
+            ${APPIMAGE_DST_PATH}/
+
+          VERSION=${VERSION} $GITHUB_WORKSPACE/appimagetool ${APPIMAGE_DST_PATH}
+      - name: SHA256Sum of AppImage package(daily build)
+        run: |
+          sha256sum $GITHUB_WORKSPACE/Flameshot-${VERSION}-x86_64.AppImage
+      - name: Upload appimage package for daily build
+        run: |
+          echo "====================appimage downlod link====================="
+          echo $(sh $GITHUB_WORKSPACE/scripts/upload_services/${UPLOAD_SERVICE}.sh $GITHUB_WORKSPACE/Flameshot-${VERSION}-x86_64.AppImage)
+          echo "=====no operation for you can see link in the log console====="
+
+  flatpak-pack:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout Source code
+        uses: actions/checkout@v2
+      - name: Setup Flatpak
+        run: |
+          sudo apt-get -y -qq update
+          sudo apt-get install -y flatpak flatpak-builder
+      - name: Setup Flathub
+        run: |
+          flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+          flatpak install -y --noninteractive flathub org.kde.Sdk//5.15 org.kde.Platform//5.15
+      - name: Pack flatpak
+        run: |
+          BUNDLE="org.flameshot.flameshot_${VERSION}_${ARCH}.flatpak"
+          MANIFEST_PATH=$GITHUB_WORKSPACE/data/flatpak/org.flameshot.flameshot.yml
+          RUNTIME_REPO="https://flathub.org/repo/flathub.flatpakrepo"
+          APP_ID="org.flameshot.flameshot"
+          BRANCH="master"
+
+          flatpak-builder --user --disable-rofiles-fuse --repo=repo --force-clean flatpak_app ${MANIFEST_PATH} --install-deps-from=flathub
+          flatpak build-bundle repo ${BUNDLE} --runtime-repo=${RUNTIME_REPO} ${APP_ID} ${BRANCH}
+      - name: SHA256Sum of Flatpak package(daily build)
+        run: |
+          sha256sum $GITHUB_WORKSPACE/org.flameshot.flameshot_${VERSION}_${ARCH}.flatpak
+      - name: Upload flatpak package(daily build)
+        run: |
+          echo "=====================flatpak downlod link====================="
+          echo $(sh $GITHUB_WORKSPACE/scripts/upload_services/${UPLOAD_SERVICE}.sh $GITHUB_WORKSPACE/org.flameshot.flameshot_${VERSION}_${ARCH}.flatpak) 
+          echo "=====no operation for you can see link in the log console====="
+
+  snap-pack:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout Source code
+        uses: actions/checkout@v2
+      - name: Pack snap
+        uses: snapcore/action-build@v1
+        id: snapcraft
+        with:
+          path: data
+      - name: Save built snap as an artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: snap
+          path: ${{ steps.snapcraft.outputs.snap }}
+      - name: SHA256Sum of Snap package(daily build)
+        run: |
+          sha256sum ${{ steps.snapcraft.outputs.snap }}
+      - name: Upload snap package(daily build)
+        run: |
+          echo "=======================snap downlod link======================"
+          echo $(sh $GITHUB_WORKSPACE/scripts/upload_services/${UPLOAD_SERVICE}.sh ${{ steps.snapcraft.outputs.snap }})
+          echo "=====no operation for you can see link in the log console====="

--- a/data/flatpak/org.flameshot.flameshot.yml
+++ b/data/flatpak/org.flameshot.flameshot.yml
@@ -1,6 +1,6 @@
-app-id: org.flameshot.app
+app-id: org.flameshot.flameshot
 runtime: org.kde.Platform
-runtime-version: '5.14'
+runtime-version: '5.15'
 sdk: org.kde.Sdk
 command: flameshot
 finish-args:
@@ -15,5 +15,5 @@ modules:
       - -DCMAKE_BUILD_TYPE=RelWithDebInfo
     sources:
       - type: git
-        url: https://github.com/borgmanJeremy/flameshot/
+        url: https://github.com/flameshot-org/flameshot
         branch: master 

--- a/data/rpm/flameshot.spec
+++ b/data/rpm/flameshot.spec
@@ -14,18 +14,46 @@ Source0: https://github.com/flameshot-org/%{sourcename}/archive/v%{version}.tar.
 #%%define _binaries_in_noarch_packages_terminate_build   0
 #BuildArch: noarch
 
+%if 0%{?is_opensuse}
+%if 0%{?suse_version} >= 1500
+BuildRequires: gcc-c++ >= 4.9.2
+BuildRequires: update-desktop-files 
+%else
+BuildRequires: gcc7
+BuildRequires: gcc7-c++
+%endif
+BuildRequires: libqt5-qttools-devel
+BuildRequires: libqt5-linguist
+%else
 BuildRequires: gcc-c++  >= 4.9.2  
-BuildRequires: pkgconfig(Qt5Core) >= 5.3.0
-BuildRequires: pkgconfig(Qt5Gui)  >= 5.3.0
-BuildRequires: pkgconfig(Qt5Widgets)  >= 5.3.0
+%endif 
+
+%if 0%{?fedora} || 0%{?rhel_version} || 0%{?centos_version}
 BuildRequires: qt5-qttools-devel
 BuildRequires: qt5-linguist
-BuildRequires: qt5-qtsvg-devel
-BuildRequires: cmake  >= 3.13.0
+%endif
 
+BuildRequires: cmake  >= 3.13.0
+BuildRequires: pkgconfig
+BuildRequires: pkgconfig(Qt5Core) >= 5.3.0
+BuildRequires: pkgconfig(Qt5Gui)  >= 5.3.0
+BuildRequires: pkgconfig(Qt5DBus) >= 5.3.0
+BuildRequires: pkgconfig(Qt5Network) >= 5.3.0
+BuildRequires: pkgconfig(Qt5Widgets)  >= 5.3.0
+BuildRequires: pkgconfig(Qt5Svg)  >= 5.3.0
+
+
+%if 0%{?fedora} || 0%{?rhel_version} || 0%{?centos_version}
 Requires: qt5-qtbase >= 5.3.0
 Requires: qt5-qttools
 Requires: qt5-qtsvg
+%endif
+%if 0%{?is_opensuse}
+Requires: libQt5Core5 >= 5.3.0
+Requires: libqt5-qttools
+Requires: libQt5Svg5
+%endif
+Requires: hicolor-icon-theme
 
 %description
 Flameshot is a screenshot software, it's
@@ -41,16 +69,25 @@ make %{?_smp_mflags}
 %install
 %make_install INSTALL_ROOT=%{buildroot}
 
+%if 0%{?is_opensuse}
+%if 0%{?suse_version} >= 1500
+%suse_update_desktop_file %{name} Graphics
+%endif
+%endif
+
+%if 0%{?fedora}
 %post -p /sbin/ldconfig
 %postun -p /sbin/ldconfig
+%endif
 
 %files
 %doc README.md
 %license LICENSE
 %{_bindir}/%{name}
+%{_datadir}/%{name}
 %{_datadir}/dbus-1/interfaces/org.flameshot.Flameshot.xml
 %{_datadir}/dbus-1/services/org.flameshot.Flameshot.service
-%{_datadir}/metainfo/flameshot.appdata.xml
+%{_datadir}/metainfo/flameshot.metainfo.xml
 %{_datadir}/flameshot/translations
 %{_datadir}/applications/%{name}.desktop
 %{_datadir}/bash-completions/completions/%{name}

--- a/data/snap/local/launchers/README.md
+++ b/data/snap/local/launchers/README.md
@@ -1,0 +1,16 @@
+# /snap/local/launchers
+
+Here are the launchers, or wrapper programs to deal with some runtime-fixable
+problems for the snapped applications, like setting proper environmental
+variables in snap.
+
+In convention launchers are named _something_-launch, for dealing certain
+problem with _something_, and usually can be called in a stacked manner to
+consolidate their modifications.
+
+```yaml
+apps:
+  _app_name_:
+    command: foo-launch bar-launch _app_command_
+```
+

--- a/data/snap/local/launchers/flameshot-launch
+++ b/data/snap/local/launchers/flameshot-launch
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# This is the maintainence launcher for the snap, make necessary runtime
+# environment changes to make the snap work here.  You may also insert security
+# confinement/deprecation/obsoletion notice of the snap here.
+
+set \
+  -o errexit \
+  -o errtrace \
+  -o nounset \
+  -o pipefail
+
+# gtk-common-themes support
+export QT_QPA_PLATFORMTHEME=gtk3
+# Correct the TMPDIR path for Chromium Framework/Electron to
+# ensure libappindicator has readable resources
+export TMPDIR=$XDG_RUNTIME_DIR
+# Coerce XDG_CURRENT_DESKTOP to Unity so that App Indicators
+# are used and do not fall back to Notification Area applets
+# or disappear completely.
+export XDG_CURRENT_DESKTOP=Unity
+
+# Finally run the next part of the command chain
+exec "${@}"

--- a/data/snap/snapcraft.yaml
+++ b/data/snap/snapcraft.yaml
@@ -1,0 +1,148 @@
+---
+
+name: flameshot
+adopt-info: flameshot
+base: core20
+summary: Powerful yet simple to use screenshot software
+description: |
+  A powerful open source screenshot and annotation tool for Linux, Flameshot
+  has a varied set of markup tools available, which include Freehand drawing,
+  Lines, Arrows, Boxes, Circles, Highlighting, Blur. Additionally, you can
+  customise the color, size and/or thickness of many of these image annotation
+  tools.
+grade: stable  # must be 'stable' to release into candidate/stable channels
+confinement: strict  # use 'strict' once you have the right plugs and slots
+architectures:
+  - build-on: amd64
+  - build-on: i386
+
+
+apps:
+  flameshot:
+    adapter: full
+    command: usr/bin/flameshot
+    desktop: usr/share/applications/flameshot.desktop
+    environment:
+      DISABLE_WAYLAND: 1
+      XDG_DATA_DIRS: $SNAP/share:$XDG_DATA_DIRS
+    slots: [dbus-flameshot]
+    plugs:
+      - desktop
+      - desktop-legacy
+      - gsettings
+      - home
+      - network
+      - network-bind
+      - opengl
+      - pulseaudio
+      - unity7
+      - wayland
+      - x11
+
+
+plugs:
+  # Gtk Common Themes support
+  # https://forum.snapcraft.io/t/how-to-use-the-system-gtk-theme-via-the-gtk-common-themes-snap/6235
+  gsettings:
+  gtk-3-themes:
+    interface: content
+    target: $SNAP/data-dir/themes
+    default-provider: gtk-common-themes
+  icon-themes:
+    interface: content
+    target: $SNAP/data-dir/icons
+    default-provider: gtk-common-themes
+  sound-themes:
+    interface: content
+    target: $SNAP/data-dir/sounds
+    default-provider: gtk-common-themes
+
+
+parts:
+  desktop-qt5:
+    source: https://github.com/ubuntu/snapcraft-desktop-helpers.git
+    source-subdir: qt
+    plugin: make
+    make-parameters: ["FLAVOR=qt5"]
+    build-packages:
+      - qtbase5-dev
+      - dpkg-dev
+    stage-packages:
+      - libxkbcommon0
+      - ttf-ubuntu-font-family
+      - dmz-cursor-theme
+      - light-themes
+      - adwaita-icon-theme
+      - gnome-themes-standard
+      - shared-mime-info
+      - libqt5gui5
+      - libgdk-pixbuf2.0-0
+      - libgtk2.0-0
+      - libqt5svg5
+      - try:
+          - appmenu-qt5
+      - locales-all
+      - xdg-user-dirs
+      - fcitx-frontend-qt5
+
+  libappindicator:
+    plugin: nil
+    stage-packages:
+      - libappindicator3-1
+    after: [desktop-qt5]
+    prime:
+      - usr/lib/$SNAPCRAFT_ARCH_TRIPLET/libdbusmenu*.so*
+      - usr/lib/$SNAPCRAFT_ARCH_TRIPLET/libappindicator*.so*
+      - usr/lib/$SNAPCRAFT_ARCH_TRIPLET/libindicator*.so*
+
+  launchers:  # custom launcher to set QT_QPA_PLATFORMTHEME=gtk3 correctly
+    source: .
+    source-subdir: snap/local/launchers
+    plugin: dump
+    organize:
+      '*': bin/
+    stage:
+      - -bin/README.*
+
+  flameshot:
+    after:
+      - desktop-qt5
+    plugin: cmake
+    cmake-parameters:
+      - '-DCMAKE_BUILD_TYPE=RelWithDebInfo'
+      - '-DCMAKE_INSTALL_PREFIX=/usr'
+    source: https://github.com/flameshot-org/flameshot.git
+    source-type: git
+    override-pull: |
+      snapcraftctl pull
+      last_committed_tag="$(git tag -l --sort=-v:refname | head -1)"
+      git_revno="$(git rev-list $(git describe --tags --abbrev=0)..HEAD --count)"
+      git_hash="$(git rev-parse --short HEAD)"
+      snapcraftctl set-version "${last_committed_tag}+git${git_revno}.${git_hash}"
+    override-build: |
+      snapcraftctl build
+      # Correct the Icon path
+      sed -i 's|^Exec=flameshot|Exec=/snap/bin/flameshot.flameshot|' ${SNAPCRAFT_PART_INSTALL}/usr/share/applications/flameshot.desktop
+      sed -i 's|^Icon=.*|Icon=${SNAP}/usr/share/icons/hicolor/scalable/apps/flameshot.svg|' ${SNAPCRAFT_PART_INSTALL}/usr/share/applications/flameshot.desktop
+      sed -i 's/^\(Name\(\[.\+\]\)\?=.*\)$/\1 (Snappy Edition)/g' ${SNAPCRAFT_PART_INSTALL}/usr/share/applications/flameshot.desktop
+    build-packages:
+      - qt5-default
+      - qttools5-dev-tools
+      - qttools5-dev
+      - libqt5svg5-dev
+    stage-packages:
+      - dbus-x11
+      - libgtk2.0-0
+      - openssl
+      - ca-certificates
+      - qtwayland5
+      - qt5-gtk-platformtheme  # for theming, font settings, cursor and to use gtk3 file chooser
+
+slots:
+  # Depending on in which environment we're running we either need
+  # to use the system or session DBus so we also need to have one
+  # slot for each.
+  dbus-flameshot:
+    interface: dbus
+    bus: session
+    name: org.flameshot.Flameshot

--- a/docs/appdata/flameshot.metainfo.xml
+++ b/docs/appdata/flameshot.metainfo.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright 2018 Vitaly Zaitsev <vitaly@easycoding.org> -->
 <component type="desktop">
-  <id>flameshot.desktop</id>
+  <id>org.flameshot.flameshot</id>
   <metadata_license>CC0-1.0</metadata_license>
-  <project_license>GPL-3.0-or-later and ASL 2.0 and GPLv2 and LGPLv3 and Free Art</project_license>
+  <project_license>GPL-3.0-or-later</project_license>
   <name>Flameshot</name>
   <summary>Powerful and simple to use screenshot software</summary>
   <description>

--- a/scripts/upload_services/transferwee.py
+++ b/scripts/upload_services/transferwee.py
@@ -99,6 +99,7 @@ def download_url(url: str) -> str:
         return None
 
     j = {
+        "intent": "entire_transfer",
         "security_hash": security_hash,
     }
     if recipient_id:

--- a/scripts/upload_services/wetransfer.com.sh
+++ b/scripts/upload_services/wetransfer.com.sh
@@ -20,6 +20,11 @@ if [ ! -f "$FILE" ]; then
     exit 1
 fi
 
-RESPONSE=$(python3 transferwee.py upload "${FILE}")
+
+scripts_path=`dirname $0`
+
+python3 -m pip install -U -q requests
+
+RESPONSE=$(python3 ${scripts_path}/transferwee.py upload "${FILE}")
 
 echo "${RESPONSE}"  # to terminal

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -140,8 +140,8 @@ install(
 configure_file(${CMAKE_SOURCE_DIR}/docs/desktopEntry/package/flameshot.desktop
                ${CMAKE_CURRENT_BINARY_DIR}/share/applications/flameshot.desktop COPYONLY)
 
-configure_file(${CMAKE_SOURCE_DIR}/docs/appdata/flameshot.appdata.xml
-               ${CMAKE_CURRENT_BINARY_DIR}/share/metainfo/flameshot.appdata.xml COPYONLY)
+configure_file(${CMAKE_SOURCE_DIR}/docs/appdata/flameshot.metainfo.xml
+               ${CMAKE_CURRENT_BINARY_DIR}/share/metainfo/flameshot.metainfo.xml COPYONLY)
 
 configure_file(${CMAKE_SOURCE_DIR}/docs/bash-completion/flameshot
                ${CMAKE_CURRENT_BINARY_DIR}/share/bash-completions/completions/flameshot COPYONLY)


### PR DESCRIPTION
- add appimage, flatpak, snap, opensuse-leap packaging
- when this PR is https://github.com/flameshot-org/packpack/pull/1 merged, then `rpm-pack(opensuse-leap-15.2)` could be passed.
- using this new tool https://github.com/probonopd/go-appimage/blob/master/src/appimagetool/README.md to build appimage.
- fix appstream metainfo, for standards, please see https://www.freedesktop.org/software/appstream/docs/chap-Quickstart.html#sect-Quickstart-DesktopApps
  - rename `flameshot.appdata.xml` to `flameshot.metainfo.xml`
  - the component ID is not a reverse domain-name. So I change it to `<id>org.flameshot.flameshot</id>`
- some of the files related to snap packaging are from https://github.com/flameshot-org/packages/tree/master/snap and I update the build tools and dependencies
- update upstream upload service python script & correct its full path. Switching the upload service to `wetransfer.com`
- make the link returned by the upload service directly visible in the log console & add sha256 checksum.
  
  ![image](https://user-images.githubusercontent.com/10769951/92498144-d983d580-f22c-11ea-8795-c95862767177.png)

some useful links about opensuse packaging
- https://en.opensuse.org/openSUSE:Packaging_desktop_menu_categories
- https://en.opensuse.org/openSUSE:Packaging_Conventions_RPM_Macros

cmake snapcraft.yml file for direct reference
- https://gitlab.com/inkscape/inkscape/blob/master/snap/snapcraft.yaml

snap related github actions
- https://github.com/snapcore/action-build
- https://github.com/snapcore/action-publish
