### PR TITLE
Show the Help Text, Tool Settings on the current active monitor

### DIFF
--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -322,9 +322,9 @@ void CaptureWidget::paintEvent(QPaintEvent*)
     painter.setClipRect(rect());
 
     if (m_showInitialMsg) {
-#if ((QT_VERSION >= QT_VERSION_CHECK(5, 10, 0) && defined(Q_OS_LINUX)) ||      \
-     defined(Q_OS_MAC) || defined(Q_OS_MAC64) || defined(Q_OS_MACOS) ||        \
-     defined(Q_OS_MACX))
+#if (defined(Q_OS_LINUX) && QT_VERSION < QT_VERSION_CHECK(5, 10, 0))
+        QRect helpRect = QGuiApplication::primaryScreen()->geometry();
+#else
         QRect helpRect;
         QScreen* currentScreen = QGuiApplication::screenAt(QCursor::pos());
         if (currentScreen) {
@@ -332,8 +332,6 @@ void CaptureWidget::paintEvent(QPaintEvent*)
         } else {
             helpRect = QGuiApplication::primaryScreen()->geometry();
         }
-#else
-        QRect helpRect = QGuiApplication::primaryScreen()->geometry();
 #endif
 
         helpRect.moveTo(mapFromGlobal(helpRect.topLeft()));
@@ -713,16 +711,19 @@ void CaptureWidget::initPanel()
 {
     QRect panelRect = rect();
     if (m_context.fullscreen) {
-#if ((QT_VERSION >= QT_VERSION_CHECK(5, 10, 0) && defined(Q_OS_LINUX)) ||      \
-     defined(Q_OS_MAC) || defined(Q_OS_MAC64) || defined(Q_OS_MACOS) ||        \
-     defined(Q_OS_MACX))
+#if (defined(Q_OS_LINUX) && QT_VERSION < QT_VERSION_CHECK(5, 10, 0))
+        panelRect = QGuiApplication::primaryScreen()->geometry();
+        auto devicePixelRatio =
+          QGuiApplication::primaryScreen()->devicePixelRatio();
+        panelRect.moveTo(panelRect.x() / devicePixelRatio,
+                         panelRect.y() / devicePixelRatio);
+#else
         QScreen* currentScreen = QGuiApplication::screenAt(QCursor::pos());
         if (currentScreen) {
             panelRect = currentScreen->geometry();
             auto devicePixelRatio = currentScreen->devicePixelRatio();
             panelRect.moveTo(panelRect.x() / devicePixelRatio,
                              panelRect.y() / devicePixelRatio);
-
         } else {
             panelRect = QGuiApplication::primaryScreen()->geometry();
             auto devicePixelRatio =
@@ -730,12 +731,6 @@ void CaptureWidget::initPanel()
             panelRect.moveTo(panelRect.x() / devicePixelRatio,
                              panelRect.y() / devicePixelRatio);
         }
-#else
-        panelRect = QGuiApplication::primaryScreen()->geometry();
-        auto devicePixelRatio =
-          QGuiApplication::primaryScreen()->devicePixelRatio();
-        panelRect.moveTo(panelRect.x() / devicePixelRatio,
-                         panelRect.y() / devicePixelRatio);
 #endif
     }
 
@@ -806,14 +801,20 @@ void CaptureWidget::showAppUpdateNotification(const QString& appLatestVersion,
         m_updateNotificationWidget =
           new UpdateNotificationWidget(this, appLatestVersion, appLatestUrl);
     }
-#if (defined(Q_OS_MAC) || defined(Q_OS_MAC64) || defined(Q_OS_MACOS) ||        \
-     defined(Q_OS_MACX))
-    int ax = (width() - m_updateNotificationWidget->width()) / 2;
-#else
+#if (defined(Q_OS_LINUX) && QT_VERSION < QT_VERSION_CHECK(5, 10, 0))
     QRect helpRect = QGuiApplication::primaryScreen()->geometry();
+#else
+    QRect helpRect;
+    QScreen* currentScreen = QGuiApplication::screenAt(QCursor::pos());
+    if (currentScreen) {
+        helpRect = currentScreen->geometry();
+    } else {
+        helpRect = QGuiApplication::primaryScreen()->geometry();
+    }
+#endif
     int ax = helpRect.left() +
              ((helpRect.width() - m_updateNotificationWidget->width()) / 2);
