### PR TITLE
Fix help string printing

### DIFF
--- a/src/cli/commandlineparser.cpp
+++ b/src/cli/commandlineparser.cpp
@@ -335,8 +335,8 @@ void CommandLineParser::printHelp(QStringList args, const Node* node)
     }
     QString argText =
       node->subNodes.isEmpty() ? "" : "[" + QObject::tr("arguments") + "]";
-    helpText += QObject::tr("Usage") + ": %1 [%2-" + QObject::tr("options") +
-                QStringLiteral("] %3\n\n")
+    helpText += (QObject::tr("Usage") + ": %1 [%2-" + QObject::tr("options") +
+                 QStringLiteral("] %3\n\n"))
                   .arg(args.join(QStringLiteral(" ")))
                   .arg(argName)
                   .arg(argText);


### PR DESCRIPTION
This patch closes: #1286

Before fix:

```
% ./flameshot -h
QString::arg: Argument missing: ] ./flameshot

, flameshot
QString::arg: Argument missing: ] ./flameshot

, [arguments]
Usage: %1 [%2-options] ./flameshot

Per default runs Flameshot in the background and adds a tray icon for configuration.

Options:
  -h, --help     Displays this help
  -v, --version  Displays version information

Arguments:
  gui            Start a manual capture in GUI mode.
  screen         Capture a single screen.
  full           Capture the entire desktop.
  launcher       Open the capture launcher.
  config         Configure flameshot.
```


After fix:

```
% ./flameshot -h
Usage: ./flameshot [flameshot-options] [arguments]

Per default runs Flameshot in the background and adds a tray icon for configuration.

Options:
  -h, --help     Displays this help
  -v, --version  Displays version information

Arguments:
  gui            Start a manual capture in GUI mode.
  screen         Capture a single screen.
  full           Capture the entire desktop.
  launcher       Open the capture launcher.
  config         Configure flameshot
```