### PR TITLE
CMakeLists.txt: Add option to use external spdlog library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,7 +87,14 @@ set(QAPPLICATION_CLASS
     QApplication
     CACHE STRING "Inheritance class for SingleApplication")
 add_subdirectory(external/singleapplication)
-add_subdirectory(external/spdlog)
+
+if(USE_EXTERNAL_SPDLOG)
+    find_package(spdlog REQUIRED)
+    message(STATUS "Using external spdlog library")
+else()
+    add_subdirectory(external/spdlog)
+endif()
+
 IF (APPLE)
   add_subdirectory(external/QHotkey)
 ENDIF ()


### PR DESCRIPTION
Since most Linux distributions provide spdlog library, this commit provides a configure option to switch between using system
spdlog implementation and bundled spdlog library.

To use external system library, configure with `-DUSE_EXTERNAL_SPDLOG=ON` . The default behavior is to use the bundled library.