### PR TITLE
Do not include QHotKey header on non-Mac system

### DIFF
--- a/src/core/controller.cpp
+++ b/src/core/controller.cpp
@@ -16,7 +16,11 @@
 //     along with Flameshot.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "controller.h"
+
+#if defined(Q_OS_MACOS)
 #include "external/QHotkey/QHotkey"
+#endif
+
 #include "src/config/configwindow.h"
 #include "src/core/qguiappcurrentscreen.h"
 #include "src/utils/confighandler.h"


### PR DESCRIPTION
QHotKey is only used on macOS. As a result, do not unconditionally include QHotKey headers.

This makes it possible to completely delete `external/QHotkey` directory when building on non-macOS environment.