### PR TITLE
fix: create a clean environment to build ubuntu-18.04 package

### DIFF
--- a/.github/workflows/Linux-pack.yml
+++ b/.github/workflows/Linux-pack.yml
@@ -30,12 +30,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        dist: [debian-10, ubuntu-18.04, ubuntu-20.04]
+        dist: [debian-10, ubuntu-20.04]
     steps:
       - name: Checkout Source code
         uses: actions/checkout@v2
       - name: Get packpack tool
-        if: matrix.dist != 'ubuntu-18.04'
         uses: actions/checkout@v2
         with:
           # flameshot-org/packpack or packpack/packpack
@@ -49,38 +48,6 @@ jobs:
         env:
           OS: debian 
           DIST: buster
-      # Please note packaging on ubuntu 18.04 will base on github actions Ubuntu 18.04.5 LTS images, 
-      # it already has cmake installed(cmake version 3.17.0). 
-      # https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu1804-README.md
-      - name: Packaging on ${{ matrix.dist }}
-        if: matrix.dist == 'ubuntu-18.04'
-        run: |
-          mkdir -p $GITHUB_WORKSPACE/build
-          cp -r $GITHUB_WORKSPACE/data/debian $GITHUB_WORKSPACE
-
-          sudo apt-get -y -qq update
-          sudo apt-get -y --no-install-recommends install \
-            build-essential \
-            debhelper \
-            fakeroot \
-            qt5-default \
-            qttools5-dev-tools \
-            qttools5-dev \
-            libqt5dbus5 \
-            libqt5network5 \
-            libqt5core5a \
-            libqt5widgets5 \
-            libqt5gui5 \
-            libqt5svg5-dev
-
-          echo "=======CMAKE VERSION========"
-          cmake --version
-          echo "============================"
-
-          sed -e "/cmake (>= 3.13~),/d" -i $GITHUB_WORKSPACE/debian/control
-          dpkg-buildpackage -b
-
-          cp $GITHUB_WORKSPACE/../${PRODUCT}_${VERSION}-${RELEASE}_amd64.deb $GITHUB_WORKSPACE/build/${PRODUCT}_${VERSION}-${RELEASE}_amd64.deb
       - name: Packaging on ${{ matrix.dist }}
         if: matrix.dist == 'ubuntu-20.04'
         run: |
@@ -95,6 +62,57 @@ jobs:
       - name: Upload ${{ matrix.dist }} package(daily build)
         run: |
           echo "================${{ matrix.dist }} downlod link==============="
+          echo $(sh $GITHUB_WORKSPACE/scripts/upload_services/${UPLOAD_SERVICE}.sh $GITHUB_WORKSPACE/build/${PRODUCT}_${VERSION}-${RELEASE}_amd64.deb)
+          echo "=====no operation for you can see link in the log console====="
+
+  deb-pack-extra:
+    name: ubuntu-18.04(extra job to packaging deb)
+    runs-on: ubuntu-20.04
+    container:
+      image: vitzy/flameshot:ubuntu-bionic
+    steps:
+      - name: Checkout Source code
+        uses: actions/checkout@v2
+      - name: Install dependencies
+        run: |
+          apt-get -y -qq update
+          apt-get -y --no-install-recommends install \
+            qt5-default \
+            qttools5-dev-tools \
+            qttools5-dev \
+            libqt5dbus5 \
+            libqt5network5 \
+            libqt5core5a \
+            libqt5widgets5 \
+            libqt5gui5 \
+            libqt5svg5-dev \
+            python3 \
+            python3-pip
+      - name: Prepare cmake(>=3.13.0)
+        run: |
+          apt-get -y autoremove cmake
+          wget https://github.com/Kitware/CMake/releases/download/v3.18.3/cmake-3.18.3-Linux-x86_64.tar.gz
+          tar -xvf cmake-3.18.3-Linux-x86_64.tar.gz
+          cd ./cmake-3.18.3-Linux-x86_64
+          cp -r bin /usr/
+          cp -r share /usr/
+          cp -r doc /usr/share/
+          cp -r man /usr/share/
+          cd ..
+          rm -rf cmake-3.18.3-Linux-x86_64 cmake-3.18.3-Linux-x86_64.tar.gz
+      - name: Packaging on ubuntu-18.04
+        run: |
+          cp -r $GITHUB_WORKSPACE/data/debian $GITHUB_WORKSPACE
+          mkdir -p $GITHUB_WORKSPACE/build
+          sed -e "/cmake (>= 3.13~),/d" -i $GITHUB_WORKSPACE/debian/control
+          dpkg-buildpackage -b
+          cp $GITHUB_WORKSPACE/../${PRODUCT}_${VERSION}-${RELEASE}_amd64.deb $GITHUB_WORKSPACE/build/${PRODUCT}_${VERSION}-${RELEASE}_amd64.deb
+      - name: SHA256Sum of ubuntu-18.04 package(daily build)
+        run: |
+          sha256sum $GITHUB_WORKSPACE/build/${PRODUCT}_${VERSION}-${RELEASE}_amd64.deb
+      - name: Upload ubuntu-18.04 package(daily build)
+        run: |
+          echo "===================ubuntu-18.04 downlod link=================="
           echo $(sh $GITHUB_WORKSPACE/scripts/upload_services/${UPLOAD_SERVICE}.sh $GITHUB_WORKSPACE/build/${PRODUCT}_${VERSION}-${RELEASE}_amd64.deb)
           echo "=====no operation for you can see link in the log console====="
 


### PR DESCRIPTION
Fix https://github.com/flameshot-org/flameshot/issues/949

First of all I wouldn't type a separate docker images for a particular environment (which contains a specific cmake version) it's not a flexible and elegant approach. 
Secondly, I'll just use the `vitzy/flameshot:ubuntu-bionic` image here, first removing the default cmake, and then downloading the latest binary from https://cmake.org/download/ to install it. I don't have a good way to add it to the existing matrix jobs(`deb-pack`). I had to create another job, which had the disadvantage of wasting a job count.

![image](https://user-images.githubusercontent.com/10769951/94042617-679bb680-fdfe-11ea-99d7-9b4a1f98a8ec.png)
