### PR TITLE
NC/fixes 25-02-2021

### DIFF
--- a/src/config/generalconf.cpp
+++ b/src/config/generalconf.cpp
@@ -386,6 +386,10 @@ void GeneralConf::initUseJpgForClipboard()
       tr("Use JPG format for clipboard (PNG default)"));
     m_layout->addWidget(m_useJpgForClipboard);
 
+#if defined(Q_OS_MACOS)
+    // FIXME - temporary fix to disable option for MacOS
+    m_useJpgForClipboard->hide();
+#endif
     connect(m_useJpgForClipboard,
             &QCheckBox::clicked,
             this,

--- a/src/config/generalconf.cpp
+++ b/src/config/generalconf.cpp
@@ -155,7 +155,30 @@ void GeneralConf::resetConfiguration()
         m_savePath->setText(
           QStandardPaths::writableLocation(QStandardPaths::PicturesLocation));
         ConfigHandler().setDefaultSettings();
+        setActualFormData();
     }
+}
+
+void GeneralConf::setActualFormData()
+{
+    // read and set current settings
+    ConfigHandler config;
+    m_sysNotifications->setChecked(config.desktopNotificationValue());
+    m_showTray->setChecked(!config.disabledTrayIconValue());
+    m_helpMessage->setChecked(config.showHelpValue());
+    m_sidePanelButton->setChecked(config.showSidePanelButtonValue());
+    m_checkForUpdates->setChecked(config.checkForUpdates());
+    m_autostart->setChecked(config.startupLaunchValue());
+    m_showStartupLaunchMessage->setChecked(config.showStartupLaunchMessage());
+    m_copyAndCloseAfterUpload->setChecked(
+      config.copyAndCloseAfterUploadEnabled());
+    m_copyPathAfterSave->setChecked(config.copyPathAfterSaveEnabled());
+    m_saveAfterCopy->setChecked(config.saveAfterCopyValue());
+    m_savePath->setText(config.savePath());
+    m_screenshotPathFixedCheck->setChecked(config.savePathFixed());
+    m_historyConfirmationToDelete->setChecked(
+      config.historyConfirmationToDelete());
+    m_useJpgForClipboard->setChecked(config.useJpgForClipboard());
 }
 
 void GeneralConf::initShowHelp()

--- a/src/config/generalconf.h
+++ b/src/config/generalconf.h
@@ -53,6 +53,8 @@ private:
     void initCopyPathAfterSave();
     void initUseJpgForClipboard();
 
+    void setActualFormData();
+
     // class members
     QVBoxLayout* m_layout;
     QCheckBox* m_sysNotifications;

