### PR TITLE
Adding selectAll keyboard shortcut

### DIFF
--- a/src/utils/configshortcuts.cpp
+++ b/src/utils/configshortcuts.cpp
@@ -39,6 +39,10 @@ const QVector<QStringList>& ConfigShortcuts::captureShortcutsDefault(
                     << QObject::tr("Resize selection down 1px")
                     << QKeySequence(Qt::SHIFT + Qt::Key_Down).toString());
 
+    m_shortcuts << (QStringList()
+                    << "TYPE_SELECT_ALL" << QObject::tr("Select entire screen")
+                    << QKeySequence(Qt::CTRL + Qt::Key_A).toString());
+
     m_shortcuts << (QStringList() << "TYPE_MOVE_LEFT"
                                   << QObject::tr("Move selection left 1px")
                                   << QKeySequence(Qt::Key_Left).toString());

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -941,6 +941,19 @@ void CaptureWidget::downResize()
     }
 }
 
+void CaptureWidget::selectAll()
+{
+    QRect newGeometry = rect();
+    m_selection->setGeometry(newGeometry);
+    m_context.selection = extendedRect(&newGeometry);
+    m_selection->setVisible(true);
+    m_showInitialMsg = false;
+    m_buttonHandler->updatePosition(m_selection->geometry());
+    updateSizeIndicator();
+    m_buttonHandler->show();
+    update();
+}
+
 void CaptureWidget::initShortcuts()
 {
     QString shortcut = ConfigHandler().shortcut(
@@ -996,6 +1009,10 @@ void CaptureWidget::initShortcuts()
     new QShortcut(QKeySequence(ConfigHandler().shortcut("TYPE_MOVE_DOWN")),
                   this,
                   SLOT(downMove()));
+
+    new QShortcut(QKeySequence(ConfigHandler().shortcut("TYPE_SELECT_ALL")),
+                  this,
+                  SLOT(selectAll()));
 
     new QShortcut(Qt::Key_Escape, this, SLOT(deleteToolwidgetOrClose()));
 }

--- a/src/widgets/capture/capturewidget.h
+++ b/src/widgets/capture/capturewidget.h
@@ -84,6 +84,8 @@ private slots:
     void upResize();
     void downResize();
 
+    void selectAll();
+
     void leftMove();
     void rightMove();
     void upMove();


### PR DESCRIPTION
Closes #1099 by allowing a keyboard shortcut (default `<Ctrl>A`) to select the entire select-able screen. The logic for this mimics the constraints / assumptions in the `moveDirection` and `resizeDirection` methods in `captureWidget.cpp`