### PR TITLE
Updated the bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -5,15 +5,21 @@ about: Create a report to help us improve
 ---
 
 <!--
-If you don't know how to get some of the following information from your computer, visit:
-https://flameshot.js.org/#/data/issue-reporting
+If you don't know how to get some of the following information from your
+computer, visit:
+https://flameshot.org/issue-reporting/
+
+**Note** that if you don't provide the requested information, the bugreport most
+probably will considered as invalid and will be closed unless you provide
+justification on why you cannot provide the requested information.
 -->
 
 **Flameshot version**
 <!-- Version or commit. -->
 
 **Describe the bug**
-<!-- A clear and concise description of what the bug is. Add screenshots if it helps explaining the issue. -->
+<!-- A clear and concise description of what the bug is. Add screenshots if it
+helps explaining the issue. -->
 
 **To Reproduce**
 <!-- Steps to reproduce the behaviour. -->


### PR DESCRIPTION
- Updated the URL of the issue reporting help page
- Enforced 80 character line length (to ensure all text will be visible to user without any horizontal scrolling)
- Added a statement that bug reports lacking sufficient information might not get processed