### PR TITLE
Hide the full utility panel instead of internal

### DIFF
--- a/src/widgets/panel/utilitypanel.cpp
+++ b/src/widgets/panel/utilitypanel.cpp
@@ -42,6 +42,8 @@ UtilityPanel::UtilityPanel(QWidget* parent)
             &QPropertyAnimation::finished,
             m_internalPanel,
             &QWidget::hide);
+
+    hide();
 }
 
 QWidget* UtilityPanel::toolWidget() const
@@ -127,7 +129,6 @@ void UtilityPanel::initInternalPanel()
     bgColor.setAlphaF(0.0);
     m_internalPanel->setStyleSheet(
       QStringLiteral("QScrollArea {background-color: %1}").arg(bgColor.name()));
-    m_internalPanel->hide();
 
     m_hide = new QPushButton();
     m_hide->setText(tr("Hide"));


### PR DESCRIPTION
Previously only the internal panel was getting hidden, rather than the
surrounding/containing QWidget. This created a bug that the Esc would
need to be pressed more than once to exit the text tool or flameshot.

Fixes #1108