### PR TITLE
appdata: Fix check errors

### DIFF
--- a/docs/appdata/flameshot.metainfo.xml
+++ b/docs/appdata/flameshot.metainfo.xml
@@ -22,4 +22,5 @@
   </screenshots>
   <url type="homepage">https://github.com/flameshot-org/flameshot</url>
   <update_contact>https://github.com/flameshot-org/flameshot/issues/new</update_contact>
+  <launchable type="desktop-id">flameshot.desktop</launchable>
 </component>


### PR DESCRIPTION
The following errors are found during appdata checking:

* org.flameshot.flameshot: missing-desktop-file
* flameshot.desktop: no-metainfo

(See https://appstream.debian.org/sid/main/issues/flameshot.html for reference.)

The root cause is the lack of a <launchable type="desktop-id"> tag in the metainfo file that references the name of .desktop file. This commit fixes that.

(Another solution would be renaming flameshot.desktop to be org.flameshot.flameshot.desktop.)