### PR TITLE
Explicitly hide tray icon before exit on Windows

### DIFF
--- a/src/core/controller.cpp
+++ b/src/core/controller.cpp
@@ -234,6 +234,13 @@ void Controller::enableTrayIcon()
         }
     };
     connect(m_trayIcon, &QSystemTrayIcon::activated, this, trayIconActivated);
+
+#ifdef Q_OS_WIN
+    // Ensure proper removal of tray icon when program quits on Windows.
+    connect(
+      qApp, &QCoreApplication::aboutToQuit, m_trayIcon, &QSystemTrayIcon::hide);
+#endif
+
     m_trayIcon->show();
 }
 


### PR DESCRIPTION
Currently flameshot tray icon will not disappear after program terminates on Windows. This is a known issue of Windows platform and need to be explicitly handled.

This commit connects the aboutToQuit signal to QSystemTrayIcon::hide slot to ensure that the tray icon is removed before program terminates.