### PR TITLE
capturewidget refactor

### DIFF
--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -539,7 +539,7 @@ void CaptureWidget::mouseReleaseEvent(QMouseEvent* e)
     updateCursor();
 }
 
-void CaptureWidget::leftMove()
+void CaptureWidget::moveLeft()
 {
     if (m_selection->geometry().left() > rect().left()) {
         m_selection->move(QPoint(m_selection->x() - 1, m_selection->y()));
@@ -548,7 +548,7 @@ void CaptureWidget::leftMove()
     }
 }
 
-void CaptureWidget::rightMove()
+void CaptureWidget::moveRight()
 {
     if (m_selection->geometry().right() < rect().right()) {
         m_selection->move(QPoint(m_selection->x() + 1, m_selection->y()));
@@ -559,7 +559,7 @@ void CaptureWidget::rightMove()
     }
 }
 
-void CaptureWidget::upMove()
+void CaptureWidget::moveUp()
 {
     if (m_selection->geometry().top() > rect().top()) {
         m_selection->move(QPoint(m_selection->x(), m_selection->y() - 1));
@@ -570,7 +570,7 @@ void CaptureWidget::upMove()
     }
 }
 
-void CaptureWidget::downMove()
+void CaptureWidget::moveDown()
 {
     if (m_selection->geometry().bottom() < rect().bottom()) {
         m_selection->move(QPoint(m_selection->x(), m_selection->y() + 1));
@@ -885,7 +885,7 @@ void CaptureWidget::setDrawThickness(const int& t)
     emit thicknessChanged(m_context.thickness);
 }
 
-void CaptureWidget::leftResize()
+void CaptureWidget::resizeLeft()
 {
     if (m_selection->isVisible() &&
         m_selection->geometry().right() > m_selection->geometry().left()) {
@@ -899,7 +899,7 @@ void CaptureWidget::leftResize()
     }
 }
 
-void CaptureWidget::rightResize()
+void CaptureWidget::resizeRight()
 {
     if (m_selection->isVisible() &&
         m_selection->geometry().right() < rect().right()) {
@@ -913,7 +913,7 @@ void CaptureWidget::rightResize()
     }
 }
 
-void CaptureWidget::upResize()
+void CaptureWidget::resizeUp()
 {
     if (m_selection->isVisible() &&
         m_selection->geometry().bottom() > m_selection->geometry().top()) {
@@ -927,7 +927,7 @@ void CaptureWidget::upResize()
     }
 }
 
-void CaptureWidget::downResize()
+void CaptureWidget::resizeDown()
 {
     if (m_selection->isVisible() &&
         m_selection->geometry().bottom() < rect().bottom()) {
@@ -973,29 +973,29 @@ void CaptureWidget::initShortcuts()
 
     new QShortcut(QKeySequence(ConfigHandler().shortcut("TYPE_RESIZE_LEFT")),
                   this,
-                  SLOT(leftResize()));
+                  SLOT(resizeLeft()));
     new QShortcut(QKeySequence(ConfigHandler().shortcut("TYPE_RESIZE_RIGHT")),
                   this,
-                  SLOT(rightResize()));
+                  SLOT(resizeRight()));
     new QShortcut(QKeySequence(ConfigHandler().shortcut("TYPE_RESIZE_UP")),
                   this,
-                  SLOT(upResize()));
+                  SLOT(resizeUp()));
     new QShortcut(QKeySequence(ConfigHandler().shortcut("TYPE_RESIZE_DOWN")),
                   this,
-                  SLOT(downResize()));
+                  SLOT(resizeDown()));
 
     new QShortcut(QKeySequence(ConfigHandler().shortcut("TYPE_MOVE_LEFT")),
                   this,
-                  SLOT(leftMove()));
+                  SLOT(moveLeft()));
     new QShortcut(QKeySequence(ConfigHandler().shortcut("TYPE_MOVE_RIGHT")),
                   this,
-                  SLOT(rightMove()));
+                  SLOT(moveRight()));
     new QShortcut(QKeySequence(ConfigHandler().shortcut("TYPE_MOVE_UP")),
                   this,
-                  SLOT(upMove()));
+                  SLOT(moveUp()));
     new QShortcut(QKeySequence(ConfigHandler().shortcut("TYPE_MOVE_DOWN")),
                   this,
-                  SLOT(downMove()));
+                  SLOT(moveDown()));
 
     new QShortcut(Qt::Key_Escape, this, SLOT(deleteToolwidgetOrClose()));
 }

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -546,30 +546,22 @@ void CaptureWidget::moveSelection(QPoint p)
 
 void CaptureWidget::moveLeft()
 {
-    if (m_selection->geometry().left() > rect().left()) {
-        moveSelection(QPoint(-1, 0));
-    }
+    moveSelection(QPoint(-1, 0));
 }
 
 void CaptureWidget::moveRight()
 {
-    if (m_selection->geometry().right() < rect().right()) {
-        moveSelection(QPoint(1, 0));
-    }
+    moveSelection(QPoint(1, 0));
 }
 
 void CaptureWidget::moveUp()
 {
-    if (m_selection->geometry().top() > rect().top()) {
-        moveSelection(QPoint(0, -1));
-    }
+    moveSelection(QPoint(0, -1));
 }
 
 void CaptureWidget::moveDown()
 {
-    if (m_selection->geometry().bottom() < rect().bottom()) {
-        moveSelection(QPoint(0, 1));
-    }
+    moveSelection(QPoint(0, 1));
 }
 
 void CaptureWidget::keyPressEvent(QKeyEvent* e)
