### PR TITLE
Fix count when the redo tool is called with circle counter

### DIFF
--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -731,6 +731,9 @@ CaptureWidget::handleButtonSignal(CaptureTool::Request r)
       m_undoStack.undo();
       break;
     case CaptureTool::REQ_REDO_MODIFICATION:
+      if (m_undoStack.redoText() == "Circle Counter") {
+        this->incrementCircleCount();
+      }
       m_undoStack.redo();
       break;
     case CaptureTool::REQ_REDRAW:


### PR DESCRIPTION
Checked if the tool about to be called in the "redo" method is the circle counter. If it is, need to increment the count to make up for subtraction during undo. 