### PR TITLE
Add a configurable keyboard shortcut to commit text.

### DIFF
--- a/src/utils/configshortcuts.cpp
+++ b/src/utils/configshortcuts.cpp
@@ -51,6 +51,10 @@ const QVector<QStringList>& ConfigShortcuts::captureShortcutsDefault(
     m_shortcuts << (QStringList() << "TYPE_MOVE_DOWN"
                                   << QObject::tr("Move selection down 1px")
                                   << QKeySequence(Qt::Key_Down).toString());
+    m_shortcuts << (QStringList()
+                    << "TYPE_COMMIT_CURRENT_TOOL"
+                    << QObject::tr("Commit text in text area")
+                    << QKeySequence(Qt::CTRL + Qt::Key_Return).toString());
 
     m_shortcuts << (QStringList() << "" << QObject::tr("Quit capture")
                                   << QKeySequence(Qt::Key_Escape).toString());

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -235,6 +235,26 @@ QPixmap CaptureWidget::pixmap()
     return m_context.selectedScreenshotArea();
 }
 
+// Finish whatever the current tool is doing, if there is a current active
+// tool.
+bool CaptureWidget::commitCurrentTool()
+{
+    if (m_activeButton) {
+        if (m_activeTool) {
+            if (m_activeTool->isValid() && m_toolWidget) {
+                pushToolToStack();
+            } else {
+                m_activeTool->deleteLater();
+            }
+            if (m_toolWidget) {
+                m_toolWidget->deleteLater();
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
 void CaptureWidget::deleteToolwidgetOrClose()
 {
     if (m_panel->isVisible()) {
@@ -335,16 +355,8 @@ void CaptureWidget::mousePressEvent(QMouseEvent* e)
         m_mouseIsClicked = true;
         // Click using a tool
         if (m_activeButton) {
-            if (m_activeTool) {
-                if (m_activeTool->isValid() && m_toolWidget) {
-                    pushToolToStack();
-                } else {
-                    m_activeTool->deleteLater();
-                }
-                if (m_toolWidget) {
-                    m_toolWidget->deleteLater();
-                    return;
-                }
+            if (commitCurrentTool()) {
+                return;
             }
             m_activeTool = m_activeButton->tool()->copy(this);
 
@@ -996,6 +1008,11 @@ void CaptureWidget::initShortcuts()
     new QShortcut(QKeySequence(ConfigHandler().shortcut("TYPE_MOVE_DOWN")),
                   this,
                   SLOT(downMove()));
+
+    new QShortcut(
+      QKeySequence(ConfigHandler().shortcut("TYPE_COMMIT_CURRENT_TOOL")),
+      this,
+      SLOT(commitCurrentTool()));
 
     new QShortcut(Qt::Key_Escape, this, SLOT(deleteToolwidgetOrClose()));
 }

--- a/src/widgets/capture/capturewidget.h
+++ b/src/widgets/capture/capturewidget.h
@@ -60,6 +60,7 @@ public:
     QPixmap pixmap();
 
 public slots:
+    bool commitCurrentTool();
     void deleteToolwidgetOrClose();
 
 signals:


### PR DESCRIPTION
This new shortcut defaults to `ctrl+enter`, and it commits the text
you're currently typing. It does *not* change the behavior of enter
(pressing enter still inserts a newline), nor does it actually exit
flameshot. This isn't exactly what was requested, but I'm going to
somewhat cavalierly say that this fixes
https://github.com/flameshot-org/flameshot/issues/812.

*Note: I added a new user-visible string here, but I didn't update any
ts files. Is that ok?