### PR TITLE
A few adjustments: remove github actions artifact & make actions more elegant.

### DIFF
--- a/.github/workflows/pack.yml
+++ b/.github/workflows/pack.yml
@@ -1,4 +1,4 @@
-name: Packing
+name: Packaging
 
 on:
   push:
@@ -33,7 +33,7 @@ jobs:
           # flameshot-org/packpack or packpack/packpack
           repository: flameshot-org/packpack
           path: tools
-      - name: Pack on ${{ matrix.dist }}
+      - name: Packaging on ${{ matrix.dist }}
         if: matrix.dist == 'debian-10'
         run: |
           cp -r $GITHUB_WORKSPACE/data/debian $GITHUB_WORKSPACE
@@ -41,7 +41,7 @@ jobs:
         env:
           OS: debian 
           DIST: buster
-      - name: Pack on ${{ matrix.dist }}
+      - name: Packaging on ${{ matrix.dist }}
         if: matrix.dist == 'ubuntu-20.04'
         run: |
           cp -r $GITHUB_WORKSPACE/data/debian $GITHUB_WORKSPACE
@@ -72,7 +72,7 @@ jobs:
           # flameshot-org/packpack or packpack/packpack
           repository: flameshot-org/packpack
           path: tools
-      - name: Pack on ${{ matrix.dist }}
+      - name: Packaging on ${{ matrix.dist }}
         if: matrix.dist == 'fedora-31'
         run: |
           cp -r $GITHUB_WORKSPACE/data/rpm $GITHUB_WORKSPACE
@@ -80,7 +80,7 @@ jobs:
         env:
           OS: fedora
           DIST: 31
-      - name: Pack on ${{ matrix.dist }}
+      - name: Packaging on ${{ matrix.dist }}
         if: matrix.dist == 'fedora-32'
         run: |
           cp -r $GITHUB_WORKSPACE/data/rpm $GITHUB_WORKSPACE
@@ -88,7 +88,7 @@ jobs:
         env:
           OS: fedora
           DIST: 32
-      - name: Pack on ${{ matrix.dist }}
+      - name: Packaging on ${{ matrix.dist }}
         if: matrix.dist == 'opensuse-leap-15.2'
         run: |
           cp -r $GITHUB_WORKSPACE/data/rpm $GITHUB_WORKSPACE
@@ -140,18 +140,19 @@ jobs:
             libqt5gui5 \
             libqt5svg5-dev \
             appstream \
+            hicolor-icon-theme \
             fcitx-frontend-qt5 \
             openssl \
             ca-certificates
       - name: Get go-appimage tool
-      # Will not use linuxdeployqt anymore, because it suopprt currently still-supported mainstream distribution, 
+      # Will not use linuxdeployqt anymore, because it suopprts currently still-supported mainstream distribution, 
       # which is glibc 2.23. For more information, please see https://github.com/probonopd/linuxdeployqt/issues/340.
-      # Will try new tool https://github.com/probonopd/go-appimage written by golang.
+      # Will try new tool https://github.com/probonopd/go-appimage written in golang by the inventor of the AppImage format.
         run: |
           wget -c https://github.com/$(wget -q https://github.com/probonopd/go-appimage/releases -O - \
-          | grep "appimagetool-.*-x86_64.AppImage" | head -n 1 | cut -d '"' -f 2) -O appimagetool
+          | grep "appimagetool-.*-${ARCH}.AppImage" | head -n 1 | cut -d '"' -f 2) -O appimagetool
           chmod +x appimagetool
-      - name: Pack appimage
+      - name: Packaging appimage
         run: |
           APPIMAGE_DST_PATH=$GITHUB_WORKSPACE/${PRODUCT}.AppDir
           mkdir -p ${APPIMAGE_DST_PATH}
@@ -164,7 +165,7 @@ jobs:
 
           mkdir -p ${APPIMAGE_DST_PATH}/usr/plugins/platforminputcontexts
           cp \
-            /usr/lib/x86_64-linux-gnu/qt5/plugins/platforminputcontexts/libfcitxplatforminputcontextplugin.so \
+            /usr/lib/${ARCH}-linux-gnu/qt5/plugins/platforminputcontexts/libfcitxplatforminputcontextplugin.so \
             ${APPIMAGE_DST_PATH}/usr/plugins/platforminputcontexts/
 
           cp \
