### PR TITLE
Exclude the `external` directory with a `.clang-format` file.

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -18,7 +18,6 @@ jobs:
     - uses: DoozyX/clang-format-lint-action@v0.9
       with:
         source: './src'
-        exclude: './external'
         extensions: 'h,cpp'
         clangFormatVersion: 11
         style: file

--- a/external/.clang-format
+++ b/external/.clang-format
@@ -1,0 +1,2 @@
+DisableFormat: true
+SortIncludes: false


### PR DESCRIPTION
(I copied this trick from https://stackoverflow.com/a/57272592/1739415)

The GitHub clang-format workflow was already ignoring the `external`
directory because of the setting in the `clang-format.yml` file, but
that doesn't help other people running `clang-format` by hand (which the
CONTRIBUTING.md file instructs developers to do). Without this change,
I'd see a bunch of changes appear in the `external/spdlog` every time I
ran clang-format by hand.

I figure it's better to configure this via files that clang knows about
so both the GitHub workflow *and* developers have a closer to identical
experience.