### PR TITLE
Symmetric new selection

### DIFF
--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -407,22 +407,23 @@ void CaptureWidget::mouseMoveEvent(QMouseEvent* e)
         QRect inputRect;
         if (m_newSelection) {
             // Drawing a new selection
-            inputRect = symmetryMod 
-                ? QRect(m_dragStartPoint*2 - m_context.mousePos, m_context.mousePos)
-                : QRect(m_dragStartPoint, m_context.mousePos);
+            inputRect = symmetryMod
+                          ? QRect(m_dragStartPoint * 2 - m_context.mousePos,
+                                  m_context.mousePos)
+                          : QRect(m_dragStartPoint, m_context.mousePos);
 
         } else if (m_mouseOverHandle == SelectionWidget::NO_SIDE) {
             // Moving the whole selection
             QRect initialRect = m_selection->savedGeometry().normalized();
             QPoint newTopLeft =
-                initialRect.topLeft() + (e->pos() - m_dragStartPoint);
+              initialRect.topLeft() + (e->pos() - m_dragStartPoint);
             inputRect = QRect(newTopLeft, initialRect.size());
 
         } else {
             // Dragging a handle
             inputRect = m_selection->savedGeometry();
             QPoint offset = e->pos() - m_dragStartPoint;
-            
+
             using sw = SelectionWidget;
             QRect& r = inputRect;
             if (m_mouseOverHandle == sw::TOPLEFT_SIDE ||
@@ -445,7 +446,7 @@ void CaptureWidget::mouseMoveEvent(QMouseEvent* e)
             }
             if (m_mouseOverHandle == sw::BOTTOMLEFT_SIDE ||
                 m_mouseOverHandle == sw::BOTTOM_SIDE ||
-                m_mouseOverHandle == sw::BOTTOMRIGHT_SIDE) { 
+                m_mouseOverHandle == sw::BOTTOMRIGHT_SIDE) {
                 // dragging one of the bottom handles
                 r.setBottom(r.bottom() + offset.y());
                 if (symmetryMod) {

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -400,33 +400,35 @@ void CaptureWidget::mouseMoveEvent(QMouseEvent* e)
 
     if (m_mouseIsClicked && !m_activeButton) {
         // Drawing, moving, or stretching a selection
+        m_selection->setVisible(true);
         if (m_buttonHandler->isVisible()) {
             m_buttonHandler->hide();
         }
         QRect inputRect;
-        m_selection->setVisible(true);
         if (m_newSelection) {
+            // Drawing a new selection
             inputRect = symmetryMod 
                 ? QRect(m_dragStartPoint*2 - m_context.mousePos, m_context.mousePos)
                 : QRect(m_dragStartPoint, m_context.mousePos);
-            m_selection->setGeometry(inputRect.normalized());
+
         } else if (m_mouseOverHandle == SelectionWidget::NO_SIDE) {
             // Moving the whole selection
             QRect initialRect = m_selection->savedGeometry().normalized();
             QPoint newTopLeft =
-              initialRect.topLeft() + (e->pos() - m_dragStartPoint);
-            QRect finalRect(newTopLeft, initialRect.size());
-            m_selection->setGeometry(finalRect.normalized().intersected(rect()));
+                initialRect.topLeft() + (e->pos() - m_dragStartPoint);
+            inputRect = QRect(newTopLeft, initialRect.size());
+
         } else {
             // Dragging a handle
-            QRect r = m_selection->savedGeometry();
+            inputRect = m_selection->savedGeometry();
             QPoint offset = e->pos() - m_dragStartPoint;
             
             using sw = SelectionWidget;
+            QRect& r = inputRect;
             if (m_mouseOverHandle == sw::TOPLEFT_SIDE ||
                 m_mouseOverHandle == sw::TOP_SIDE ||
-                m_mouseOverHandle ==
-                  sw::TOPRIGHT_SIDE) { // dragging one of the top handles
+                m_mouseOverHandle == sw::TOPRIGHT_SIDE) {
+                // dragging one of the top handles
                 r.setTop(r.top() + offset.y());
                 if (symmetryMod) {
                     r.setBottom(r.bottom() - offset.y());
@@ -434,8 +436,8 @@ void CaptureWidget::mouseMoveEvent(QMouseEvent* e)
             }
             if (m_mouseOverHandle == sw::TOPLEFT_SIDE ||
                 m_mouseOverHandle == sw::LEFT_SIDE ||
-                m_mouseOverHandle ==
-                  sw::BOTTONLEFT_SIDE) { // dragging one of the left handles
+                m_mouseOverHandle == sw::BOTTONLEFT_SIDE) {
+                // dragging one of the left handles
                 r.setLeft(r.left() + offset.x());
                 if (symmetryMod) {
                     r.setRight(r.right() - offset.x());
@@ -443,8 +445,8 @@ void CaptureWidget::mouseMoveEvent(QMouseEvent* e)
             }
             if (m_mouseOverHandle == sw::BOTTONLEFT_SIDE ||
                 m_mouseOverHandle == sw::BOTTON_SIDE ||
-                m_mouseOverHandle ==
-                  sw::BOTTONRIGHT_SIDE) { // dragging one of the bottom handles
+                m_mouseOverHandle == sw::BOTTONRIGHT_SIDE) { 
+                // dragging one of the bottom handles
                 r.setBottom(r.bottom() + offset.y());
                 if (symmetryMod) {
                     r.setTop(r.top() - offset.y());
@@ -452,15 +454,15 @@ void CaptureWidget::mouseMoveEvent(QMouseEvent* e)
             }
             if (m_mouseOverHandle == sw::TOPRIGHT_SIDE ||
                 m_mouseOverHandle == sw::RIGHT_SIDE ||
-                m_mouseOverHandle ==
-                  sw::BOTTONRIGHT_SIDE) { // dragging one of the right handles
+                m_mouseOverHandle == sw::BOTTONRIGHT_SIDE) {
+                // dragging one of the right handles
                 r.setRight(r.right() + offset.x());
                 if (symmetryMod) {
                     r.setLeft(r.left() - offset.x());
                 }
             }
-            m_selection->setGeometry(r.intersected(rect()).normalized());
         }
+        m_selection->setGeometry(inputRect.intersected(rect()).normalized());
         update();
     } else if (m_mouseIsClicked && m_activeTool) {
         // drawing with a tool

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -436,16 +436,16 @@ void CaptureWidget::mouseMoveEvent(QMouseEvent* e)
             }
             if (m_mouseOverHandle == sw::TOPLEFT_SIDE ||
                 m_mouseOverHandle == sw::LEFT_SIDE ||
-                m_mouseOverHandle == sw::BOTTONLEFT_SIDE) {
+                m_mouseOverHandle == sw::BOTTOMLEFT_SIDE) {
                 // dragging one of the left handles
                 r.setLeft(r.left() + offset.x());
                 if (symmetryMod) {
                     r.setRight(r.right() - offset.x());
                 }
             }
-            if (m_mouseOverHandle == sw::BOTTONLEFT_SIDE ||
-                m_mouseOverHandle == sw::BOTTON_SIDE ||
-                m_mouseOverHandle == sw::BOTTONRIGHT_SIDE) { 
+            if (m_mouseOverHandle == sw::BOTTOMLEFT_SIDE ||
+                m_mouseOverHandle == sw::BOTTOM_SIDE ||
+                m_mouseOverHandle == sw::BOTTOMRIGHT_SIDE) { 
                 // dragging one of the bottom handles
                 r.setBottom(r.bottom() + offset.y());
                 if (symmetryMod) {
@@ -454,7 +454,7 @@ void CaptureWidget::mouseMoveEvent(QMouseEvent* e)
             }
             if (m_mouseOverHandle == sw::TOPRIGHT_SIDE ||
                 m_mouseOverHandle == sw::RIGHT_SIDE ||
-                m_mouseOverHandle == sw::BOTTONRIGHT_SIDE) {
+                m_mouseOverHandle == sw::BOTTOMRIGHT_SIDE) {
                 // dragging one of the right handles
                 r.setRight(r.right() + offset.x());
                 if (symmetryMod) {
@@ -998,11 +998,11 @@ void CaptureWidget::updateCursor()
             // cursor on the handlers
             switch (m_mouseOverHandle) {
                 case sw::TOPLEFT_SIDE:
-                case sw::BOTTONRIGHT_SIDE:
+                case sw::BOTTOMRIGHT_SIDE:
                     setCursor(Qt::SizeFDiagCursor);
                     break;
                 case sw::TOPRIGHT_SIDE:
-                case sw::BOTTONLEFT_SIDE:
+                case sw::BOTTOMLEFT_SIDE:
                     setCursor(Qt::SizeBDiagCursor);
                     break;
                 case sw::LEFT_SIDE:
@@ -1010,7 +1010,7 @@ void CaptureWidget::updateCursor()
                     setCursor(Qt::SizeHorCursor);
                     break;
                 case sw::TOP_SIDE:
-                case sw::BOTTON_SIDE:
+                case sw::BOTTOM_SIDE:
                     setCursor(Qt::SizeVerCursor);
                     break;
                 default:

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -416,25 +416,12 @@ void CaptureWidget::mouseMoveEvent(QMouseEvent* e)
             QPoint newTopLeft =
               initialRect.topLeft() + (e->pos() - m_dragStartPoint);
             QRect finalRect(newTopLeft, initialRect.size());
-
-            if (finalRect.left() < rect().left()) {
-                finalRect.setLeft(rect().left());
-            } else if (finalRect.right() > rect().right()) {
-                finalRect.setRight(rect().right());
-            }
-            if (finalRect.top() < rect().top()) {
-                finalRect.setTop(rect().top());
-            } else if (finalRect.bottom() > rect().bottom()) {
-                finalRect.setBottom(rect().bottom());
-            }
-            m_selection->setGeometry(
-              finalRect.normalized().intersected(rect()));
+            m_selection->setGeometry(finalRect.normalized().intersected(rect()));
         } else {
             // Dragging a handle
             QRect r = m_selection->savedGeometry();
             QPoint offset = e->pos() - m_dragStartPoint;
             
-
             using sw = SelectionWidget;
             if (m_mouseOverHandle == sw::TOPLEFT_SIDE ||
                 m_mouseOverHandle == sw::TOP_SIDE ||

--- a/src/widgets/capture/selectionwidget.cpp
+++ b/src/widgets/capture/selectionwidget.cpp
@@ -53,9 +53,9 @@ SelectionWidget::SideType SelectionWidget::getMouseSide(
     } else if (m_TRArea.contains(point)) {
         return TOPRIGHT_SIDE;
     } else if (m_BLArea.contains(point)) {
-        return BOTTONLEFT_SIDE;
+        return BOTTOMLEFT_SIDE;
     } else if (m_BRArea.contains(point)) {
-        return BOTTONRIGHT_SIDE;
+        return BOTTOMRIGHT_SIDE;
     } else if (m_LArea.contains(point)) {
         return LEFT_SIDE;
     } else if (m_TArea.contains(point)) {
@@ -63,7 +63,7 @@ SelectionWidget::SideType SelectionWidget::getMouseSide(
     } else if (m_RArea.contains(point)) {
         return RIGHT_SIDE;
     } else if (m_BArea.contains(point)) {
-        return BOTTON_SIDE;
+        return BOTTOM_SIDE;
     } else {
         return NO_SIDE;
     }

--- a/src/widgets/capture/selectionwidget.h
+++ b/src/widgets/capture/selectionwidget.h
@@ -28,11 +28,11 @@ public:
     enum SideType
     {
         TOPLEFT_SIDE,
-        BOTTONLEFT_SIDE,
+        BOTTOMLEFT_SIDE,
         TOPRIGHT_SIDE,
-        BOTTONRIGHT_SIDE,
+        BOTTOMRIGHT_SIDE,
         TOP_SIDE,
-        BOTTON_SIDE,
+        BOTTOM_SIDE,
         RIGHT_SIDE,
         LEFT_SIDE,
         NO_SIDE,


### PR DESCRIPTION
Enables the symmetry modifier key (shift) to work not only when dragging on an existing selection handle, but also when creating a new selection (centered about the initial click).

Other changes:
- Refactor different mouse selection modes to only define the new selection area, not implement the entire interaction
- Fix a typo in SelectionWidget enum