### PR TITLE
Add Ubuntu keyboard shortcuts to the index and make heading size consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@
   - [Local](#local)
   - [Global](#global)
     - [On KDE Plasma desktop](#on-kde-plasma-desktop)
+    - [On Ubuntu](#on-ubuntu-tested-on-1804)
 - [Considerations](#considerations)
 - [Installation](#installation)
   - [Prebuilt Packages](#prebuilt-packages)
@@ -234,7 +235,7 @@ Steps for using the configuration:
 6. Now the Flameshot entry should appear in the list. Click _Apply_ to apply the changes.
 7. If you want to change the defaults, you can expand the entry, select the appropriate action and modify it as you wish; the process is pretty mush self-explanatory.
 
-### On Ubuntu (Tested on 18.04)
+#### On Ubuntu (Tested on 18.04)
 
 Taken from [adaptation](https://askubuntu.com/posts/1039949/revisions) of [Pavel Answer on askubuntu](https://askubuntu.com/revisions/1036473/1). To use flameshot instead of default screenshot application in ubuntu we need to release the binding on <kbd>Prt Sc</kbd> key, and then create a new binding for `/usr/bin/flameshot gui`.
 


### PR DESCRIPTION
Adds the Ubuntu keyboard shortcuts guide to the index (added in 95d8920becb36159ab1db328ebb92825a6cba1e2). Additionally, it makes the `On Ubuntu (Tested on 18.04)` heading size consistent with the `On KDE Plasma desktop` heading size.