### PR TITLE
#813 eyedropper tool

### DIFF
--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -48,6 +48,11 @@ target_sources(flameshot PRIVATE undo/undotool.h undo/undotool.cpp)
 
 target_sources(
   flameshot
+  PRIVATE eyedropper/eyedroppertool.h
+          eyedropper/eyedroppertool.cpp)
+
+target_sources(
+  flameshot
   PRIVATE abstractactiontool.cpp
           abstractpathtool.cpp
           abstracttwopointtool.cpp

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -49,7 +49,9 @@ target_sources(flameshot PRIVATE undo/undotool.h undo/undotool.cpp)
 target_sources(
   flameshot
   PRIVATE eyedropper/eyedroppertool.h
-          eyedropper/eyedroppertool.cpp)
+          eyedropper/eyedroppertool.cpp
+          eyedropper/eyedropperwidget.h
+          eyedropper/eyedropperwidget.cpp)
 
 target_sources(
   flameshot

--- a/src/tools/capturetool.h
+++ b/src/tools/capturetool.h
@@ -44,7 +44,8 @@ enum class ToolType
   SELECTION,
   SIZEINDICATOR,
   TEXT,
-  UNDO
+  UNDO,
+  EYEDROPPER,
 };
 
 class CaptureTool : public QObject

--- a/src/tools/eyedropper/eyedroppertool.cpp
+++ b/src/tools/eyedropper/eyedroppertool.cpp
@@ -16,9 +16,22 @@
 //     along with Flameshot.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "eyedroppertool.h"
+#include "eyedropperwidget.h"
+#include "src/core/controller.h"
+#include <QDebug>
+#include <QPoint>
+
+namespace {
+  EyedropperWidget* infoWidget;
+  QPoint lastPoint;
+}
 
 EyedropperTool::EyedropperTool(QObject* parent)
   : CaptureTool(parent)
+{
+}
+
+EyedropperTool::~EyedropperTool()
 {
 }
 
@@ -81,7 +94,12 @@ void
 EyedropperTool::process(QPainter& painter,
                         const QPixmap& pixmap,
                         bool recordUndo)
