### PR TITLE
Prompt where to save the capture when invoked by KDE shortcut

### DIFF
--- a/docs/shortcuts-config/flameshot-shortcuts-kde
+++ b/docs/shortcuts-config/flameshot-shortcuts-kde
@@ -23,7 +23,7 @@ Type=SIMPLE_ACTION_DATA
 ActionsCount=1
 
 [Data_1_1Actions0]
-Arguments='Pictures/Screenshots' 0 0
+Arguments='' 0 0
 Call=graphicCapture
 RemoteApp=org.flameshot.Flameshot
 RemoteObj=/


### PR DESCRIPTION
How can I change the KDE shortcut file (or the `Arguments` in the shortcuts) to have Flameshot prompt me where to save the screenshot and with what name, as it does when invoked by clicking it? Is setting the first argument to `''` the correct way to do it?

![image](https://user-images.githubusercontent.com/33569/107872003-ec897a00-6e4a-11eb-8a37-52d733483f79.png)

If so, I would like to suggest this be the setting in the KDE shortcuts config file, not the hardcoded `Pictures/Screenshots`, for three reasons:

1. If the user has changed their directory in the Flameshot configuration, then saving to `Pictures/Screenshots` is counter-intuitive
2. The directory might not even exist
3. For consistency with pressing the 💾 icon when invoking Flameshot via clicking its icon, Flameshot should also prompt.