-#endif
+
     m_updateNotificationWidget->move(ax, 0);
     makeChild(m_updateNotificationWidget);
     m_updateNotificationWidget->show();

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -322,8 +322,9 @@ void CaptureWidget::paintEvent(QPaintEvent*)
     painter.setClipRect(rect());
 
     if (m_showInitialMsg) {
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0) && (defined(Q_OS_MAC) || defined(Q_OS_MAC64) || defined(Q_OS_MACOS) ||        \
-     defined(Q_OS_MACX) || defined(Q_OS_LINUX)))
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0) &&                               \
+     (defined(Q_OS_MAC) || defined(Q_OS_MAC64) || defined(Q_OS_MACOS) ||       \
+      defined(Q_OS_MACX) || defined(Q_OS_LINUX)))
         QRect helpRect;
         QScreen* currentScreen = QGuiApplication::screenAt(QCursor::pos());
         if (currentScreen) {
@@ -712,23 +713,29 @@ void CaptureWidget::initPanel()
 {
     QRect panelRect = rect();
     if (m_context.fullscreen) {
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0) && (defined(Q_OS_MAC) || defined(Q_OS_MAC64) || defined(Q_OS_MACOS) ||        \
-     defined(Q_OS_MACX) || defined(Q_OS_LINUX)))
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0) &&                               \
+     (defined(Q_OS_MAC) || defined(Q_OS_MAC64) || defined(Q_OS_MACOS) ||       \
+      defined(Q_OS_MACX) || defined(Q_OS_LINUX)))
         QScreen* currentScreen = QGuiApplication::screenAt(QCursor::pos());
         if (currentScreen) {
             panelRect = currentScreen->geometry();
             auto devicePixelRatio = currentScreen->devicePixelRatio();
-            panelRect.moveTo(panelRect.x() / devicePixelRatio, panelRect.y() / devicePixelRatio);
-            
+            panelRect.moveTo(panelRect.x() / devicePixelRatio,
+                             panelRect.y() / devicePixelRatio);
+
         } else {
             panelRect = QGuiApplication::primaryScreen()->geometry();
-            auto devicePixelRatio = QGuiApplication::primaryScreen()->devicePixelRatio();
-            panelRect.moveTo(panelRect.x() / devicePixelRatio, panelRect.y() / devicePixelRatio);
+            auto devicePixelRatio =
+              QGuiApplication::primaryScreen()->devicePixelRatio();
+            panelRect.moveTo(panelRect.x() / devicePixelRatio,
+                             panelRect.y() / devicePixelRatio);
         }
 #else
         panelRect = QGuiApplication::primaryScreen()->geometry();
