### PR TITLE
Fix side panel height on stacked multi-monitor setup

### DIFF
--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -577,8 +577,8 @@ CaptureWidget::resizeEvent(QResizeEvent* e)
   QWidget::resizeEvent(e);
   m_context.widgetDimensions = rect();
   m_context.widgetOffset = mapToGlobal(QPoint(0, 0));
-  m_panel->setFixedHeight(height());
   if (!m_context.fullscreen) {
+    m_panel->setFixedHeight(height());
     m_buttonHandler->updateScreenRegions(rect());
   }
 }


### PR DESCRIPTION
Fixes #919

Not sure what was the purpose of this resize, I think it can be useful only in non-fullscreen mode (currently available [only for debugging](https://github.com/flameshot-org/flameshot/blob/460e30c2ce6e0923e8b69d9fd26adc9ddd8157ac/src/core/controller.cpp#L130-L144))