--- a/src/utils/confighandler.cpp
+++ b/src/utils/confighandler.cpp
@@ -318,31 +318,29 @@ bool ConfigHandler::startupLaunchValue()
 
 bool ConfigHandler::verifyLaunchFile()
 {
-    bool res = false;
-
 #if defined(Q_OS_LINUX) || defined(Q_OS_UNIX)
     QString path = QStandardPaths::locate(QStandardPaths::GenericConfigLocation,
                                           "autostart/",
                                           QStandardPaths::LocateDirectory) +
                    "Flameshot.desktop";
-    res = QFile(path).exists();
+    bool res = QFile(path).exists();
 #elif defined(Q_OS_WIN)
     QSettings bootUpSettings(
       "HKEY_CURRENT_USER\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run",
       QSettings::NativeFormat);
-    res = bootUpSettings.value("Flameshot").toString() ==
-          QDir::toNativeSeparators(QCoreApplication::applicationFilePath());
+    bool res =
+      bootUpSettings.value("Flameshot").toString() ==
+      QDir::toNativeSeparators(QCoreApplication::applicationFilePath());
 #endif
     return res;
 }
 
 void ConfigHandler::setStartupLaunch(const bool start)
 {
-
-    m_settings.setValue(QStringLiteral("startupLaunch"), start);
     if (start == m_settings.value(QStringLiteral("startupLaunch")).toBool()) {
         return;
     }
+    m_settings.setValue(QStringLiteral("startupLaunch"), start);
 #if defined(Q_OS_MACOS)
     /* TODO - there should be more correct way via API, but didn't find it
      without extra dependencies, there should be something like that:

--- a/src/utils/confighandler.cpp
+++ b/src/utils/confighandler.cpp
@@ -238,9 +238,19 @@ void ConfigHandler::setDesktopNotification(const bool showDesktopNotification)
                         showDesktopNotification);
 }
 
+QString ConfigHandler::filenamePatternDefault()
+{
+    m_strRes = QLatin1String("%F_%H-%M");
+    return m_strRes;
+}
+
 QString ConfigHandler::filenamePatternValue()
 {
-    return m_settings.value(QStringLiteral("filenamePattern")).toString();
+    m_strRes = m_settings.value(QStringLiteral("filenamePattern")).toString();
+    if (m_strRes.isEmpty()) {
+        m_strRes = filenamePatternDefault();
+    }
+    return m_strRes;
 }
 
 void ConfigHandler::setFilenamePattern(const QString& pattern)

--- a/src/utils/confighandler.cpp
+++ b/src/utils/confighandler.cpp
@@ -506,9 +506,12 @@ void ConfigHandler::setCopyPathAfterSaveEnabled(const bool value)
 
 bool ConfigHandler::useJpgForClipboard() const
 {
+#if not defined(Q_OS_MACOS)
+    // FIXME - temporary fix to disable option for MacOS
     if (m_settings.contains(QStringLiteral("useJpgForClipboard"))) {
         return m_settings.value(QStringLiteral("useJpgForClipboard")).toBool();
     }
+#endif
     return false;
 }
 

--- a/src/utils/confighandler.h
+++ b/src/utils/confighandler.h
@@ -43,6 +43,7 @@ public:
     bool desktopNotificationValue();
     void setDesktopNotification(const bool);
 
+    QString filenamePatternDefault();
     QString filenamePatternValue();
     void setFilenamePattern(const QString&);
 

--- a/src/utils/filenamehandler.cpp
+++ b/src/utils/filenamehandler.cpp
@@ -33,16 +33,17 @@ QString FileNameHandler::parsedPattern()
 QString FileNameHandler::parseFilename(const QString& name)
 {
     QString res = name;
-    // remove trailing characters '%' in the pattern
     if (name.isEmpty()) {
-        res = QLatin1String("%F_%H-%M");
+        res = ConfigHandler().filenamePatternDefault();
     }
+
+    // remove trailing characters '%' in the pattern
     while (res.endsWith('%')) {
         res.chop(1);
     }
     std::time_t t = std::time(NULL);
 
-    char* tempData = QStringTocharArr(res);
+    char* tempData = QStringToCharArr(res);
     char data[MAX_CHARACTERS] = { 0 };
     std::strftime(data, sizeof(data), tempData, std::localtime(&t));
     res = QString::fromLocal8Bit(data, (int)strlen(data));
@@ -92,7 +93,7 @@ QString FileNameHandler::charArrToQString(const char* c)
     return QString::fromLocal8Bit(c, MAX_CHARACTERS);
 }
 
-char* FileNameHandler::QStringTocharArr(const QString& s)
+char* FileNameHandler::QStringToCharArr(const QString& s)
 {
     QByteArray ba = s.toLocal8Bit();
     return const_cast<char*>(strdup(ba.constData()));

--- a/src/utils/filenamehandler.h
+++ b/src/utils/filenamehandler.h
@@ -25,7 +25,7 @@ public slots:
 private:
     // using charArr = char[MAX_CHARACTERS];
     QString charArrToQString(const char* c);
-    char* QStringTocharArr(const QString& s);
+    char* QStringToCharArr(const QString& s);
 
     void fixPath(QString& directory, QString& filename);
 };

--- a/src/utils/screenshotsaver.cpp
+++ b/src/utils/screenshotsaver.cpp
@@ -29,7 +29,6 @@ ScreenshotSaver::ScreenshotSaver(const unsigned id)
 // dbus, the application freezes.
 void ScreenshotSaver::saveToClipboard(const QPixmap& capture)
 {
-
     // If we are able to properly save the file, save the file and copy to
     // clipboard.
     if ((ConfigHandler().saveAfterCopyValue()) &&
@@ -42,6 +41,7 @@ void ScreenshotSaver::saveToClipboard(const QPixmap& capture)
     // Otherwise only save to clipboard
     else {
         if (ConfigHandler().useJpgForClipboard()) {
+            // FIXME - it doesn't work on MacOS
             QByteArray array;
             QBuffer buffer{ &array };
             QImageWriter imageWriter{ &buffer, "JPEG" };
@@ -58,14 +58,12 @@ void ScreenshotSaver::saveToClipboard(const QPixmap& capture)
                 QMimeData* mimeData = new QMimeData;
                 mimeData->setData("image/jpeg", array);
                 QApplication::clipboard()->setMimeData(mimeData);
-
             } else {
                 SystemNotification().sendMessage(
                   QObject::tr("Error while saving to clipboard"));
                 return;
             }
         } else {
-
             // Need to send message before copying to clipboard
             SystemNotification().sendMessage(
               QObject::tr("Capture saved to clipboard"));


### PR DESCRIPTION
- fix - File name pattern editor 'Clear' and 'Reset' behavior (configuration window)
- fix - Reset button doesn't reset configurations to the initial values
- fix - MacOS - Image is not copied to the clipboard when the 'Use JPG format for clipboard' checkbox is set
- fix - 'Launch at startup feature' doesn't work after uncheck/check in the Configuration window