@@ -891,37 +883,29 @@ void CaptureWidget::repositionSelection(QRect r)
 void CaptureWidget::adjustSelection(QMargins m)
 {
     QRect newGeometry = m_selection->geometry() + m;
-    // if (rect().contains(newGeometry)) {
+    if (rect().contains(newGeometry)) {
         repositionSelection(newGeometry);
-    // }
+    }
 }
 
 void CaptureWidget::resizeLeft()
 {
-    if (m_selection->geometry().right() > m_selection->geometry().left()) {
-        adjustSelection(QMargins(0, 0, -1, 0));
-    }
+    adjustSelection(QMargins(0, 0, -1, 0));
 }
 
 void CaptureWidget::resizeRight()
 {
-    if (m_selection->geometry().right() < rect().right()) {
-        adjustSelection(QMargins(0, 0, 1, 0));
-    }
+    adjustSelection(QMargins(0, 0, 1, 0));
 }
 
 void CaptureWidget::resizeUp()
 {
-    if (m_selection->geometry().bottom() > m_selection->geometry().top()) {
-        adjustSelection(QMargins(0, 0, 0, -1));
-    }
+    adjustSelection(QMargins(0, 0, 0, -1));
 }
 
 void CaptureWidget::resizeDown()
 {
-    if (m_selection->geometry().bottom() < rect().bottom()) {
-        adjustSelection(QMargins(0, 0, 0, 1));
-    }
+    adjustSelection(QMargins(0, 0, 0, 1));
 }
 
 void CaptureWidget::initShortcuts()

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -541,11 +541,7 @@ void CaptureWidget::mouseReleaseEvent(QMouseEvent* e)
 
 void CaptureWidget::moveSelection(QPoint p)
 {
-    m_selection->move(QPoint(m_selection->x(), m_selection->y()) + p);
-    QRect newGeometry = m_selection->geometry().intersected(rect());
-    m_context.selection = extendedRect(&newGeometry);
-    m_buttonHandler->updatePosition(m_selection->geometry());
-    update();
+    adjustSelection(QMargins(-p.x(), -p.y(), p.x(), p.y()));
 }
 
 void CaptureWidget::moveLeft()
@@ -880,10 +876,10 @@ void CaptureWidget::setDrawThickness(const int& t)
     emit thicknessChanged(m_context.thickness);
 }
 
-void CaptureWidget::resizeSelection(QMargins m)
+void CaptureWidget::repositionSelection(QRect r)
 {
     if (m_selection->isVisible()) {
-        m_selection->setGeometry(m_selection->geometry() + m);
+        m_selection->setGeometry(r);
         QRect newGeometry = m_selection->geometry().intersected(rect());
         m_context.selection = extendedRect(&newGeometry);
         m_buttonHandler->updatePosition(m_selection->geometry());
@@ -892,31 +888,39 @@ void CaptureWidget::resizeSelection(QMargins m)
     }
 }
 
