### PR TITLE
Moved style override to after app creation

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -40,7 +40,6 @@
 
 int main(int argc, char* argv[])
 {
-    QApplication::setStyle(new StyleOverride);
     // required for the button serialization
     // TODO: change to QVector in v1.0
     qRegisterMetaTypeStreamOperators<QList<int>>("QList<int>");
@@ -49,6 +48,7 @@ int main(int argc, char* argv[])
     // no arguments, just launch Flameshot
     if (argc == 1) {
         SingleApplication app(argc, argv);
+        QApplication::setStyle(new StyleOverride);
 
         QTranslator translator, qtTranslator;
         QStringList trPaths = PathInfo::translationsPaths();


### PR DESCRIPTION
This fixes the issue where flameshot does not inherit the system theme. 

From: https://doc.qt.io/qt-5/qapplication.html#setStyle
```
Setting the style before a palette has been set, i.e., before creating QApplication, will cause the application to use QStyle::standardPalette() for the palette.
```