### PR TITLE
Improve pixelation of thin selections

### DIFF
--- a/src/tools/pixelate/pixelatetool.cpp
+++ b/src/tools/pixelate/pixelatetool.cpp
@@ -89,7 +89,7 @@ void PixelateTool::process(QPainter& painter,
         int width = selection.width() * (0.5 / qMax(1, m_thickness));
 
         QPixmap t = pixmap.copy(selection);
-        t = t.scaledToWidth(qMax(width, 10), Qt::SmoothTransformation);
+        t = t.scaledToWidth(qMax(width, 1), Qt::SmoothTransformation);
         t = t.scaledToWidth(selection.width());
         painter.drawImage(selection, t.toImage());
     }


### PR DESCRIPTION
Assuming I'm correctly understanding the code: Previously the level of pixelation would decrease if the selected area was too thin to hold 10 pixelated blocks. Now the level of pixelation only decreases when the selected area is too thin to hold even one pixelated block. This makes it easier to hide information in relatively thin selections.

This doesn't really solve the issue of pixelation decreasing when the area is thin, see these screenshots (taken with thickness=80) and note that the horizontal one has very large blocks still, but the vertical one has significantly smaller blocks than it should:

![image](https://user-images.githubusercontent.com/9433472/95642281-77262b00-0a9f-11eb-986e-dac70b740de6.png)

![image](https://user-images.githubusercontent.com/9433472/95642284-79888500-0a9f-11eb-93c5-9668ea8bace1.png)

It does significantly improve the situation, though.