+void CaptureWidget::adjustSelection(QMargins m)
+{
+    QRect newGeometry = m_selection->geometry() + m;
+    // if (rect().contains(newGeometry)) {
+        repositionSelection(newGeometry);
+    // }
+}
+
 void CaptureWidget::resizeLeft()
 {
     if (m_selection->geometry().right() > m_selection->geometry().left()) {
-        resizeSelection(QMargins(0, 0, -1, 0));
+        adjustSelection(QMargins(0, 0, -1, 0));
     }
 }
 
 void CaptureWidget::resizeRight()
 {
     if (m_selection->geometry().right() < rect().right()) {
-        resizeSelection(QMargins(0, 0, 1, 0));
+        adjustSelection(QMargins(0, 0, 1, 0));
     }
 }
 
 void CaptureWidget::resizeUp()
 {
     if (m_selection->geometry().bottom() > m_selection->geometry().top()) {
-        resizeSelection(QMargins(0, 0, 0, -1));
+        adjustSelection(QMargins(0, 0, 0, -1));
     }
 }
 
 void CaptureWidget::resizeDown()
 {
     if (m_selection->geometry().bottom() < rect().bottom()) {
-        resizeSelection(QMargins(0, 0, 0, 1));
+        adjustSelection(QMargins(0, 0, 0, 1));
     }
 }
 

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -539,45 +539,40 @@ void CaptureWidget::mouseReleaseEvent(QMouseEvent* e)
     updateCursor();
 }
 
+void CaptureWidget::moveSelection(QPoint p)
+{
+    m_selection->move(QPoint(m_selection->x(), m_selection->y()) + p);
+    QRect newGeometry = m_selection->geometry().intersected(rect());
+    m_context.selection = extendedRect(&newGeometry);
+    m_buttonHandler->updatePosition(m_selection->geometry());
+    update();
+}
+
 void CaptureWidget::moveLeft()
 {
     if (m_selection->geometry().left() > rect().left()) {
-        m_selection->move(QPoint(m_selection->x() - 1, m_selection->y()));
-        m_buttonHandler->updatePosition(m_selection->geometry());
-        update();
+        moveSelection(QPoint(-1, 0));
     }
 }
 
 void CaptureWidget::moveRight()
 {
     if (m_selection->geometry().right() < rect().right()) {
-        m_selection->move(QPoint(m_selection->x() + 1, m_selection->y()));
-        QRect newGeometry = m_selection->geometry().intersected(rect());
-        m_context.selection = extendedRect(&newGeometry);
-        m_buttonHandler->updatePosition(m_selection->geometry());
-        update();
+        moveSelection(QPoint(1, 0));
     }
 }
 
 void CaptureWidget::moveUp()
 {
     if (m_selection->geometry().top() > rect().top()) {
-        m_selection->move(QPoint(m_selection->x(), m_selection->y() - 1));
-        QRect newGeometry = m_selection->geometry().intersected(rect());
-        m_context.selection = extendedRect(&newGeometry);
-        m_buttonHandler->updatePosition(m_selection->geometry());
-        update();
+        moveSelection(QPoint(0, -1));
     }
 }
 
 void CaptureWidget::moveDown()
 {
     if (m_selection->geometry().bottom() < rect().bottom()) {
-        m_selection->move(QPoint(m_selection->x(), m_selection->y() + 1));
-        QRect newGeometry = m_selection->geometry().intersected(rect());
-        m_context.selection = extendedRect(&newGeometry);
-        m_buttonHandler->updatePosition(m_selection->geometry());
-        update();
+        moveSelection(QPoint(0, 1));
     }
 }
 
@@ -885,59 +880,43 @@ void CaptureWidget::setDrawThickness(const int& t)
     emit thicknessChanged(m_context.thickness);
 }
 
