### PR TITLE
chore(CI): using environment files to manage environment

### DIFF
--- a/.github/workflows/Linux-pack.yml
+++ b/.github/workflows/Linux-pack.yml
@@ -23,7 +23,7 @@ env:
   # docker images, see https://hub.docker.com/r/vitzy/flameshot
   # vitzy/flameshot or packpack/packpack
   DOCKER_REPO: vitzy/flameshot
-  # upload services: 0x0.st, file.io, transfer.sh, wetransfer.com
+  # upload services: wetransfer.com, file.io, 0x0.st
   UPLOAD_SERVICE: wetransfer.com
 
 jobs:
@@ -67,7 +67,7 @@ jobs:
           echo ${last_committed_tag:1}
           echo "Details: ${last_committed_tag}+git${git_revno}.${git_hash}"
           echo "================================"
-          echo ::set-env name=VERSION::$(echo ${last_committed_tag:1})
+          echo "VERSION=${last_committed_tag:1}" >> $GITHUB_ENV
       - name: Get packpack tool
         uses: actions/checkout@v2
         with:
@@ -132,7 +132,7 @@ jobs:
           echo ${last_committed_tag:1}
           echo "Details: ${last_committed_tag}+git${git_revno}.${git_hash}"
           echo "================================"
-          echo ::set-env name=VERSION::$(echo ${last_committed_tag:1})
+          echo "VERSION=${last_committed_tag:1}" >> $GITHUB_ENV
       - name: Install dependencies
         run: |
           apt-get -y -qq update
@@ -234,7 +234,7 @@ jobs:
           echo ${last_committed_tag:1}
           echo "Details: ${last_committed_tag}+git${git_revno}.${git_hash}"
           echo "================================"
-          echo ::set-env name=VERSION::$(echo ${last_committed_tag:1})
+          echo "VERSION=${last_committed_tag:1}" >> $GITHUB_ENV
       - name: Get packpack tool
         uses: actions/checkout@v2
         with:
@@ -327,7 +327,7 @@ jobs:
           echo ${last_committed_tag:1}
           echo "Details: ${last_committed_tag}+git${git_revno}.${git_hash}"
           echo "================================"
-          echo ::set-env name=VERSION::$(echo ${last_committed_tag:1})
+          echo "VERSION=${last_committed_tag:1}" >> $GITHUB_ENV
       - name: Install Dependencies
         run: |
           sudo apt-get -y -qq update
@@ -427,7 +427,7 @@ jobs:
           echo ${last_committed_tag:1}
           echo "Details: ${last_committed_tag}+git${git_revno}.${git_hash}"
           echo "================================"
-          echo ::set-env name=VERSION::$(echo ${last_committed_tag:1})
+          echo "VERSION=${last_committed_tag:1}" >> $GITHUB_ENV
       - name: Setup flatpak
         run: |
           sudo apt-get -y -qq update
@@ -493,8 +493,7 @@ jobs:
           echo ${last_committed_tag:1}
           echo "Details: ${last_committed_tag}+git${git_revno}.${git_hash}"
           echo "================================"
-          echo ::set-env name=VERSION::$(echo ${last_committed_tag:1})
-
+          echo "VERSION=${last_committed_tag:1}" >> $GITHUB_ENV
       - name: Packaging snap
         uses: snapcore/action-build@v1
         id: snapcraft

--- a/.github/workflows/Windows-pack.yml
+++ b/.github/workflows/Windows-pack.yml
@@ -75,7 +75,7 @@ jobs:
           echo ${last_committed_tag:1}
           echo "Details: ${last_committed_tag}+git${git_revno}.${git_hash}"
           echo "================================"
-          echo ::set-env name=VERSION::$(echo ${last_committed_tag:1})
+          echo "VERSION=${last_committed_tag:1}" >> $GITHUB_ENV
 
       - name: Cache Qt
         id: cache-qt

--- a/README.md
+++ b/README.md
@@ -30,8 +30,11 @@
     </a>
     <br>
     <a href="https://snapcraft.io/flameshot">
-  <img alt="Get it from the Snap Store" src="https://snapcraft.io/static/images/badges/en/snap-store-black.svg" />
-</a>
+      <img alt="Get it from the Snap Store" src="https://snapcraft.io/static/images/badges/en/snap-store-black.svg" />
+    </a>
+    <a href="https://flathub.org/apps/details/org.flameshot.Flameshot">
+      <img height="60" alt="Download on Flathub" src="https://flathub.org/assets/badges/flathub-badge-en.svg"/>
+    </a>
   </p>
 </div>
 


### PR DESCRIPTION
* using Environment Files, due to the `set-env` command is deprecated and will be disabled soon
* https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
* https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files
* add flathub store badge

Closes https://github.com/flameshot-org/flameshot/issues/1069