### PR TITLE
Emit dbus captureSaved signal when saving files

### DIFF
--- a/data/dbus/org.flameshot.Flameshot.xml
+++ b/data/dbus/org.flameshot.Flameshot.xml
@@ -115,5 +115,17 @@
       <arg name="id" type="u" direction="out"/>
     </signal>
 
+    <!--
+        captureSaved:
+        @id: identificator of the call.
+        @savePath: canonical path of the newly created image file.
+
+        An image was written to disk after capture.
+    -->
+    <signal name="captureSaved">
+      <arg name="id" type="u" direction="out"/>
+      <arg name="savePath" type="s" direction="out"/>
+    </signal>
+
   </interface>
 </node>

--- a/src/core/capturerequest.cpp
+++ b/src/core/capturerequest.cpp
@@ -85,9 +85,9 @@ void CaptureRequest::exportCapture(const QPixmap& p)
 {
     if ((m_tasks & ExportTask::FILESYSTEM_SAVE_TASK) != ExportTask::NO_TASK) {
         if (m_path.isEmpty()) {
-            ScreenshotSaver().saveToFilesystemGUI(p);
+            ScreenshotSaver(m_id).saveToFilesystemGUI(p);
         } else {
-            ScreenshotSaver().saveToFilesystem(p, m_path, "");
+            ScreenshotSaver(m_id).saveToFilesystem(p, m_path, "");
         }
     }
 

--- a/src/core/controller.cpp
+++ b/src/core/controller.cpp
@@ -312,6 +312,11 @@ void Controller::showRecentScreenshots()
     m_history->show();
 }
 
+void Controller::sendCaptureSaved(uint id, const QString& savePath)
+{
+    emit captureSaved(id, savePath);
+}
+
 void Controller::startFullscreenCapture(const uint id)
 {
     bool ok = true;

--- a/src/core/controller.h
+++ b/src/core/controller.h
@@ -50,6 +50,7 @@ public:
 signals:
     void captureTaken(uint id, QPixmap p, QRect selection);
     void captureFailed(uint id);
+    void captureSaved(uint id, QString savePath);
 
 public slots:
     void requestCapture(const CaptureRequest& request);
@@ -67,6 +68,8 @@ public slots:
     void updateConfigComponents();
 
     void showRecentScreenshots();
+
+    void sendCaptureSaved(uint id, const QString& savePath);
 
 private slots:
     void startFullscreenCapture(const uint id = 0);

--- a/src/core/flameshotdbusadapter.cpp
+++ b/src/core/flameshotdbusadapter.cpp
@@ -34,6 +34,10 @@ FlameshotDBusAdapter::FlameshotDBusAdapter(QObject* parent)
             &Controller::captureTaken,
             this,
             &FlameshotDBusAdapter::handleCaptureTaken);
+    connect(controller,
+            &Controller::captureSaved,
+            this,
+            &FlameshotDBusAdapter::captureSaved);
 }
 
 FlameshotDBusAdapter::~FlameshotDBusAdapter() {}

--- a/src/core/flameshotdbusadapter.h
+++ b/src/core/flameshotdbusadapter.h
@@ -32,6 +32,7 @@ public:
 signals:
     void captureTaken(uint id, QByteArray rawImage, QRect selection);
     void captureFailed(uint id);
+    void captureSaved(uint id, QString savePath);
 
 public slots:
     Q_NOREPLY void graphicCapture(QString path, int delay, uint id);

--- a/src/utils/screenshotsaver.cpp
+++ b/src/utils/screenshotsaver.cpp
@@ -16,6 +16,7 @@
 //     along with Flameshot.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "screenshotsaver.h"
+#include "src/core/controller.h"
 #include "src/utils/confighandler.h"
 #include "src/utils/filenamehandler.h"
 #include "src/utils/systemnotification.h"
@@ -25,7 +26,13 @@
 #include <QImageWriter>
 #include <QMessageBox>
 
-ScreenshotSaver::ScreenshotSaver() {}
+ScreenshotSaver::ScreenshotSaver()
+  : m_id(0)
+{}
+
+ScreenshotSaver::ScreenshotSaver(const unsigned id)
+  : m_id(id)
+{}
 
 // TODO: If data is saved to the clipboard before the notification is sent via
 // dbus, the application freezes.
