### PR TITLE
Document flameshot.ini using an example file

### DIFF
--- a/flameshot.example.ini
+++ b/flameshot.example.ini
@@ -1,0 +1,101 @@
+[General]
+; Configure which buttons to show after drawing a selection
+; Not easy to set by hand
+;buttons=@Variant(\0\0\0\x7f\0\0\0\vQList<int>\0\0\0\0\x14\0\0\0\0\0\0\0\x1\0\0\0\x2\0\0\0\x3\0\0\0\x4\0\0\0\x5\0\0\0\x6\0\0\0\x12\0\0\0\xf\0\0\0\x13\0\0\0\a\0\0\0\b\0\0\0\t\0\0\0\x10\0\0\0\n\0\0\0\v\0\0\0\f\0\0\0\r\0\0\0\xe\0\0\0\x11)
+
+; List of colors for color picker
+; The colors are arranged counter-clockwise with the first being set to the right of the cursor
+; Colors are any valid hex code or W3C color name
+; "picker" adds a custom color picker
+;userColors=#800000, #ff0000, #ffff00, #00ff00, #008000, #00ffff, #0000ff, #ff00ff, #800080, picker
+
+; Image Save Path
+;savePath=
+
+; Whether the savePath is a fixed path (bool)
+;savePathFixed=false
+
+; Main UI color
+; Color is any valid hex code or W3C color name
+;uiColor=#740096
+
+; Contrast UI color
+; Color is any valid hex code or W3C color name
+;contrastUiColor=#270032
+
+; Last used color
+; Color is any valid hex code or W3C color name
+;drawColor=
+
+; Show the help screen on startup (bool)
+;showHelp=true
+
+; Show the side panel button (bool)
+;showSidePanelButton=true
+
+; Ignore updates to versions less than this value
+;ignoreUpdateToVersion=
+
+; Show desktop notifications (bool)
+;showDesktopNotification=true
+
+; Filename pattern using C++ strftime formatting
+;filenamePattern=%F_%H-%M
+
+; Whether the tray icon is disabled (bool)
+;disabledTrayIcon=false
+
+; Last used tool thickness (int)
+;drawThickness=0
+
+; Keep the App Launcher open after selecting an app (bool)
+;keepOpenAppLauncher=false
+
+; Launch at startup (bool)
+;startupLaunch=
+
+; Opacity of area outside selection (int in range 0-255)
+;contrastOpacity=190
+
+; Save image after copy (bool)
+;saveAfterCopy=false
+
+; Copy path to image after save (bool)
+;copyPathAfterSave=false
+
+; Use JPG format instead of PNG (bool)
+;useJpgForClipboard=false
+
+; Shortcut Settings for all tools
+[Shortcuts]
+;TYPE_ARROW=A
+;TYPE_CIRCLE=C
+;TYPE_CIRCLECOUNT=
+;TYPE_COMMIT_CURRENT_TOOL=Ctrl+Return
+;TYPE_COPY=Ctrl+C
+;TYPE_DRAWER=D
+;TYPE_EXIT=Ctrl+Q
+;TYPE_IMAGEUPLOADER=Return
+;TYPE_MARKER=M
+;TYPE_MOVESELECTION=Ctrl+M
+;TYPE_MOVE_DOWN=Down
+;TYPE_MOVE_LEFT=Left
+;TYPE_MOVE_RIGHT=Right
+;TYPE_MOVE_UP=Up
+;TYPE_OPEN_APP=Ctrl+O
+;TYPE_PENCIL=P
+;TYPE_PIN=
+;TYPE_PIXELATE=B
+;TYPE_RECTANGLE=R
+;TYPE_REDO=Ctrl+Shift+Z
+;TYPE_RESIZE_DOWN=Shift+Down
+;TYPE_RESIZE_LEFT=Shift+Left
+;TYPE_RESIZE_RIGHT=Shift+Right
+;TYPE_RESIZE_UP=Shift+Up
+;TYPE_SAVE=Ctrl+S
+;TYPE_SELECTION=S
+;TYPE_SELECTIONINDICATOR=
+;TYPE_SELECT_ALL=Ctrl+A
+;TYPE_TEXT=T
+;TYPE_TOGGLE_PANEL=Space
+;TYPE_UNDO=Ctrl+Z


### PR DESCRIPTION
All settings are documented into an example file with default values. The values are left blank in cases that are OS dependent or change at runtime.

Note: This PR currently depends on #1342 since it also documents the use of "picker" in userColors. This can be fixed if that PR is not accepted.