-{}
+{
+  QImage image = pixmap.toImage();
+  QRgb rgb = image.pixel(lastPoint);
+  // qInfo() << "RGB: (" << qRed(rgb) << ", " << qGreen(rgb) << ", " << qBlue(rgb) << ")";
+  // todo: stuff
+}
 
 void
 EyedropperTool::paintMousePreview(QPainter& painter,
@@ -94,19 +112,31 @@ EyedropperTool::undo(QPixmap& pixmap)
 
 void
 EyedropperTool::drawEnd(const QPoint& p)
-{}
+{
+}
 
 void
 EyedropperTool::drawMove(const QPoint& p)
-{}
+{
+  lastPoint = p;
+
+  // todo: m_widget here becomes nullptr, why?
+  //  m_widget->setFocus();
+  //  m_widget->activateWindow();
+  //  m_widget->raise();
+}
 
 void
 EyedropperTool::drawStart(const CaptureContext& context)
-{}
+{
+  lastPoint = context.mousePos;
+}
 
 void
 EyedropperTool::pressed(const CaptureContext& context)
-{}
+{
+  emit requestAction(REQ_ADD_CHILD_WINDOW);
+}
 
 void
 EyedropperTool::colorChanged(const QColor& c)
@@ -115,3 +145,13 @@ EyedropperTool::colorChanged(const QColor& c)
 void
 EyedropperTool::thicknessChanged(const int th)
 {}
+
+QWidget*
+EyedropperTool::widget()
+{
+  if (!m_widget) {
+    // todo: WindowStaysOnTopHint has no effect
+    m_widget = new EyedropperWidget(nullptr, Qt::WindowStaysOnTopHint);
+  }
+  return m_widget;
+}

--- a/src/tools/eyedropper/eyedroppertool.cpp
+++ b/src/tools/eyedropper/eyedroppertool.cpp
@@ -1,0 +1,117 @@
+// Copyright(c) 2017-2019 Alejandro Sirgo Rica & Contributors
+//
+// This file is part of Flameshot.
+//
+//     Flameshot is free software: you can redistribute it and/or modify
+//     it under the terms of the GNU General Public License as published by
+//     the Free Software Foundation, either version 3 of the License, or
+//     (at your option) any later version.
+//
+//     Flameshot is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//     GNU General Public License for more details.
+//
+//     You should have received a copy of the GNU General Public License
+//     along with Flameshot.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "eyedroppertool.h"
+
+EyedropperTool::EyedropperTool(QObject* parent)
+  : CaptureTool(parent)
+{
+}
+
+bool
+EyedropperTool::isValid() const
+{
+  return false;
+}
+
+bool
+EyedropperTool::closeOnButtonPressed() const
+{
+  return false;
+}
+
+bool
+EyedropperTool::isSelectable() const
+{
+  return true;
+}
+
+bool
+EyedropperTool::showMousePreview() const
+{
+  return false;
+}
+
+QIcon
+EyedropperTool::icon(const QColor& background, bool inEditor) const
+{
+  Q_UNUSED(inEditor);
+  return QIcon(iconPath(background) + "colorize.svg");
+}
+
+QString
+EyedropperTool::name() const
+{
+  return tr("Eyedropper");
+}
+
+ToolType
+EyedropperTool::nameID() const
+{
+  return ToolType::EYEDROPPER;
+}
+
+QString
+EyedropperTool::description() const
+{
+  return tr("Get the pixel information");
+}
+
+CaptureTool*
+EyedropperTool::copy(QObject* parent)
+{
+  return new EyedropperTool(parent);
+}
+
+void
+EyedropperTool::process(QPainter& painter,
+                        const QPixmap& pixmap,
+                        bool recordUndo)
+{}
+
+void
+EyedropperTool::paintMousePreview(QPainter& painter,
+                                  const CaptureContext& context)
+{}
+
+void
+EyedropperTool::undo(QPixmap& pixmap)
+{}
+
+void
+EyedropperTool::drawEnd(const QPoint& p)
+{}
+
+void
+EyedropperTool::drawMove(const QPoint& p)
+{}
+
+void
+EyedropperTool::drawStart(const CaptureContext& context)
+{}
+
+void
+EyedropperTool::pressed(const CaptureContext& context)
+{}
+
+void
+EyedropperTool::colorChanged(const QColor& c)
+{}
+
+void
+EyedropperTool::thicknessChanged(const int th)
+{}

--- a/src/tools/eyedropper/eyedroppertool.h
+++ b/src/tools/eyedropper/eyedroppertool.h
@@ -1,0 +1,49 @@
+// Copyright(c) 2017-2019 Alejandro Sirgo Rica & Contributors
+//
+// This file is part of Flameshot.
+//
+//     Flameshot is free software: you can redistribute it and/or modify
+//     it under the terms of the GNU General Public License as published by
+//     the Free Software Foundation, either version 3 of the License, or
+//     (at your option) any later version.
+//
+//     Flameshot is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//     GNU General Public License for more details.
+//
+//     You should have received a copy of the GNU General Public License
+//     along with Flameshot.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include "src/tools/capturetool.h"
+
+class EyedropperTool : public CaptureTool
+{
+  Q_OBJECT;
+public:
+  explicit EyedropperTool(QObject* parent = nullptr);
+
+  bool isValid() const override;
+  bool closeOnButtonPressed() const override;
+  bool isSelectable() const override;
+  bool showMousePreview() const override;
+
+  QIcon icon(const QColor& background, bool inEditor) const override;
+  QString name() const override;
+  ToolType nameID() const override;
+  QString description() const override;
+  CaptureTool* copy(QObject* parent) override;
+  void process(QPainter& painter, const QPixmap& pixmap, bool recordUndo) override;
+  void paintMousePreview(QPainter& painter, const CaptureContext& context) override;
+  void undo(QPixmap& pixmap) override;
+
+public slots:
+  void drawEnd(const QPoint& p) override;
+  void drawMove(const QPoint& p) override;
+  void drawStart(const CaptureContext& context) override;
+  void pressed(const CaptureContext& context) override;
+  void colorChanged(const QColor& c) override;
+  void thicknessChanged(const int th) override;
+};

--- a/src/tools/eyedropper/eyedroppertool.h
+++ b/src/tools/eyedropper/eyedroppertool.h
@@ -19,11 +19,14 @@
 
 #include "src/tools/capturetool.h"
 
+class EyedropperWidget;
+
 class EyedropperTool : public CaptureTool
 {
   Q_OBJECT;
 public:
   explicit EyedropperTool(QObject* parent = nullptr);
+  ~EyedropperTool() override;
 
   bool isValid() const override;
   bool closeOnButtonPressed() const override;
@@ -46,4 +49,8 @@ public slots:
   void pressed(const CaptureContext& context) override;
   void colorChanged(const QColor& c) override;
   void thicknessChanged(const int th) override;
+  QWidget* widget() override;
+
+private:
+  EyedropperWidget* m_widget { nullptr };
 };

--- a/src/tools/eyedropper/eyedropperwidget.cpp
+++ b/src/tools/eyedropper/eyedropperwidget.cpp
@@ -1,0 +1,24 @@
+// Copyright(c) 2017-2019 Alejandro Sirgo Rica & Contributors
+//
+// This file is part of Flameshot.
+//
+//     Flameshot is free software: you can redistribute it and/or modify
+//     it under the terms of the GNU General Public License as published by
+//     the Free Software Foundation, either version 3 of the License, or
+//     (at your option) any later version.
+//
+//     Flameshot is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//     GNU General Public License for more details.
+//
+//     You should have received a copy of the GNU General Public License
+//     along with Flameshot.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "eyedropperwidget.h"
+
+EyedropperWidget::EyedropperWidget(QWidget* parent, const Qt::WindowFlags& f)
+  : QWidget(parent, f)
+{
+  setFixedSize(100, 100);
+}

--- a/src/tools/eyedropper/eyedropperwidget.h
+++ b/src/tools/eyedropper/eyedropperwidget.h
@@ -1,0 +1,26 @@
+// Copyright(c) 2017-2019 Alejandro Sirgo Rica & Contributors
+//
+// This file is part of Flameshot.
+//
+//     Flameshot is free software: you can redistribute it and/or modify
+//     it under the terms of the GNU General Public License as published by
+//     the Free Software Foundation, either version 3 of the License, or
+//     (at your option) any later version.
+//
+//     Flameshot is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//     GNU General Public License for more details.
+//
+//     You should have received a copy of the GNU General Public License
+//     along with Flameshot.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <QWidget>
+
+class EyedropperWidget : public QWidget
+{
+public:
+  explicit EyedropperWidget(QWidget* parent = nullptr, const Qt::WindowFlags& f = Qt::WindowFlags());
+};

--- a/src/tools/toolfactory.cpp
+++ b/src/tools/toolfactory.cpp
@@ -36,6 +36,7 @@
 #include "sizeindicator/sizeindicatortool.h"
 #include "text/texttool.h"
 #include "undo/undotool.h"
+#include "eyedropper/eyedroppertool.h"
 
 ToolFactory::ToolFactory(QObject* parent)
   : QObject(parent)
@@ -105,6 +106,9 @@ ToolFactory::CreateTool(CaptureToolButton::ButtonType t, QObject* parent)
       break;
     case CaptureToolButton::TYPE_CIRCLECOUNT:
       tool = new CircleCountTool(parent);
+      break;
+    case CaptureToolButton::TYPE_EYEDROPPER:
+      tool = new EyedropperTool(parent);
       break;
 
     default:

--- a/src/utils/confighandler.cpp
+++ b/src/utils/confighandler.cpp
@@ -57,7 +57,8 @@ ConfigHandler::getButtons()
             << CaptureToolButton::TYPE_IMAGEUPLOADER
             << CaptureToolButton::TYPE_OPEN_APP << CaptureToolButton::TYPE_PIN
             << CaptureToolButton::TYPE_TEXT
-            << CaptureToolButton::TYPE_CIRCLECOUNT;
+            << CaptureToolButton::TYPE_CIRCLECOUNT
+            << CaptureToolButton::TYPE_EYEDROPPER;
   }
 
   using bt = CaptureToolButton::ButtonType;