-void CaptureWidget::resizeLeft()
+void CaptureWidget::resizeSelection(QMargins m)
 {
-    if (m_selection->isVisible() &&
-        m_selection->geometry().right() > m_selection->geometry().left()) {
-        m_selection->setGeometry(m_selection->geometry() +
-                                 QMargins(0, 0, -1, 0));
+    if (m_selection->isVisible()) {
+        m_selection->setGeometry(m_selection->geometry() + m);
         QRect newGeometry = m_selection->geometry().intersected(rect());
         m_context.selection = extendedRect(&newGeometry);
         m_buttonHandler->updatePosition(m_selection->geometry());
         updateSizeIndicator();
         update();
+    }
+}
+
+void CaptureWidget::resizeLeft()
+{
+    if (m_selection->geometry().right() > m_selection->geometry().left()) {
+        resizeSelection(QMargins(0, 0, -1, 0));
     }
 }
 
 void CaptureWidget::resizeRight()
 {
-    if (m_selection->isVisible() &&
-        m_selection->geometry().right() < rect().right()) {
-        m_selection->setGeometry(m_selection->geometry() +
-                                 QMargins(0, 0, 1, 0));
-        QRect newGeometry = m_selection->geometry().intersected(rect());
-        m_context.selection = extendedRect(&newGeometry);
-        m_buttonHandler->updatePosition(m_selection->geometry());
-        updateSizeIndicator();
-        update();
+    if (m_selection->geometry().right() < rect().right()) {
+        resizeSelection(QMargins(0, 0, 1, 0));
     }
 }
 
 void CaptureWidget::resizeUp()
 {
-    if (m_selection->isVisible() &&
-        m_selection->geometry().bottom() > m_selection->geometry().top()) {
-        m_selection->setGeometry(m_selection->geometry() +
-                                 QMargins(0, 0, 0, -1));
-        QRect newGeometry = m_selection->geometry().intersected(rect());
-        m_context.selection = extendedRect(&newGeometry);
-        m_buttonHandler->updatePosition(m_selection->geometry());
-        updateSizeIndicator();
-        update();
+    if (m_selection->geometry().bottom() > m_selection->geometry().top()) {
+        resizeSelection(QMargins(0, 0, 0, -1));
     }
 }
 
 void CaptureWidget::resizeDown()
 {
-    if (m_selection->isVisible() &&
-        m_selection->geometry().bottom() < rect().bottom()) {
-        m_selection->setGeometry(m_selection->geometry() +
-                                 QMargins(0, 0, 0, 1));
-        QRect newGeometry = m_selection->geometry().intersected(rect());
-        m_context.selection = extendedRect(&newGeometry);
-        m_buttonHandler->updatePosition(m_selection->geometry());
-        updateSizeIndicator();
-        update();
+    if (m_selection->geometry().bottom() < rect().bottom()) {
+        resizeSelection(QMargins(0, 0, 0, 1));
     }
 }
 

--- a/src/widgets/capture/capturewidget.h
+++ b/src/widgets/capture/capturewidget.h
@@ -79,13 +79,11 @@ private slots:
     void childEnter();
     void childLeave();
 
-    void resizeSelection(QMargins m);
     void resizeLeft();
     void resizeRight();
     void resizeUp();
     void resizeDown();
 
-    void moveSelection(QPoint p);
     void moveLeft();
     void moveRight();
     void moveUp();
@@ -140,6 +138,10 @@ private:
     void updateCursor();
     void pushToolToStack();
     void makeChild(QWidget* w);
+
+    void repositionSelection(QRect r);
+    void adjustSelection(QMargins m);
+    void moveSelection(QPoint p);
 
 private:
     QRect extendedSelection() const;

--- a/src/widgets/capture/capturewidget.h
+++ b/src/widgets/capture/capturewidget.h
@@ -79,15 +79,15 @@ private slots:
     void childEnter();
     void childLeave();
 
-    void leftResize();
-    void rightResize();
-    void upResize();
-    void downResize();
+    void resizeLeft();
+    void resizeRight();
+    void resizeUp();
+    void resizeDown();
 
-    void leftMove();
-    void rightMove();
-    void upMove();
-    void downMove();
+    void moveLeft();
+    void moveRight();
+    void moveUp();
+    void moveDown();
 
     void setState(CaptureToolButton* b);
     void processTool(CaptureTool* t);

--- a/src/widgets/capture/capturewidget.h
+++ b/src/widgets/capture/capturewidget.h
@@ -79,11 +79,13 @@ private slots:
     void childEnter();
     void childLeave();
 
+    void resizeSelection(QMargins m);
     void resizeLeft();
     void resizeRight();
     void resizeUp();
     void resizeDown();
 
+    void moveSelection(QPoint p);
     void moveLeft();
     void moveRight();
     void moveUp();


### PR DESCRIPTION
Removing a lot of redundant code and abstracting some checks away into helper functions. Also uses some native Qt methods to do checks instead of doing it manually. Useful for #1106 so I can stop borrowing code from different places.

Move and resize functions are now renamed to go together in an alphabetical file outline.