@@ -172,13 +173,13 @@ jobs:
             ${APPIMAGE_DST_PATH}/
 
           VERSION=${VERSION} $GITHUB_WORKSPACE/appimagetool ${APPIMAGE_DST_PATH}
-      - name: SHA256Sum of AppImage package(daily build)
+      - name: SHA256Sum of appimage package(daily build)
         run: |
-          sha256sum $GITHUB_WORKSPACE/Flameshot-${VERSION}-x86_64.AppImage
+          sha256sum $GITHUB_WORKSPACE/Flameshot-${VERSION}-${ARCH}.AppImage
       - name: Upload appimage package for daily build
         run: |
           echo "====================appimage downlod link====================="
-          echo $(sh $GITHUB_WORKSPACE/scripts/upload_services/${UPLOAD_SERVICE}.sh $GITHUB_WORKSPACE/Flameshot-${VERSION}-x86_64.AppImage)
+          echo $(sh $GITHUB_WORKSPACE/scripts/upload_services/${UPLOAD_SERVICE}.sh $GITHUB_WORKSPACE/Flameshot-${VERSION}-${ARCH}.AppImage)
           echo "=====no operation for you can see link in the log console====="
 
   flatpak-pack:
@@ -186,7 +187,7 @@ jobs:
     steps:
       - name: Checkout Source code
         uses: actions/checkout@v2
-      - name: Setup Flatpak
+      - name: Setup flatpak
         run: |
           sudo apt-get -y -qq update
           sudo apt-get install -y flatpak flatpak-builder
@@ -194,7 +195,7 @@ jobs:
         run: |
           flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
           flatpak install -y --noninteractive flathub org.kde.Sdk//5.15 org.kde.Platform//5.15
-      - name: Pack flatpak
+      - name: Packaging flatpak
         run: |
           BUNDLE="org.flameshot.flameshot_${VERSION}_${ARCH}.flatpak"
           MANIFEST_PATH=$GITHUB_WORKSPACE/data/flatpak/org.flameshot.flameshot.yml
@@ -204,7 +205,7 @@ jobs:
 
           flatpak-builder --user --disable-rofiles-fuse --repo=repo --force-clean flatpak_app ${MANIFEST_PATH} --install-deps-from=flathub
           flatpak build-bundle repo ${BUNDLE} --runtime-repo=${RUNTIME_REPO} ${APP_ID} ${BRANCH}
-      - name: SHA256Sum of Flatpak package(daily build)
+      - name: SHA256Sum of flatpak package(daily build)
         run: |
           sha256sum $GITHUB_WORKSPACE/org.flameshot.flameshot_${VERSION}_${ARCH}.flatpak
       - name: Upload flatpak package(daily build)
@@ -218,17 +219,12 @@ jobs:
     steps:
       - name: Checkout Source code
         uses: actions/checkout@v2
-      - name: Pack snap
+      - name: Packaging snap
         uses: snapcore/action-build@v1
         id: snapcraft
         with:
           path: data
-      - name: Save built snap as an artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: snap
-          path: ${{ steps.snapcraft.outputs.snap }}
-      - name: SHA256Sum of Snap package(daily build)
+      - name: SHA256Sum of snap package(daily build)
         run: |
           sha256sum ${{ steps.snapcraft.outputs.snap }}
       - name: Upload snap package(daily build)


### PR DESCRIPTION
- add hicolor-icon-theme(default fallback theme for FreeDesktop.org icon themes) for appimage, more details, see https://ubuntu.pkgs.org/20.04/ubuntu-main-amd64/hicolor-icon-theme_0.17-2_all.deb.html
- remove github actions artifact, because GitHub stores artifacts for 90 days(https://docs.github.com/en/actions/configuring-and-managing-workflows/persisting-workflow-data-using-artifacts), but storage capacity is only 0.5GB for free. https://wetransfer.com is a good product for us to store artifacts temporarily, t will keep for 7 days. Its terms of service: https://wetransfer.com/legal/terms. And its download page is more user-friendly.
  
  ![image](https://user-images.githubusercontent.com/10769951/92556219-eee41880-f29b-11ea-8acf-6784c9a0d2bb.png)

- fix some typos