@@ -63,6 +70,12 @@ bool ScreenshotSaver::saveToFilesystem(const QPixmap& capture,
         ConfigHandler().setSavePath(path);
         saveMessage =
           messagePrefix + QObject::tr("Capture saved as ") + completePath;
+        QString fileNoPath =
+          completePath.right(completePath.lastIndexOf(QLatin1String("/")));
+        Controller::getInstance()->sendCaptureSaved(
+          m_id,
+          QFileInfo(completePath).canonicalPath() + QLatin1String("/") +
+            fileNoPath);
     } else {
         saveMessage = messagePrefix + QObject::tr("Error trying to save as ") +
                       completePath;
@@ -103,6 +116,8 @@ bool ScreenshotSaver::saveToFilesystemGUI(const QPixmap& capture)
         if (ok) {
             QString pathNoFile =
               savePath.left(savePath.lastIndexOf(QLatin1String("/")));
+            QString fileNoPath =
+              savePath.right(savePath.lastIndexOf(QLatin1String("/")));
             ConfigHandler().setSavePath(pathNoFile);
             QString msg = QObject::tr("Capture saved as ") + savePath;
             if (config.copyPathAfterSaveEnabled()) {
@@ -112,6 +127,10 @@ bool ScreenshotSaver::saveToFilesystemGUI(const QPixmap& capture)
                       savePath;
             }
             SystemNotification().sendMessage(msg, savePath);
+            Controller::getInstance()->sendCaptureSaved(
+              m_id,
+              QFileInfo(savePath).canonicalPath() + QLatin1String("/") +
+                fileNoPath);
         } else {
             QString msg = QObject::tr("Error trying to save as ") + savePath;
             QMessageBox saveErrBox(

--- a/src/utils/screenshotsaver.cpp
+++ b/src/utils/screenshotsaver.cpp
@@ -70,12 +70,8 @@ bool ScreenshotSaver::saveToFilesystem(const QPixmap& capture,
         ConfigHandler().setSavePath(path);
         saveMessage =
           messagePrefix + QObject::tr("Capture saved as ") + completePath;
-        QString fileNoPath =
-          completePath.right(completePath.lastIndexOf(QLatin1String("/")));
         Controller::getInstance()->sendCaptureSaved(
-          m_id,
-          QFileInfo(completePath).canonicalPath() + QLatin1String("/") +
-            fileNoPath);
+          m_id, QFileInfo(completePath).canonicalFilePath());
     } else {
         saveMessage = messagePrefix + QObject::tr("Error trying to save as ") +
                       completePath;
@@ -116,8 +112,6 @@ bool ScreenshotSaver::saveToFilesystemGUI(const QPixmap& capture)
         if (ok) {
             QString pathNoFile =
               savePath.left(savePath.lastIndexOf(QLatin1String("/")));
-            QString fileNoPath =
-              savePath.right(savePath.lastIndexOf(QLatin1String("/")));
             ConfigHandler().setSavePath(pathNoFile);
             QString msg = QObject::tr("Capture saved as ") + savePath;
             if (config.copyPathAfterSaveEnabled()) {
@@ -128,9 +122,7 @@ bool ScreenshotSaver::saveToFilesystemGUI(const QPixmap& capture)
             }
             SystemNotification().sendMessage(msg, savePath);
             Controller::getInstance()->sendCaptureSaved(
-              m_id,
-              QFileInfo(savePath).canonicalPath() + QLatin1String("/") +
-                fileNoPath);
+              m_id, QFileInfo(savePath).canonicalFilePath());
         } else {
             QString msg = QObject::tr("Error trying to save as ") + savePath;
             QMessageBox saveErrBox(

--- a/src/utils/screenshotsaver.h
+++ b/src/utils/screenshotsaver.h
@@ -24,10 +24,14 @@ class ScreenshotSaver
 {
 public:
     ScreenshotSaver();
+    ScreenshotSaver(const unsigned id);
 
     void saveToClipboard(const QPixmap& capture);
     bool saveToFilesystem(const QPixmap& capture,
                           const QString& path,
                           const QString& messagePrefix);
     bool saveToFilesystemGUI(const QPixmap& capture);
+
+private:
+    unsigned m_id;
 };

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -1108,9 +1108,10 @@ void CaptureWidget::saveScreenshot()
     }
     hide();
     if (m_context.savePath.isEmpty()) {
-        ScreenshotSaver().saveToFilesystemGUI(pixmap());
+        ScreenshotSaver(m_id).saveToFilesystemGUI(pixmap());
     } else {
-        ScreenshotSaver().saveToFilesystem(pixmap(), m_context.savePath, "");
+        ScreenshotSaver(m_id).saveToFilesystem(
+          pixmap(), m_context.savePath, "");
     }
     close();
 }


### PR DESCRIPTION
New captureSaved signal contains the request ID and canonical path of the saved
file. This allows a dbus listener interested in postprocessing files access to
the path most recently written.