### PR TITLE
fix text config in side panel

### DIFF
--- a/src/tools/text/textconfig.cpp
+++ b/src/tools/text/textconfig.cpp
@@ -40,10 +40,9 @@ TextConfig::TextConfig(QWidget* parent)
   int index = fontsCB->findText(font().family());
   fontsCB->setCurrentIndex(index);
 
-  QColor bgColor(palette().windowText().color());
-  QString iconPrefix = ColorUtils::colorIsDark(bgColor)
-                         ? PathInfo::whiteIconPath()
-                         : PathInfo::blackIconPath();
+  QString iconPrefix = ColorUtils::colorIsDark(palette().windowText().color())
+                         ? PathInfo::blackIconPath()
+                         : PathInfo::whiteIconPath();
 
   m_strikeOutButton = new QPushButton(
     QIcon(iconPrefix + "format_strikethrough.svg"), QLatin1String(""));

--- a/src/widgets/panel/utilitypanel.cpp
+++ b/src/widgets/panel/utilitypanel.cpp
@@ -57,6 +57,7 @@ UtilityPanel::addToolWidget(QWidget* w)
   }
   if (w) {
     m_toolWidget = w;
+    m_toolWidget->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Preferred);
     m_upLayout->addWidget(w);
   }
 }


### PR DESCRIPTION
The text config widget was growing too big for some reason, adding hor. scroll.

Also fixed the button color.

![](https://i.imgur.com/XCgv5OM.png)