--- a/src/widgets/capture/capturetoolbutton.cpp
+++ b/src/widgets/capture/capturetoolbutton.cpp
@@ -141,6 +141,7 @@ static std::map<CaptureToolButton::ButtonType, int> buttonTypeOrder{
   { CaptureToolButton::TYPE_IMAGEUPLOADER, 17 },
   { CaptureToolButton::TYPE_OPEN_APP, 18 },
   { CaptureToolButton::TYPE_PIN, 19 },
+  { CaptureToolButton::TYPE_EYEDROPPER, 20 },
 };
 
 int
@@ -173,4 +174,5 @@ QVector<CaptureToolButton::ButtonType>
     CaptureToolButton::TYPE_OPEN_APP,
     CaptureToolButton::TYPE_PIN,
     CaptureToolButton::TYPE_CIRCLECOUNT,
+    CaptureToolButton::TYPE_EYEDROPPER,
   };

--- a/src/widgets/capture/capturetoolbutton.h
+++ b/src/widgets/capture/capturetoolbutton.h
@@ -54,6 +54,7 @@ public:
     TYPE_PIN = 17,
     TYPE_TEXT = 18,
     TYPE_CIRCLECOUNT = 19,
+    TYPE_EYEDROPPER = 20,
 
   };
   Q_ENUM(ButtonType)


### PR DESCRIPTION
Hello maintainers, i'm new to qt and this is my first pr into that repo. I'm going to maintain that project further
The #813 issue seems very straightforward to implement but i have some problems with the code
Couldn't you elaborate on why I can't make the window above the capture's one?
The idea is simple, show small frameless window (or widget, i don't yet know qt's terminology) with color info and keep it above the capture's window while the eyedropper tool is active