### PR TITLE
Fix pixelation of small areas

### DIFF
--- a/src/tools/pixelate/pixelatetool.cpp
+++ b/src/tools/pixelate/pixelatetool.cpp
@@ -87,10 +87,12 @@ void PixelateTool::process(QPainter& painter,
         scene.render(&painter, selection, QRectF());
     } else {
         int width = selection.width() * (0.5 / qMax(1, m_thickness));
+        int height = selection.height() * (0.5 / qMax(1, m_thickness));
+        QSize size = QSize(qMax(width, 1), qMax(height, 1));
 
         QPixmap t = pixmap.copy(selection);
-        t = t.scaledToWidth(qMax(width, 1), Qt::SmoothTransformation);
-        t = t.scaledToWidth(selection.width());
+        t = t.scaled(size, Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
+        t = t.scaled(selection.width(), selection.height());
         painter.drawImage(selection, t.toImage());
     }
 }


### PR DESCRIPTION
The fundamental problem here was that the pixmap can only be downscaled to an integer number of pixels in either dimension, so if (say) the selected area was 4px wide, you couldn't produce blocks any larger than 4px×4px by scaling the width alone. By scaling both the width and height separately, we make sure to always lose as much resolution as the user asked for.

Pixelation of thin areas now results in correctly-sized blocks, regardless of whether the area is thin horizontally or vertically (image using thickness 36):

![image](https://user-images.githubusercontent.com/9433472/95656218-aae76c00-0b04-11eb-96f5-06aba216641e.png)

(sidenote: the size of the blocks produced is actually twice the thickness in pixels, not just the thickness – changing the `0.5` to `1.0` fixes this, but at the risk of reducing the level of security for existing users, and it seems pointless to support pixelating with 2px or 3px blocks anyway)

Fixes #1039.