### PR TITLE
Fixed Missing dependency, Fixed spelling mistake

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ Info: If I take code from your project and that implies a relicense to GPLv3, yo
 
 ## Contribute
 
-If you want to contribute check the [CONTRIBUTING.md](CONTRIBUTING.md)
+If you want to contribute check the [CONTRIBUTING.md](docs/CONTRIBUTING.md)
 
 
 

--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ Also you can open and build/debug the project in a C++ IDE. For example, in Qt C
 
 ```shell
 # Compile-time
-apt install g++ cmake build-essential qt5-default qttools5-dev-tools libqt5svg5-dev
+apt install g++ cmake build-essential qt5-default qttools5-dev-tools libqt5svg5-dev qttools5-dev
 
 # Run-time
 apt install libqt5dbus5 libqt5network5 libqt5core5a libqt5widgets5 libqt5gui5 libqt5svg5

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -49,7 +49,7 @@
 #include <draggablewidgetmaker.h>
 
 // CaptureWidget is the main component used to capture the screen. It contains
-// an are of selection with its respective buttons.
+// an area of selection with its respective buttons.
 
 // enableSaveWIndow
 CaptureWidget::CaptureWidget(const uint id,


### PR DESCRIPTION
qttools5-dev is also required on ubuntu 20.04 (tested on pop os 20.04). So added it under dependency (debian) in readme.md
Fixed a spelling mistake in comment in src/widgets/capture/capturewidget.cpp