### PR TITLE
Fix side panel button on Windows

### DIFF
--- a/src/config/buttonlistview.cpp
+++ b/src/config/buttonlistview.cpp
@@ -36,9 +36,9 @@ void
 ButtonListView::initButtonList()
 {
   ToolFactory factory;
-  auto listTypes = CaptureButton::getIterableButtonTypes();
+  auto listTypes = CaptureToolButton::getIterableButtonTypes();
 
-  for (const CaptureButton::ButtonType t : listTypes) {
+  for (const CaptureToolButton::ButtonType t : listTypes) {
     CaptureTool* tool = factory.CreateTool(t);
 
     // add element to the local map
@@ -64,14 +64,14 @@ ButtonListView::initButtonList()
 void
 ButtonListView::updateActiveButtons(QListWidgetItem* item)
 {
-  CaptureButton::ButtonType bType = m_buttonTypeByName[item->text()];
+  CaptureToolButton::ButtonType bType = m_buttonTypeByName[item->text()];
   if (item->checkState() == Qt::Checked) {
     m_listButtons.append(bType);
     // TODO refactor so we don't need external sorts
-    using bt = CaptureButton::ButtonType;
+    using bt = CaptureToolButton::ButtonType;
     std::sort(m_listButtons.begin(), m_listButtons.end(), [](bt a, bt b) {
-      return CaptureButton::getPriorityByButton(a) <
-             CaptureButton::getPriorityByButton(b);
+      return CaptureToolButton::getPriorityByButton(a) <
+             CaptureToolButton::getPriorityByButton(b);
     });
   } else {
     m_listButtons.remove(m_listButtons.indexOf(bType));
@@ -104,10 +104,10 @@ void
 ButtonListView::updateComponents()
 {
   m_listButtons = ConfigHandler().getButtons();
-  auto listTypes = CaptureButton::getIterableButtonTypes();
+  auto listTypes = CaptureToolButton::getIterableButtonTypes();
   for (int i = 0; i < this->count(); ++i) {
     QListWidgetItem* item = this->item(i);
-    auto elem = static_cast<CaptureButton::ButtonType>(listTypes.at(i));
+    auto elem = static_cast<CaptureToolButton::ButtonType>(listTypes.at(i));
     if (m_listButtons.contains(elem)) {
       item->setCheckState(Qt::Checked);
     } else {

--- a/src/config/buttonlistview.h
+++ b/src/config/buttonlistview.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "src/widgets/capture/capturebutton.h"
+#include "src/widgets/capture/capturetoolbutton.h"
 #include <QListWidget>
 
 class ButtonListView : public QListWidget
@@ -36,8 +36,8 @@ protected:
   void initButtonList();
 
 private:
-  QVector<CaptureButton::ButtonType> m_listButtons;
-  QMap<QString, CaptureButton::ButtonType> m_buttonTypeByName;
+  QVector<CaptureToolButton::ButtonType> m_listButtons;
+  QMap<QString, CaptureToolButton::ButtonType> m_buttonTypeByName;
 
   void updateActiveButtons(QListWidgetItem*);
 };

--- a/src/config/configwindow.cpp
+++ b/src/config/configwindow.cpp
@@ -24,7 +24,7 @@
 #include "src/utils/confighandler.h"
 #include "src/utils/globalvalues.h"
 #include "src/utils/pathinfo.h"
-#include "src/widgets/capture/capturebutton.h"
+#include "src/widgets/capture/capturetoolbutton.h"
 #include <QFileSystemWatcher>
 #include <QIcon>
 #include <QKeyEvent>

--- a/src/config/uicoloreditor.cpp
+++ b/src/config/uicoloreditor.cpp
@@ -121,7 +121,7 @@ UIcolorEditor::initButtons()
   QGroupBox* frame = new QGroupBox();
   frame->setFixedSize(frameSize, frameSize);
 
-  m_buttonMainColor = new CaptureButton(m_buttonIconType, frame);
+  m_buttonMainColor = new CaptureToolButton(m_buttonIconType, frame);
   m_buttonMainColor->move(m_buttonMainColor->x() + extraSize / 2,
                           m_buttonMainColor->y() + extraSize / 2);
   QHBoxLayout* h1 = new QHBoxLayout();
@@ -134,7 +134,7 @@ UIcolorEditor::initButtons()
                                    " mode of the main color."));
 
   QGroupBox* frame2 = new QGroupBox();
-  m_buttonContrast = new CaptureButton(m_buttonIconType, frame2);
+  m_buttonContrast = new CaptureToolButton(m_buttonIconType, frame2);
   m_buttonContrast->move(m_buttonContrast->x() + extraSize / 2,
                          m_buttonContrast->y() + extraSize / 2);
 
@@ -150,11 +150,11 @@ UIcolorEditor::initButtons()
                                   " mode of the contrast color."));
 
   connect(m_buttonMainColor,
-          &CaptureButton::pressedButton,
+          &CaptureToolButton::pressedButton,
           this,
           &UIcolorEditor::changeLastButton);
   connect(m_buttonContrast,
-          &CaptureButton::pressedButton,
+          &CaptureToolButton::pressedButton,
           this,
           &UIcolorEditor::changeLastButton);
   // clicking the labels changes the button too
@@ -169,7 +169,7 @@ UIcolorEditor::initButtons()
 
 // visual update for the selected button
 void
-UIcolorEditor::changeLastButton(CaptureButton* b)
+UIcolorEditor::changeLastButton(CaptureToolButton* b)
 {
   if (m_lastButtonPressed != b) {
     m_lastButtonPressed = b;

--- a/src/config/uicoloreditor.h
+++ b/src/config/uicoloreditor.h
@@ -18,12 +18,12 @@
 #pragma once
 
 #include "color_wheel.hpp"
-#include "src/widgets/capture/capturebutton.h"
+#include "src/widgets/capture/capturetoolbutton.h"
 #include <QGroupBox>
 
 class QVBoxLayout;
 class QHBoxLayout;
-class CaptureButton;
+class CaptureToolButton;
 class ClickableLabel;
 
 class UIcolorEditor : public QGroupBox
@@ -38,19 +38,19 @@ public slots:
 private slots:
   void updateUIcolor();
   void updateLocalColor(const QColor);
-  void changeLastButton(CaptureButton*);
+  void changeLastButton(CaptureToolButton*);
 
 private:
   QColor m_uiColor, m_contrastColor;
-  CaptureButton* m_buttonMainColor;
+  CaptureToolButton* m_buttonMainColor;
   ClickableLabel* m_labelMain;
-  CaptureButton* m_buttonContrast;
+  CaptureToolButton* m_buttonContrast;
   ClickableLabel* m_labelContrast;
-  CaptureButton* m_lastButtonPressed;
+  CaptureToolButton* m_lastButtonPressed;
   color_widgets::ColorWheel* m_colorWheel;
 
-  static const CaptureButton::ButtonType m_buttonIconType =
-    CaptureButton::TYPE_CIRCLE;
+  static const CaptureToolButton::ButtonType m_buttonIconType =
+    CaptureToolButton::TYPE_CIRCLE;
 
   QHBoxLayout* m_hLayout;
   QVBoxLayout* m_vLayout;

--- a/src/core/controller.cpp
+++ b/src/core/controller.cpp
@@ -20,7 +20,7 @@
 #include "src/utils/confighandler.h"
 #include "src/utils/screengrabber.h"
 #include "src/utils/systemnotification.h"
-#include "src/widgets/capture/capturebutton.h"
+#include "src/widgets/capture/capturetoolbutton.h"
 #include "src/widgets/capture/capturewidget.h"
 #include "src/widgets/capturelauncher.h"
 #include "src/widgets/infowindow.h"

--- a/src/tools/toolfactory.cpp
+++ b/src/tools/toolfactory.cpp
@@ -42,68 +42,68 @@ ToolFactory::ToolFactory(QObject* parent)
 {}
 
 CaptureTool*
-ToolFactory::CreateTool(CaptureButton::ButtonType t, QObject* parent)
+ToolFactory::CreateTool(CaptureToolButton::ButtonType t, QObject* parent)
 {
   CaptureTool* tool;
   switch (t) {
-    case CaptureButton::TYPE_ARROW:
+    case CaptureToolButton::TYPE_ARROW:
       tool = new ArrowTool(parent);
       break;
-    case CaptureButton::TYPE_CIRCLE:
+    case CaptureToolButton::TYPE_CIRCLE:
       tool = new CircleTool(parent);
       break;
-    case CaptureButton::TYPE_COPY:
+    case CaptureToolButton::TYPE_COPY:
       tool = new CopyTool(parent);
       break;
-    case CaptureButton::TYPE_EXIT:
+    case CaptureToolButton::TYPE_EXIT:
       tool = new ExitTool(parent);
       break;
-    case CaptureButton::TYPE_IMAGEUPLOADER:
+    case CaptureToolButton::TYPE_IMAGEUPLOADER:
       tool = new ImgurUploaderTool(parent);
       break;
-    case CaptureButton::TYPE_DRAWER:
+    case CaptureToolButton::TYPE_DRAWER:
       tool = new LineTool(parent);
       break;
-    case CaptureButton::TYPE_MARKER:
+    case CaptureToolButton::TYPE_MARKER:
       tool = new MarkerTool(parent);
       break;
-    case CaptureButton::TYPE_MOVESELECTION:
+    case CaptureToolButton::TYPE_MOVESELECTION:
       tool = new MoveTool(parent);
       break;
-    case CaptureButton::TYPE_PENCIL:
+    case CaptureToolButton::TYPE_PENCIL:
       tool = new PencilTool(parent);
       break;
-    case CaptureButton::TYPE_RECTANGLE:
+    case CaptureToolButton::TYPE_RECTANGLE:
       tool = new RectangleTool(parent);
       break;
-    case CaptureButton::TYPE_SAVE:
+    case CaptureToolButton::TYPE_SAVE:
       tool = new SaveTool(parent);
       break;
-    case CaptureButton::TYPE_SELECTION:
+    case CaptureToolButton::TYPE_SELECTION:
       tool = new SelectionTool(parent);
       break;
-    case CaptureButton::TYPE_SELECTIONINDICATOR:
+    case CaptureToolButton::TYPE_SELECTIONINDICATOR:
       tool = new SizeIndicatorTool(parent);
       break;
-    case CaptureButton::TYPE_UNDO:
+    case CaptureToolButton::TYPE_UNDO:
       tool = new UndoTool(parent);
       break;
-    case CaptureButton::TYPE_REDO:
+    case CaptureToolButton::TYPE_REDO:
       tool = new RedoTool(parent);
       break;
-    case CaptureButton::TYPE_OPEN_APP:
+    case CaptureToolButton::TYPE_OPEN_APP:
       tool = new AppLauncher(parent);
       break;
-    case CaptureButton::TYPE_PIXELATE:
+    case CaptureToolButton::TYPE_PIXELATE:
       tool = new PixelateTool(parent);
       break;
-    case CaptureButton::TYPE_PIN:
+    case CaptureToolButton::TYPE_PIN:
       tool = new PinTool(parent);
       break;
-    case CaptureButton::TYPE_TEXT:
+    case CaptureToolButton::TYPE_TEXT:
       tool = new TextTool(parent);
       break;
-    case CaptureButton::TYPE_CIRCLECOUNT:
+    case CaptureToolButton::TYPE_CIRCLECOUNT:
       tool = new CircleCountTool(parent);
       break;
 

--- a/src/tools/toolfactory.h
+++ b/src/tools/toolfactory.h
@@ -18,7 +18,7 @@
 #pragma once
 
 #include "src/tools/capturetool.h"
-#include "src/widgets/capture/capturebutton.h"
+#include "src/widgets/capture/capturetoolbutton.h"
 #include <QObject>
 
 class CaptureTool;
@@ -33,6 +33,6 @@ public:
   ToolFactory(const ToolFactory&) = delete;
   ToolFactory& operator=(const ToolFactory&) = delete;
 
-  CaptureTool* CreateTool(CaptureButton::ButtonType t,
+  CaptureTool* CreateTool(CaptureToolButton::ButtonType t,
                           QObject* parent = nullptr);
 };

--- a/src/utils/confighandler.cpp
+++ b/src/utils/confighandler.cpp
@@ -26,10 +26,10 @@ ConfigHandler::ConfigHandler()
   m_settings.setDefaultFormat(QSettings::IniFormat);
 }
 
-QVector<CaptureButton::ButtonType>
+QVector<CaptureToolButton::ButtonType>
 ConfigHandler::getButtons()
 {
-  QVector<CaptureButton::ButtonType> buttons;
+  QVector<CaptureToolButton::ButtonType> buttons;
   if (m_settings.contains(QStringLiteral("buttons"))) {
     // TODO: remove toList in v1.0
     QVector<int> buttonsInt = m_settings.value(QStringLiteral("buttons"))
@@ -43,29 +43,33 @@ ConfigHandler::getButtons()
     buttons = fromIntToButton(buttonsInt);
   } else {
     // Default tools
-    buttons << CaptureButton::TYPE_PENCIL << CaptureButton::TYPE_DRAWER
-            << CaptureButton::TYPE_ARROW << CaptureButton::TYPE_SELECTION
-            << CaptureButton::TYPE_RECTANGLE << CaptureButton::TYPE_CIRCLE
-            << CaptureButton::TYPE_MARKER << CaptureButton::TYPE_PIXELATE
-            << CaptureButton::TYPE_SELECTIONINDICATOR
-            << CaptureButton::TYPE_MOVESELECTION << CaptureButton::TYPE_UNDO
-            << CaptureButton::TYPE_REDO << CaptureButton::TYPE_COPY
-            << CaptureButton::TYPE_SAVE << CaptureButton::TYPE_EXIT
-            << CaptureButton::TYPE_IMAGEUPLOADER << CaptureButton::TYPE_OPEN_APP
-            << CaptureButton::TYPE_PIN << CaptureButton::TYPE_TEXT
-            << CaptureButton::TYPE_CIRCLECOUNT;
+    buttons << CaptureToolButton::TYPE_PENCIL << CaptureToolButton::TYPE_DRAWER
+            << CaptureToolButton::TYPE_ARROW
+            << CaptureToolButton::TYPE_SELECTION
+            << CaptureToolButton::TYPE_RECTANGLE
+            << CaptureToolButton::TYPE_CIRCLE << CaptureToolButton::TYPE_MARKER
+            << CaptureToolButton::TYPE_PIXELATE
+            << CaptureToolButton::TYPE_SELECTIONINDICATOR
+            << CaptureToolButton::TYPE_MOVESELECTION
+            << CaptureToolButton::TYPE_UNDO << CaptureToolButton::TYPE_REDO
+            << CaptureToolButton::TYPE_COPY << CaptureToolButton::TYPE_SAVE
+            << CaptureToolButton::TYPE_EXIT
+            << CaptureToolButton::TYPE_IMAGEUPLOADER
+            << CaptureToolButton::TYPE_OPEN_APP << CaptureToolButton::TYPE_PIN
+            << CaptureToolButton::TYPE_TEXT
+            << CaptureToolButton::TYPE_CIRCLECOUNT;
   }
 
-  using bt = CaptureButton::ButtonType;
+  using bt = CaptureToolButton::ButtonType;
   std::sort(buttons.begin(), buttons.end(), [](bt a, bt b) {
-    return CaptureButton::getPriorityByButton(a) <
-           CaptureButton::getPriorityByButton(b);
+    return CaptureToolButton::getPriorityByButton(a) <
+           CaptureToolButton::getPriorityByButton(b);
   });
   return buttons;
 }
 
 void
-ConfigHandler::setButtons(const QVector<CaptureButton::ButtonType>& buttons)
+ConfigHandler::setButtons(const QVector<CaptureToolButton::ButtonType>& buttons)
 {
   QVector<int> l = fromButtonToInt(buttons);
   normalizeButtons(l);
@@ -438,8 +442,8 @@ void
 ConfigHandler::setAllTheButtons()
 {
   QVector<int> buttons;
-  auto listTypes = CaptureButton::getIterableButtonTypes();
-  for (const CaptureButton::ButtonType t : listTypes) {
+  auto listTypes = CaptureToolButton::getIterableButtonTypes();
+  for (const CaptureToolButton::ButtonType t : listTypes) {
     buttons << static_cast<int>(t);
   }
   // TODO: remove toList in v1.0
@@ -456,7 +460,7 @@ ConfigHandler::configFilePath() const
 bool
 ConfigHandler::normalizeButtons(QVector<int>& buttons)
 {
-  auto listTypes = CaptureButton::getIterableButtonTypes();
+  auto listTypes = CaptureToolButton::getIterableButtonTypes();
   QVector<int> listTypesInt;
   for (auto i : listTypes)
     listTypesInt << static_cast<int>(i);
@@ -471,17 +475,17 @@ ConfigHandler::normalizeButtons(QVector<int>& buttons)
   return hasChanged;
 }
 
-QVector<CaptureButton::ButtonType>
+QVector<CaptureToolButton::ButtonType>
 ConfigHandler::fromIntToButton(const QVector<int>& l)
 {
-  QVector<CaptureButton::ButtonType> buttons;
+  QVector<CaptureToolButton::ButtonType> buttons;
   for (auto const i : l)
-    buttons << static_cast<CaptureButton::ButtonType>(i);
+    buttons << static_cast<CaptureToolButton::ButtonType>(i);
   return buttons;
 }
 
 QVector<int>
-ConfigHandler::fromButtonToInt(const QVector<CaptureButton::ButtonType>& l)
+ConfigHandler::fromButtonToInt(const QVector<CaptureToolButton::ButtonType>& l)
 {
   QVector<int> buttons;
   for (auto const i : l)

--- a/src/utils/confighandler.h
+++ b/src/utils/confighandler.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "src/widgets/capture/capturebutton.h"
+#include "src/widgets/capture/capturetoolbutton.h"
 #include <QSettings>
 #include <QVector>
 
@@ -26,8 +26,8 @@ class ConfigHandler
 public:
   explicit ConfigHandler();
 
-  QVector<CaptureButton::ButtonType> getButtons();
-  void setButtons(const QVector<CaptureButton::ButtonType>&);
+  QVector<CaptureToolButton::ButtonType> getButtons();
+  void setButtons(const QVector<CaptureToolButton::ButtonType>&);
 
   QVector<QColor> getUserColors();
   void setUserColors(const QVector<QColor>&);
@@ -93,6 +93,6 @@ private:
 
   bool normalizeButtons(QVector<int>&);
 
-  QVector<CaptureButton::ButtonType> fromIntToButton(const QVector<int>& l);
-  QVector<int> fromButtonToInt(const QVector<CaptureButton::ButtonType>& l);
+  QVector<CaptureToolButton::ButtonType> fromIntToButton(const QVector<int>& l);
+  QVector<int> fromButtonToInt(const QVector<CaptureToolButton::ButtonType>& l);
 };

--- a/src/widgets/capture/CMakeLists.txt
+++ b/src/widgets/capture/CMakeLists.txt
@@ -3,6 +3,7 @@ target_sources(
   flameshot
   PRIVATE buttonhandler.h
           capturebutton.h
+          capturetoolbutton.h
           capturewidget.h
           colorpicker.h
           hovereventfilter.h
@@ -13,6 +14,7 @@ target_sources(
   flameshot
   PRIVATE buttonhandler.cpp
           capturebutton.cpp
+          capturetoolbutton.cpp
           capturewidget.cpp
           colorpicker.cpp
           hovereventfilter.cpp

--- a/src/widgets/capture/buttonhandler.cpp
+++ b/src/widgets/capture/buttonhandler.cpp
@@ -24,7 +24,8 @@
 // ButtonHandler is a habdler for every active button. It makes easier to
 // manipulate the buttons as a unit.
 
-ButtonHandler::ButtonHandler(const QVector<CaptureButton*>& v, QObject* parent)
+ButtonHandler::ButtonHandler(const QVector<CaptureToolButton*>& v,
+                             QObject* parent)
   : QObject(parent)
 {
   setButtons(v);
@@ -40,7 +41,7 @@ ButtonHandler::ButtonHandler(QObject* parent)
 void
 ButtonHandler::hide()
 {
-  for (CaptureButton* b : m_vectorButtons)
+  for (CaptureToolButton* b : m_vectorButtons)
     b->hide();
 }
 
@@ -50,7 +51,7 @@ ButtonHandler::show()
   if (m_vectorButtons.isEmpty() || m_vectorButtons.first()->isVisible()) {
     return;
   }
-  for (CaptureButton* b : m_vectorButtons)
+  for (CaptureToolButton* b : m_vectorButtons)
     b->animatedShow();
 }
 
@@ -58,7 +59,7 @@ bool
 ButtonHandler::isVisible() const
 {
   bool ret = true;
-  for (const CaptureButton* b : m_vectorButtons) {
+  for (const CaptureToolButton* b : m_vectorButtons) {
     if (!b->isVisible()) {
       ret = false;
       break;
@@ -370,12 +371,12 @@ ButtonHandler::adjustHorizontalCenter(QPoint& center)
 
 // setButtons redefines the buttons of the button handler
 void
-ButtonHandler::setButtons(const QVector<CaptureButton*> v)
+ButtonHandler::setButtons(const QVector<CaptureToolButton*> v)
 {
   if (v.isEmpty())
     return;
 
-  for (CaptureButton* b : m_vectorButtons)
+  for (CaptureToolButton* b : m_vectorButtons)
     delete (b);
   m_vectorButtons = v;
   m_buttonBaseSize = GlobalValues::buttonBaseSize();

--- a/src/widgets/capture/buttonhandler.h
+++ b/src/widgets/capture/buttonhandler.h
@@ -17,12 +17,12 @@
 
 #pragma once
 
-#include "capturebutton.h"
+#include "capturetoolbutton.h"
 #include <QObject>
 #include <QRegion>
 #include <QVector>
 
-class CaptureButton;
+class CaptureToolButton;
 class QRect;
 class QPoint;
 
@@ -30,7 +30,7 @@ class ButtonHandler : public QObject
 {
   Q_OBJECT
 public:
-  ButtonHandler(const QVector<CaptureButton*>&, QObject* parent = nullptr);
+  ButtonHandler(const QVector<CaptureToolButton*>&, QObject* parent = nullptr);
   explicit ButtonHandler(QObject* parent = nullptr);
 
   void hideSectionUnderMouse(const QPoint& p);
@@ -39,7 +39,7 @@ public:
   bool buttonsAreInside() const;
   size_t size() const;
 
-  void setButtons(const QVector<CaptureButton*>);
+  void setButtons(const QVector<CaptureToolButton*>);
   bool contains(const QPoint& p) const;
   void updateScreenRegions(const QVector<QRect>& rects);
   void updateScreenRegions(const QRect& rect);
@@ -59,7 +59,7 @@ private:
 
   QRect intersectWithAreas(const QRect& rect);
 
-  QVector<CaptureButton*> m_vectorButtons;
+  QVector<CaptureToolButton*> m_vectorButtons;
 
   QRegion m_screenRegions;
 

--- a/src/widgets/capture/capturebutton.cpp
+++ b/src/widgets/capture/capturebutton.cpp
@@ -16,57 +16,36 @@
 //     along with Flameshot.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "capturebutton.h"
-#include "src/tools/capturetool.h"
-#include "src/tools/toolfactory.h"
 #include "src/utils/colorutils.h"
 #include "src/utils/confighandler.h"
 #include "src/utils/globalvalues.h"
-#include "src/widgets/capture/capturewidget.h"
-#include <QApplication>
 #include <QGraphicsDropShadowEffect>
-#include <QIcon>
-#include <QMouseEvent>
-#include <QPropertyAnimation>
-#include <QToolTip>
 
-// Button represents a single button of the capture widget, it can enable
-// multiple functionality.
-
-CaptureButton::CaptureButton(const ButtonType t, QWidget* parent)
+CaptureButton::CaptureButton(QWidget* parent)
   : QPushButton(parent)
-  , m_buttonType(t)
 {
-  initButton();
-  if (t == TYPE_SELECTIONINDICATOR) {
-    QFont f = this->font();
-    setFont(QFont(f.family(), 7, QFont::Bold));
-  } else {
-    updateIcon();
-  }
-  setCursor(Qt::ArrowCursor);
+  init();
+}
+
+CaptureButton::CaptureButton(const QString& text, QWidget* parent)
+  : QPushButton(text, parent)
+{
+  init();
+}
+
+CaptureButton::CaptureButton(const QIcon& icon,
+                             const QString& text,
+                             QWidget* parent)
+  : QPushButton(icon, text, parent)
+{
+  init();
 }
 
 void
-CaptureButton::initButton()
+CaptureButton::init()
 {
-  m_tool = ToolFactory().CreateTool(m_buttonType, this);
-
+  setCursor(Qt::ArrowCursor);
   setFocusPolicy(Qt::NoFocus);
-  resize(GlobalValues::buttonBaseSize(), GlobalValues::buttonBaseSize());
-  setMask(QRegion(QRect(-1,
-                        -1,
-                        GlobalValues::buttonBaseSize() + 2,
-                        GlobalValues::buttonBaseSize() + 2),
-                  QRegion::Ellipse));
-
-  setToolTip(m_tool->description());
-
-  m_emergeAnimation = new QPropertyAnimation(this, "size", this);
-  m_emergeAnimation->setEasingCurve(QEasingCurve::InOutQuad);
-  m_emergeAnimation->setDuration(80);
-  m_emergeAnimation->setStartValue(QSize(0, 0));
-  m_emergeAnimation->setEndValue(
-    QSize(GlobalValues::buttonBaseSize(), GlobalValues::buttonBaseSize()));
 
   auto dsEffect = new QGraphicsDropShadowEffect(this);
   dsEffect->setBlurRadius(5);
@@ -76,89 +55,32 @@ CaptureButton::initButton()
   setGraphicsEffect(dsEffect);
 }
 
-void
-CaptureButton::updateIcon()
-{
-  setIcon(icon());
-  setIconSize(size() * 0.6);
-}
-
-QVector<CaptureButton::ButtonType>
-CaptureButton::getIterableButtonTypes()
-{
-  return iterableButtonTypes;
-}
-
 QString
 CaptureButton::globalStyleSheet()
 {
-  QColor mainColor = ConfigHandler().uiMainColorValue();
-  QString baseSheet = "CaptureButton { border-radius: %3;"
-                      "background-color: %1; color: %4 }"
-                      "CaptureButton:hover { background-color: %2; }"
-                      "CaptureButton:pressed:!hover { "
-                      "background-color: %1; }";
-  // define color when mouse is hovering
-  QColor contrast = ColorUtils::contrastColor(m_mainColor);
-
-  // foreground color
-  QString color = ColorUtils::colorIsDark(mainColor) ? "white" : "black";
-
-  return baseSheet.arg(mainColor.name())
-    .arg(contrast.name())
-    .arg(GlobalValues::buttonBaseSize() / 2)
-    .arg(color);
+  return CaptureButton(nullptr).styleSheet();
 }
 
 QString
 CaptureButton::styleSheet() const
 {
-  QString baseSheet = "CaptureButton { border-radius: %3;"
+  QString baseSheet = "CaptureButton { border: none;"
+                      "padding: 3px 8px;"
                       "background-color: %1; color: %4 }"
+                      "CaptureToolButton { border-radius: %3;"
+                      "padding: 0; }"
                       "CaptureButton:hover { background-color: %2; }"
                       "CaptureButton:pressed:!hover { "
                       "background-color: %1; }";
   // define color when mouse is hovering
   QColor contrast = ColorUtils::contrastColor(m_mainColor);
   // foreground color
-  QString color = ColorUtils::colorIsDark(m_mainColor) ? "white" : "black";
+  QColor color = ColorUtils::colorIsDark(m_mainColor) ? Qt::white : Qt::black;
 
   return baseSheet.arg(m_mainColor.name())
     .arg(contrast.name())
     .arg(GlobalValues::buttonBaseSize() / 2)
-    .arg(color);
-}
-
-// get icon returns the icon for the type of button
-QIcon
-CaptureButton::icon() const
-{
-  return m_tool->icon(m_mainColor, true);
-}
-
-void
-CaptureButton::mousePressEvent(QMouseEvent* e)
-{
-  if (e->button() == Qt::LeftButton) {
-    emit pressedButton(this);
-    emit pressed();
-  }
-}
-
-void
-CaptureButton::animatedShow()
-{
-  if (!isVisible()) {
-    show();
-    m_emergeAnimation->start();
-    connect(m_emergeAnimation, &QPropertyAnimation::finished, this, []() {});
-  }
-}
-
-CaptureTool*
-CaptureButton::tool() const
-{
-  return m_tool;
+    .arg(color.name());
 }
 
 void
@@ -166,51 +88,6 @@ CaptureButton::setColor(const QColor& c)
 {
   m_mainColor = c;
   setStyleSheet(styleSheet());
-  updateIcon();
 }
 
 QColor CaptureButton::m_mainColor = ConfigHandler().uiMainColorValue();
-
-static std::map<CaptureButton::ButtonType, int> buttonTypeOrder{
-  { CaptureButton::TYPE_PENCIL, 0 },
-  { CaptureButton::TYPE_DRAWER, 1 },
-  { CaptureButton::TYPE_ARROW, 2 },
-  { CaptureButton::TYPE_SELECTION, 3 },
-  { CaptureButton::TYPE_RECTANGLE, 4 },
-  { CaptureButton::TYPE_CIRCLE, 5 },
-  { CaptureButton::TYPE_MARKER, 6 },
-  { CaptureButton::TYPE_TEXT, 7 },
-  { CaptureButton::TYPE_PIXELATE, 8 },
-  { CaptureButton::TYPE_SELECTIONINDICATOR, 9 },
-  { CaptureButton::TYPE_MOVESELECTION, 10 },
-  { CaptureButton::TYPE_UNDO, 11 },
-  { CaptureButton::TYPE_REDO, 12 },
-  { CaptureButton::TYPE_COPY, 13 },
-  { CaptureButton::TYPE_SAVE, 14 },
-  { CaptureButton::TYPE_EXIT, 15 },
-  { CaptureButton::TYPE_IMAGEUPLOADER, 16 },
-  { CaptureButton::TYPE_OPEN_APP, 17 },
-  { CaptureButton::TYPE_PIN, 18 },
-  { CaptureButton::TYPE_CIRCLECOUNT, 19 },
-};
-
-int
-CaptureButton::getPriorityByButton(CaptureButton::ButtonType b)
-{
-  auto it = buttonTypeOrder.find(b);
-  return it == buttonTypeOrder.cend() ? (int)buttonTypeOrder.size()
-                                      : it->second;
-}
-
-QVector<CaptureButton::ButtonType> CaptureButton::iterableButtonTypes = {
-  CaptureButton::TYPE_PENCIL,        CaptureButton::TYPE_DRAWER,
-  CaptureButton::TYPE_ARROW,         CaptureButton::TYPE_SELECTION,
-  CaptureButton::TYPE_RECTANGLE,     CaptureButton::TYPE_CIRCLE,
-  CaptureButton::TYPE_MARKER,        CaptureButton::TYPE_TEXT,
-  CaptureButton::TYPE_PIXELATE,      CaptureButton::TYPE_SELECTIONINDICATOR,
-  CaptureButton::TYPE_MOVESELECTION, CaptureButton::TYPE_UNDO,
-  CaptureButton::TYPE_REDO,          CaptureButton::TYPE_COPY,
-  CaptureButton::TYPE_SAVE,          CaptureButton::TYPE_EXIT,
-  CaptureButton::TYPE_IMAGEUPLOADER, CaptureButton::TYPE_OPEN_APP,
-  CaptureButton::TYPE_PIN,           CaptureButton::TYPE_CIRCLECOUNT,
-};

--- a/src/widgets/capture/capturebutton.h
+++ b/src/widgets/capture/capturebutton.h
@@ -17,85 +17,28 @@
 
 #pragma once
 
-#include <QMap>
 #include <QPushButton>
-#include <QVector>
-
-class QWidget;
-class QPropertyAnimation;
-class CaptureTool;
 
 class CaptureButton : public QPushButton
 {
   Q_OBJECT
 
 public:
-  // Don't forget to add the new types to CaptureButton::iterableButtonTypes
-  // in the .cpp and the order value in the private array buttonTypeOrder
-  enum ButtonType
-  {
-    TYPE_PENCIL = 0,
-    TYPE_DRAWER = 1,
-    TYPE_ARROW = 2,
-    TYPE_SELECTION = 3,
-    TYPE_RECTANGLE = 4,
-    TYPE_CIRCLE = 5,
-    TYPE_MARKER = 6,
-    TYPE_SELECTIONINDICATOR = 7,
-    TYPE_MOVESELECTION = 8,
-    TYPE_UNDO = 9,
-    TYPE_COPY = 10,
-    TYPE_SAVE = 11,
-    TYPE_EXIT = 12,
-    TYPE_IMAGEUPLOADER = 13,
-    TYPE_OPEN_APP = 14,
-    TYPE_PIXELATE = 15,
-    TYPE_REDO = 16,
-    TYPE_PIN = 17,
-    TYPE_TEXT = 18,
-    TYPE_CIRCLECOUNT = 19,
-
-  };
-
-#if QT_VERSION < QT_VERSION_CHECK(5, 5, 0)
-  Q_ENUMS(ButtonType)
-#else
-  Q_ENUM(ButtonType)
-#endif
-
   CaptureButton() = delete;
-  explicit CaptureButton(const ButtonType, QWidget* parent = nullptr);
+  CaptureButton(QWidget* parent = nullptr);
+  CaptureButton(const QString& text, QWidget* parent = nullptr);
+  CaptureButton(const QIcon& icon,
+                const QString& text,
+                QWidget* parent = nullptr);
 
   static QString globalStyleSheet();
-  static QVector<CaptureButton::ButtonType> getIterableButtonTypes();
-  static int getPriorityByButton(CaptureButton::ButtonType);
 
-  QString name() const;
-  QString description() const;
-  QIcon icon() const;
   QString styleSheet() const;
-  CaptureTool* tool() const;
 
   void setColor(const QColor& c);
-  void animatedShow();
-
-protected:
-  virtual void mousePressEvent(QMouseEvent*);
-  static QVector<ButtonType> iterableButtonTypes;
-
-  CaptureTool* m_tool;
-
-signals:
-  void pressedButton(CaptureButton*);
 
 private:
-  CaptureButton(QWidget* parent = nullptr);
-  ButtonType m_buttonType;
-
-  QPropertyAnimation* m_emergeAnimation;
-
   static QColor m_mainColor;
 
-  void initButton();
-  void updateIcon();
+  void init();
 };

--- a/src/widgets/capture/capturetoolbutton.cpp
+++ b/src/widgets/capture/capturetoolbutton.cpp
@@ -1,0 +1,176 @@
+// Copyright(c) 2017-2019 Alejandro Sirgo Rica & Contributors
+//
+// This file is part of Flameshot.
+//
+//     Flameshot is free software: you can redistribute it and/or modify
+//     it under the terms of the GNU General Public License as published by
+//     the Free Software Foundation, either version 3 of the License, or
+//     (at your option) any later version.
+//
+//     Flameshot is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//     GNU General Public License for more details.
+//
+//     You should have received a copy of the GNU General Public License
+//     along with Flameshot.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "capturetoolbutton.h"
+#include "src/tools/capturetool.h"
+#include "src/tools/toolfactory.h"
+#include "src/utils/colorutils.h"
+#include "src/utils/confighandler.h"
+#include "src/utils/globalvalues.h"
+#include "src/widgets/capture/capturewidget.h"
+#include <QApplication>
+#include <QIcon>
+#include <QMouseEvent>
+#include <QPropertyAnimation>
+#include <QToolTip>
+
+// Button represents a single button of the capture widget, it can enable
+// multiple functionality.
+
+CaptureToolButton::CaptureToolButton(const ButtonType t, QWidget* parent)
+  : CaptureButton(parent)
+  , m_buttonType(t)
+{
+  initButton();
+  if (t == TYPE_SELECTIONINDICATOR) {
+    QFont f = this->font();
+    setFont(QFont(f.family(), 7, QFont::Bold));
+  } else {
+    updateIcon();
+  }
+}
+
+void
+CaptureToolButton::initButton()
+{
+  m_tool = ToolFactory().CreateTool(m_buttonType, this);
+
+  resize(GlobalValues::buttonBaseSize(), GlobalValues::buttonBaseSize());
+  setMask(QRegion(QRect(-1,
+                        -1,
+                        GlobalValues::buttonBaseSize() + 2,
+                        GlobalValues::buttonBaseSize() + 2),
+                  QRegion::Ellipse));
+
+  setToolTip(m_tool->description());
+
+  m_emergeAnimation = new QPropertyAnimation(this, "size", this);
+  m_emergeAnimation->setEasingCurve(QEasingCurve::InOutQuad);
+  m_emergeAnimation->setDuration(80);
+  m_emergeAnimation->setStartValue(QSize(0, 0));
+  m_emergeAnimation->setEndValue(
+    QSize(GlobalValues::buttonBaseSize(), GlobalValues::buttonBaseSize()));
+}
+
+void
+CaptureToolButton::updateIcon()
+{
+  setIcon(icon());
+  setIconSize(size() * 0.6);
+}
+
+QVector<CaptureToolButton::ButtonType>
+CaptureToolButton::getIterableButtonTypes()
+{
+  return iterableButtonTypes;
+}
+
+// get icon returns the icon for the type of button
+QIcon
+CaptureToolButton::icon() const
+{
+  return m_tool->icon(m_mainColor, true);
+}
+
+void
+CaptureToolButton::mousePressEvent(QMouseEvent* e)
+{
+  if (e->button() == Qt::LeftButton) {
+    emit pressedButton(this);
+    emit pressed();
+  }
+}
+
+void
+CaptureToolButton::animatedShow()
+{
+  if (!isVisible()) {
+    show();
+    m_emergeAnimation->start();
+    connect(m_emergeAnimation, &QPropertyAnimation::finished, this, []() {});
+  }
+}
+
+CaptureTool*
+CaptureToolButton::tool() const
+{
+  return m_tool;
+}
+
+void
+CaptureToolButton::setColor(const QColor& c)
+{
+  CaptureButton::setColor(c);
+  updateIcon();
+}
+
+QColor CaptureToolButton::m_mainColor = ConfigHandler().uiMainColorValue();
+
+static std::map<CaptureToolButton::ButtonType, int> buttonTypeOrder{
+  { CaptureToolButton::TYPE_PENCIL, 0 },
+  { CaptureToolButton::TYPE_DRAWER, 1 },
+  { CaptureToolButton::TYPE_ARROW, 2 },
+  { CaptureToolButton::TYPE_SELECTION, 3 },
+  { CaptureToolButton::TYPE_RECTANGLE, 4 },
+  { CaptureToolButton::TYPE_CIRCLE, 5 },
+  { CaptureToolButton::TYPE_MARKER, 6 },
+  { CaptureToolButton::TYPE_TEXT, 7 },
+  { CaptureToolButton::TYPE_PIXELATE, 8 },
+  { CaptureToolButton::TYPE_SELECTIONINDICATOR, 9 },
+  { CaptureToolButton::TYPE_MOVESELECTION, 10 },
+  { CaptureToolButton::TYPE_UNDO, 11 },
+  { CaptureToolButton::TYPE_REDO, 12 },
+  { CaptureToolButton::TYPE_COPY, 13 },
+  { CaptureToolButton::TYPE_SAVE, 14 },
+  { CaptureToolButton::TYPE_EXIT, 15 },
+  { CaptureToolButton::TYPE_IMAGEUPLOADER, 16 },
+  { CaptureToolButton::TYPE_OPEN_APP, 17 },
+  { CaptureToolButton::TYPE_PIN, 18 },
+  { CaptureToolButton::TYPE_CIRCLECOUNT, 19 },
+};
+
+int
+CaptureToolButton::getPriorityByButton(CaptureToolButton::ButtonType b)
+{
+  auto it = buttonTypeOrder.find(b);
+  return it == buttonTypeOrder.cend() ? (int)buttonTypeOrder.size()
+                                      : it->second;
+}
+
+QVector<CaptureToolButton::ButtonType>
+  CaptureToolButton::iterableButtonTypes = {
+    CaptureToolButton::TYPE_PENCIL,
+    CaptureToolButton::TYPE_DRAWER,
+    CaptureToolButton::TYPE_ARROW,
+    CaptureToolButton::TYPE_SELECTION,
+    CaptureToolButton::TYPE_RECTANGLE,
+    CaptureToolButton::TYPE_CIRCLE,
+    CaptureToolButton::TYPE_MARKER,
+    CaptureToolButton::TYPE_TEXT,
+    CaptureToolButton::TYPE_PIXELATE,
+    CaptureToolButton::TYPE_SELECTIONINDICATOR,
+    CaptureToolButton::TYPE_MOVESELECTION,
+    CaptureToolButton::TYPE_UNDO,
+    CaptureToolButton::TYPE_REDO,
+    CaptureToolButton::TYPE_COPY,
+    CaptureToolButton::TYPE_SAVE,
+    CaptureToolButton::TYPE_EXIT,
+    CaptureToolButton::TYPE_IMAGEUPLOADER,
+    CaptureToolButton::TYPE_OPEN_APP,
+    CaptureToolButton::TYPE_PIN,
+    CaptureToolButton::TYPE_CIRCLECOUNT,
+  };

--- a/src/widgets/capture/capturetoolbutton.h
+++ b/src/widgets/capture/capturetoolbutton.h
@@ -1,0 +1,93 @@
+// Copyright(c) 2017-2019 Alejandro Sirgo Rica & Contributors
+//
+// This file is part of Flameshot.
+//
+//     Flameshot is free software: you can redistribute it and/or modify
+//     it under the terms of the GNU General Public License as published by
+//     the Free Software Foundation, either version 3 of the License, or
+//     (at your option) any later version.
+//
+//     Flameshot is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//     GNU General Public License for more details.
+//
+//     You should have received a copy of the GNU General Public License
+//     along with Flameshot.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include "capturebutton.h"
+#include <QMap>
+#include <QVector>
+
+class QWidget;
+class QPropertyAnimation;
+class CaptureTool;
+
+class CaptureToolButton : public CaptureButton
+{
+  Q_OBJECT
+
+public:
+  // Don't forget to add the new types to CaptureButton::iterableButtonTypes
+  // in the .cpp and the order value in the private array buttonTypeOrder
+  enum ButtonType
+  {
+    TYPE_PENCIL = 0,
+    TYPE_DRAWER = 1,
+    TYPE_ARROW = 2,
+    TYPE_SELECTION = 3,
+    TYPE_RECTANGLE = 4,
+    TYPE_CIRCLE = 5,
+    TYPE_MARKER = 6,
+    TYPE_SELECTIONINDICATOR = 7,
+    TYPE_MOVESELECTION = 8,
+    TYPE_UNDO = 9,
+    TYPE_COPY = 10,
+    TYPE_SAVE = 11,
+    TYPE_EXIT = 12,
+    TYPE_IMAGEUPLOADER = 13,
+    TYPE_OPEN_APP = 14,
+    TYPE_PIXELATE = 15,
+    TYPE_REDO = 16,
+    TYPE_PIN = 17,
+    TYPE_TEXT = 18,
+    TYPE_CIRCLECOUNT = 19,
+
+  };
+  Q_ENUM(ButtonType)
+
+  explicit CaptureToolButton(const ButtonType, QWidget* parent = nullptr);
+
+  static QVector<CaptureToolButton::ButtonType> getIterableButtonTypes();
+  static int getPriorityByButton(CaptureToolButton::ButtonType);
+
+  QString name() const;
+  QString description() const;
+  QIcon icon() const;
+  CaptureTool* tool() const;
+
+  void setColor(const QColor& c);
+  void animatedShow();
+
+protected:
+  void mousePressEvent(QMouseEvent* e) override;
+  static QVector<ButtonType> iterableButtonTypes;
+
+  CaptureTool* m_tool;
+
+signals:
+  void pressedButton(CaptureToolButton*);
+
+private:
+  CaptureToolButton(QWidget* parent = nullptr);
+  ButtonType m_buttonType;
+
+  QPropertyAnimation* m_emergeAnimation;
+
+  static QColor m_mainColor;
+
+  void initButton();
+  void updateIcon();
+};

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -176,17 +176,18 @@ CaptureWidget::updateButtons()
   m_contrastUiColor = m_config.uiContrastColorValue();
 
   auto buttons = m_config.getButtons();
-  QVector<CaptureButton*> vectorButtons;
+  QVector<CaptureToolButton*> vectorButtons;
 
-  for (const CaptureButton::ButtonType& t : buttons) {
-    CaptureButton* b = new CaptureButton(t, this);
-    if (t == CaptureButton::TYPE_SELECTIONINDICATOR) {
+  for (const CaptureToolButton::ButtonType& t : buttons) {
+    CaptureToolButton* b = new CaptureToolButton(t, this);
+    if (t == CaptureToolButton::TYPE_SELECTIONINDICATOR) {
       m_sizeIndButton = b;
     }
     b->setColor(m_uiColor);
     makeChild(b);
 
-    connect(b, &CaptureButton::pressedButton, this, &CaptureWidget::setState);
+    connect(
+      b, &CaptureToolButton::pressedButton, this, &CaptureWidget::setState);
     connect(b->tool(),
             &CaptureTool::requestAction,
             this,
@@ -626,16 +627,6 @@ CaptureWidget::initPanel()
             &QPushButton::clicked,
             this,
             &CaptureWidget::togglePanel);
-
-    QColor mainColor = config.uiMainColorValue();
-    QColor textColor =
-      ColorUtils::colorIsDark(mainColor) ? Qt::white : Qt::black;
-    QPalette palette = panelToggleButton->palette();
-    palette.setColor(QPalette::Button, mainColor);
-    palette.setColor(QPalette::ButtonText, textColor);
-    panelToggleButton->setAutoFillBackground(true);
-    panelToggleButton->setPalette(palette);
-    panelToggleButton->update();
   }
 
   m_panel = new UtilityPanel(this);
@@ -681,7 +672,7 @@ CaptureWidget::initSelection()
 }
 
 void
-CaptureWidget::setState(CaptureButton* b)
+CaptureWidget::setState(CaptureToolButton* b)
 {
   if (!b) {
     return;

--- a/src/widgets/capture/capturewidget.h
+++ b/src/widgets/capture/capturewidget.h
@@ -26,7 +26,7 @@
 #pragma once
 
 #include "buttonhandler.h"
-#include "capturebutton.h"
+#include "capturetoolbutton.h"
 #include "src/tools/capturecontext.h"
 #include "src/tools/capturetool.h"
 #include "src/utils/confighandler.h"
@@ -86,7 +86,7 @@ private slots:
   void upResize();
   void downResize();
 
-  void setState(CaptureButton* b);
+  void setState(CaptureToolButton* b);
   void processTool(CaptureTool* t);
   void handleButtonSignal(CaptureTool::Request r);
   void setDrawColor(const QColor& c);
@@ -140,9 +140,9 @@ private:
   QRect extendedRect(QRect* r) const;
 
   QUndoStack m_undoStack;
-  QPointer<CaptureButton> m_sizeIndButton;
+  QPointer<CaptureToolButton> m_sizeIndButton;
   // Last pressed button
-  QPointer<CaptureButton> m_activeButton;
+  QPointer<CaptureToolButton> m_activeButton;
   QPointer<CaptureTool> m_activeTool;
   QPointer<QWidget> m_toolWidget;
 

--- a/src/widgets/orientablepushbutton.cpp
+++ b/src/widgets/orientablepushbutton.cpp
@@ -24,17 +24,17 @@
 #include <QStylePainter>
 
 OrientablePushButton::OrientablePushButton(QWidget* parent)
-  : QPushButton(parent)
+  : CaptureButton(parent)
 {}
 
 OrientablePushButton::OrientablePushButton(const QString& text, QWidget* parent)
-  : QPushButton(text, parent)
+  : CaptureButton(text, parent)
 {}
 
 OrientablePushButton::OrientablePushButton(const QIcon& icon,
                                            const QString& text,
                                            QWidget* parent)
-  : QPushButton(icon, text, parent)
+  : CaptureButton(icon, text, parent)
 {}
 
 QSize

--- a/src/widgets/orientablepushbutton.h
+++ b/src/widgets/orientablepushbutton.h
@@ -19,9 +19,10 @@
 
 #pragma once
 
+#include "capture/capturebutton.h"
 #include <QPushButton>
 
-class OrientablePushButton : public QPushButton
+class OrientablePushButton : public CaptureButton
 {
   Q_OBJECT
 public:


### PR DESCRIPTION
Fixes [the issue on Windows](https://github.com/flameshot-org/flameshot/pull/631#issuecomment-691658871) by reusing `CaptureButton` CSS instead of using palette.

![](https://i.imgur.com/xE5YGuz.png)

For now I simply extracted all styling stuff into a separate base class, and created new `CaptureToolButton` class for tool buttons.
Probably should be refactored further.

Now the side panel button also has the same hover style.