### PR TITLE
Allow setting custom color picker in userColors

### DIFF
--- a/src/utils/confighandler.cpp
+++ b/src/utils/confighandler.cpp
@@ -101,6 +101,8 @@ QVector<QColor> ConfigHandler::getUserColors()
              m_settings.value(QStringLiteral("userColors")).toStringList()) {
             if (QColor::isValidColor(hex)) {
                 colors.append(QColor(hex));
+            } else if (hex == QStringLiteral("picker")) {
+                colors.append(QColor());
             }
         }
 
@@ -119,7 +121,11 @@ void ConfigHandler::setUserColors(const QVector<QColor>& l)
     QStringList hexColors;
 
     for (const QColor& color : l) {
-        hexColors.append(color.name());
+        if (color.isValid()) {
+            hexColors.append(color.name());
+        } else {
+            hexColors.append(QStringLiteral("picker"));
+        }
     }
 
     m_settings.setValue(QStringLiteral("userColors"),


### PR DESCRIPTION
This exposes the custom color picker to the settings so that the color wheel can be modified and still contain the color picker.

How to test:
1. Add to flameshot.ini:
`userColors=#ffffff, #000000, picker, otherinvalid`
2. Verify that the only items in the color wheel are black, white, and a color picker.