-        auto devicePixelRatio = QGuiApplication::primaryScreen()->devicePixelRatio();
-        panelRect.moveTo(panelRect.x() / devicePixelRatio, panelRect.y() / devicePixelRatio);
+        auto devicePixelRatio =
+          QGuiApplication::primaryScreen()->devicePixelRatio();
+        panelRect.moveTo(panelRect.x() / devicePixelRatio,
+                         panelRect.y() / devicePixelRatio);
 #endif
     }
 

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -322,8 +322,8 @@ void CaptureWidget::paintEvent(QPaintEvent*)
     painter.setClipRect(rect());
 
     if (m_showInitialMsg) {
-#if (defined(Q_OS_MAC) || defined(Q_OS_MAC64) || defined(Q_OS_MACOS) ||        \
-     defined(Q_OS_MACX) || defined(Q_OS_LINUX))
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0) && (defined(Q_OS_MAC) || defined(Q_OS_MAC64) || defined(Q_OS_MACOS) ||        \
+     defined(Q_OS_MACX) || defined(Q_OS_LINUX)))
         QRect helpRect;
         QScreen* currentScreen = QGuiApplication::screenAt(QCursor::pos());
         if (currentScreen) {
@@ -712,8 +712,8 @@ void CaptureWidget::initPanel()
 {
     QRect panelRect = rect();
     if (m_context.fullscreen) {
-#if (defined(Q_OS_MAC) || defined(Q_OS_MAC64) || defined(Q_OS_MACOS) ||        \
-     defined(Q_OS_MACX) || defined(Q_OS_LINUX))
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0) && (defined(Q_OS_MAC) || defined(Q_OS_MAC64) || defined(Q_OS_MACOS) ||        \
+     defined(Q_OS_MACX) || defined(Q_OS_LINUX)))
         QScreen* currentScreen = QGuiApplication::screenAt(QCursor::pos());
         if (currentScreen) {
             panelRect = currentScreen->geometry();

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -322,9 +322,9 @@ void CaptureWidget::paintEvent(QPaintEvent*)
     painter.setClipRect(rect());
 
     if (m_showInitialMsg) {
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0) &&                               \
-     (defined(Q_OS_MAC) || defined(Q_OS_MAC64) || defined(Q_OS_MACOS) ||       \
-      defined(Q_OS_MACX) || defined(Q_OS_LINUX)))
+#if ((QT_VERSION >= QT_VERSION_CHECK(5, 10, 0) && defined(Q_OS_LINUX)) ||      \
+     defined(Q_OS_MAC) || defined(Q_OS_MAC64) || defined(Q_OS_MACOS) ||        \
+     defined(Q_OS_MACX))
         QRect helpRect;
         QScreen* currentScreen = QGuiApplication::screenAt(QCursor::pos());
         if (currentScreen) {
@@ -713,9 +713,9 @@ void CaptureWidget::initPanel()
 {
     QRect panelRect = rect();
     if (m_context.fullscreen) {
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0) &&                               \
-     (defined(Q_OS_MAC) || defined(Q_OS_MAC64) || defined(Q_OS_MACOS) ||       \
-      defined(Q_OS_MACX) || defined(Q_OS_LINUX)))
+#if ((QT_VERSION >= QT_VERSION_CHECK(5, 10, 0) && defined(Q_OS_LINUX)) ||      \
+     defined(Q_OS_MAC) || defined(Q_OS_MAC64) || defined(Q_OS_MACOS) ||        \
+     defined(Q_OS_MACX))
         QScreen* currentScreen = QGuiApplication::screenAt(QCursor::pos());
         if (currentScreen) {
             panelRect = currentScreen->geometry();

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -323,7 +323,7 @@ void CaptureWidget::paintEvent(QPaintEvent*)
 
     if (m_showInitialMsg) {
 #if (defined(Q_OS_MAC) || defined(Q_OS_MAC64) || defined(Q_OS_MACOS) ||        \
-     defined(Q_OS_MACX))
+     defined(Q_OS_MACX) || defined(Q_OS_LINUX))
         QRect helpRect;
         QScreen* currentScreen = QGuiApplication::screenAt(QCursor::pos());
         if (currentScreen) {
@@ -712,11 +712,24 @@ void CaptureWidget::initPanel()
 {
     QRect panelRect = rect();
     if (m_context.fullscreen) {
+#if (defined(Q_OS_MAC) || defined(Q_OS_MAC64) || defined(Q_OS_MACOS) ||        \
+     defined(Q_OS_MACX) || defined(Q_OS_LINUX))
+        QScreen* currentScreen = QGuiApplication::screenAt(QCursor::pos());
+        if (currentScreen) {
+            panelRect = currentScreen->geometry();
+            auto devicePixelRatio = currentScreen->devicePixelRatio();
+            panelRect.moveTo(panelRect.x() / devicePixelRatio, panelRect.y() / devicePixelRatio);
+            
+        } else {
+            panelRect = QGuiApplication::primaryScreen()->geometry();
+            auto devicePixelRatio = QGuiApplication::primaryScreen()->devicePixelRatio();
+            panelRect.moveTo(panelRect.x() / devicePixelRatio, panelRect.y() / devicePixelRatio);
+        }
+#else
         panelRect = QGuiApplication::primaryScreen()->geometry();
-        auto devicePixelRatio =
-          QGuiApplication::primaryScreen()->devicePixelRatio();
-        panelRect.moveTo(panelRect.x() / devicePixelRatio,
-                         panelRect.y() / devicePixelRatio);
+        auto devicePixelRatio = QGuiApplication::primaryScreen()->devicePixelRatio();
+        panelRect.moveTo(panelRect.x() / devicePixelRatio, panelRect.y() / devicePixelRatio);
+#endif
     }
 
     ConfigHandler config;


### PR DESCRIPTION
**Issue:** Help text and tool settings button, panel always displayed on the primary monitor.

**Solution:** Make the help text and tool settings button, panel display on the current active monitor. The active monitor is determined by the mouse position when flameshot gui was ran.

**System information:**
Distribution: Kubuntu 20.10
Kernel version: Linux Kernel 5.9.16-tkg-upds
Flameshot version: 265e42c