### PR TITLE
Fix windows build badge and typos

### DIFF
--- a/.github/workflows/Linux-pack.yml
+++ b/.github/workflows/Linux-pack.yml
@@ -138,7 +138,6 @@ jobs:
             extra-cmake-modules \
             build-essential \
             qt5-default \
-            qt5-qmake \
             qttools5-dev-tools \
             qttools5-dev \
             libqt5dbus5 \

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -35,7 +35,6 @@ jobs:
             extra-cmake-modules \
             build-essential \
             qt5-default \
-            qt5-qmake \
             qttools5-dev-tools \
             qttools5-dev \
             libqt5dbus5 \

--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@
   </p>
   <p>
     <a href="https://github.com/flameshot-org/flameshot/actions">
-      <img src="https://img.shields.io/github/workflow/status/flameshot-org/flameshot/Packaging?label=gnu%2Flinux" alt="GNU/Linux Build Status" />
+      <img src="https://img.shields.io/github/workflow/status/flameshot-org/flameshot/Packaging(Linux)?label=gnu%2Flinux" alt="GNU/Linux Build Status" />
     </a>
-    <a href="https://ci.appveyor.com/project/lupoDharkael/flameshot">
-      <img src="https://img.shields.io/appveyor/ci/lupoDharkael/flameshot.svg?style=flat-square&label=windows" alt="Windows Build Status" />
+    <a href="https://github.com/flameshot-org/flameshot/actions">
+      <img src="https://img.shields.io/github/workflow/status/flameshot-org/flameshot/Packaging(Windows)?label=windows" alt="Windows Build Status" />
     </a>
     <a href="https://github.com/flameshot-org/flameshot/releases">
       <img src="https://img.shields.io/github/release/flameshot-org/flameshot.svg?style=flat-square" alt="Latest Stable Release" />
@@ -25,7 +25,7 @@
     <a href="https://github.com/flameshot-org/flameshot/blob/master/LICENSE">
       <img src="https://img.shields.io/github/license/flameshot-org/flameshot.svg?style=flat-square" alt="License" />
     </a>
-    <a href="https://flameshot-org.github.io">
+    <a href="https://flameshot.org">
       <img src="https://img.shields.io/github/release/flameshot-org/flameshot.svg?style=flat-square&label=docs" alt="Docs" />
     </a>
   </p>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -67,7 +67,7 @@ target_sources(
           ${CMAKE_CURRENT_SOURCE_DIR}/../external/Qt-Color-Widgets/src/color_wheel.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/../external/Qt-Color-Widgets/include/color_wheel.hpp
           ${CMAKE_CURRENT_SOURCE_DIR}/../data/graphics.qrc
-          ${CMAKE_CURRENT_SOURCE_DIR}/../data/icon.rc # flamshot binary icon resource file
+          ${CMAKE_CURRENT_SOURCE_DIR}/../data/icon.rc # windows binary icon resource file
           ${QM_FILES}
           main.cpp)
 


### PR DESCRIPTION
* Drop qmake build-dependency from CI, they should not be installed since we have switched to CMake.
* Update README.md badges to reflect recent Windows CI updates.
* Set doc badge to point to flameshot.org website.
* Fix a typo in src/CMakeLists.txt.