### PR TITLE
fix XDG desktop check

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -38,6 +38,7 @@ int waitAfterConnecting(int delay, QCoreApplication& app)
     return app.exec();
 }
 
+#ifdef Q_OS_LINUX
 // source: https://github.com/ksnip/ksnip/issues/416
 void wayland_hacks()
 {
@@ -47,6 +48,7 @@ void wayland_hacks()
         qputenv("QT_QPA_PLATFORM", "xcb");
     }
 }
+#endif
 
 int main(int argc, char* argv[])
 {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,6 +25,7 @@
 #include "src/utils/dbusutils.h"
 #include <QDBusConnection>
 #include <QDBusMessage>
+#include <desktopinfo.h>
 #endif
 
 int waitAfterConnecting(int delay, QCoreApplication& app)
@@ -41,11 +42,8 @@ int waitAfterConnecting(int delay, QCoreApplication& app)
 void wayland_hacks()
 {
     // Workaround to https://github.com/ksnip/ksnip/issues/416
-    QByteArray currentDesktop = qgetenv("XDG_CURRENT_DESKTOP").toLower();
-    QByteArray sessionDesktop = qgetenv("XDG_SESSION_DESKTOP").toLower();
-    QByteArray sessionType = qgetenv("XDG_SESSION_TYPE").toLower();
-    if (sessionType.contains("wayland") && (currentDesktop.contains("gnome") ||
-                                            sessionDesktop.contains("gnome"))) {
+    DesktopInfo info;
+    if (info.windowManager() == DesktopInfo::GNOME) {
         qputenv("QT_QPA_PLATFORM", "xcb");
     }
 }

--- a/src/utils/desktopinfo.cpp
+++ b/src/utils/desktopinfo.cpp
@@ -27,11 +27,11 @@ DesktopInfo::WM DesktopInfo::windowManager()
 {
     DesktopInfo::WM res = DesktopInfo::OTHER;
     QStringList desktops = XDG_CURRENT_DESKTOP.split(QChar(':'));
-    for (auto & desktop : desktops) {
-        if (desktop.contains(QLatin1String("GNOME"),Qt::CaseInsensitive)) {
+    for (auto& desktop : desktops) {
+        if (desktop.contains(QLatin1String("GNOME"), Qt::CaseInsensitive)) {
             return DesktopInfo::GNOME;
         }
-        if (desktop.contains(QLatin1String("sway"),Qt::CaseInsensitive)) {
+        if (desktop.contains(QLatin1String("sway"), Qt::CaseInsensitive)) {
             return DesktopInfo::SWAY;
         }
         if (desktop.contains(QLatin1String("kde-plasma"))) {

--- a/src/utils/desktopinfo.cpp
+++ b/src/utils/desktopinfo.cpp
@@ -26,16 +26,26 @@ bool DesktopInfo::waylandDectected()
 DesktopInfo::WM DesktopInfo::windowManager()
 {
     DesktopInfo::WM res = DesktopInfo::OTHER;
-    if (XDG_CURRENT_DESKTOP.contains(QLatin1String("GNOME"),
-                                     Qt::CaseInsensitive) ||
-        !GNOME_DESKTOP_SESSION_ID.isEmpty()) {
-        res = DesktopInfo::GNOME;
-    } else if (XDG_CURRENT_DESKTOP.contains(QLatin1String("sway"),
-                                            Qt::CaseInsensitive)) {
-        res = DesktopInfo::SWAY;
-    } else if (!KDE_FULL_SESSION.isEmpty() ||
-               DESKTOP_SESSION == QLatin1String("kde-plasma")) {
-        res = DesktopInfo::KDE;
+    QStringList desktops = XDG_CURRENT_DESKTOP.split(QChar(':'));
+    for (auto & desktop : desktops) {
+        if (desktop.contains(QLatin1String("GNOME"),Qt::CaseInsensitive)) {
+            return DesktopInfo::GNOME;
+        }
+        if (desktop.contains(QLatin1String("sway"),Qt::CaseInsensitive)) {
+            return DesktopInfo::SWAY;
+        }
+        if (desktop.contains(QLatin1String("kde-plasma"))) {
+            return DesktopInfo::KDE;
+        }
     }
+
+    if (!GNOME_DESKTOP_SESSION_ID.isEmpty()) {
+        return DesktopInfo::GNOME;
+    }
+
+    if (!KDE_FULL_SESSION.isEmpty()) {
+        return DesktopInfo::KDE;
+    }
+
     return res;
 }


### PR DESCRIPTION
This should fix the issue mentioned by @tinywrkb in #1356.

Properly parse the XDG_CURRENT_DESKTOP variable to handle colon seperated lists. I've checked around and while there is no specification, [xdg-desktop-portal](https://github.com/flatpak/xdg-desktop-portal/blob/89d2197002f164d02d891c530dcaa2808f27f593/src/portal-impl.c#L189) splits the variable by colons.