### PR TITLE
feat(CI): add arm64v8 and arm32v7 support for debian 10 family

### DIFF
--- a/.github/workflows/Linux-pack.yml
+++ b/.github/workflows/Linux-pack.yml
@@ -20,6 +20,7 @@ env:
   # docker images, see https://hub.docker.com/r/flameshotorg/ci-building-images
   # flameshotorg/ci-building-images or packpack/packpack
   DOCKER_REPO: flameshotorg/ci-building-images
+  PACKPACK_REPO: flameshot-org/packpack
   # available upload services: wetransfer.com, file.io, 0x0.st
   UPLOAD_SERVICE: wetransfer.com
 
@@ -36,6 +37,18 @@ jobs:
               os: debian,
               symbol: buster,
               arch: amd64
+            }          
+          - {
+              name: debian-10,
+              os: debian,
+              symbol: buster,
+              arch: arm64
+            }       
+          - {
+              name: debian-10,
+              os: debian,
+              symbol: buster,
+              arch: armhf
             }
           - {
               name: ubuntu-20.04,
@@ -44,6 +57,43 @@ jobs:
               arch: amd64
             }
     steps:
+      - name: Enable Docker Experimental Features 
+        run: |
+          echo $'{\n  "experimental": true\n}' | sudo tee /etc/docker/daemon.json
+          mkdir -p ~/.docker
+          echo $'{\n  "experimental": "enabled"\n}' | sudo tee ~/.docker/config.json
+          sudo service docker restart
+          docker version -f '{{.Client.Experimental}}'
+          docker version -f '{{.Server.Experimental}}'
+          docker buildx version
+      - name: Support for ARM via QEMU's user-mode emulation
+        # Register binfmt_misc entry for qemu-user-static
+        # https://github.com/multiarch/qemu-user-static
+        env:
+          DOCKER_ARCH: ${{ matrix.dist.arch }}
+        run: |
+          case ${DOCKER_ARCH} in
+            amd64|i386)
+              QEMU_ARCH=
+              ;;
+            arm32*)
+              QEMU_ARCH=arm
+              ;;
+            armhf)
+              QEMU_ARCH=arm
+              ;;
+            arm64*)
+              QEMU_ARCH=aarch64
+              ;;
+            *)
+              QEMU_ARCH=${DOCKER_ARCH}
+              ;;
+          esac
+          if [ -n "${QEMU_ARCH}" ]; then
+            docker rm $(docker create --volume qemu-user-static:/usr/bin multiarch/qemu-user-static:${QEMU_ARCH} dummy)
+            docker run --rm --privileged --volume qemu-user-static:/usr/bin:ro multiarch/qemu-user-static:register --persistent yes --credential yes
+            cat /proc/sys/fs/binfmt_misc/qemu-${QEMU_ARCH}
+          fi
       - name: Checkout Source code
         if: github.event_name == 'push'
         uses: actions/checkout@v2
@@ -70,17 +120,53 @@ jobs:
       - name: Get packpack tool
         uses: actions/checkout@v2
         with:
-          # flameshot-org/packpack or packpack/packpack
-          repository: flameshot-org/packpack
+          repository: ${{ env.PACKPACK_REPO }}
           path: tools
+          ref: multiarch
       - name: Packaging on ${{ matrix.dist.name }} ${{ matrix.dist.arch }}
-        run: |
-          cp -r $GITHUB_WORKSPACE/packaging/debian $GITHUB_WORKSPACE
-          bash $GITHUB_WORKSPACE/tools/packpack
-          mv $GITHUB_WORKSPACE/build/${PRODUCT}_${VERSION}-${RELEASE}_${{ matrix.dist.arch }}.deb $GITHUB_WORKSPACE/build/${PRODUCT}-${VERSION}-${RELEASE}.${{ matrix.dist.name }}.${{ matrix.dist.arch }}.deb
         env:
           OS: ${{ matrix.dist.os }}
           DIST: ${{ matrix.dist.symbol }}
+          DOCKER_ARCH: ${{ matrix.dist.arch }}
+        run: |
+          case ${DOCKER_ARCH} in
+            arm32v7)
+              export ARCH=arm/v7
+              ;;
+            armhf)
+              export ARCH=arm/v7
+              ;;
+            arm64*)
+              export ARCH=arm64
+              ;;
+            *)
+              export ARCH=${DOCKER_ARCH}
+              ;;
+          esac
+          cp -r $GITHUB_WORKSPACE/packaging/debian $GITHUB_WORKSPACE
+          bash $GITHUB_WORKSPACE/tools/packpack
+          mv $GITHUB_WORKSPACE/build/${PRODUCT}_${VERSION}-${RELEASE}_${{ matrix.dist.arch }}.deb $GITHUB_WORKSPACE/build/${PRODUCT}-${VERSION}-${RELEASE}.${{ matrix.dist.name }}.${{ matrix.dist.arch }}.deb
+      - name: In order to unset the registered formats, and unload the binaries
+        env:
+          DOCKER_ARCH: ${{ matrix.dist.arch }}
+        run: |
+          case ${DOCKER_ARCH} in
+            amd64|i386)
+              QEMU_ARCH=
+              ;;
+            arm32*)
+              QEMU_ARCH=arm
+              ;;
+            arm64*)
+              QEMU_ARCH=aarch64
+              ;;
+            *)
+              QEMU_ARCH=${DOCKER_ARCH}
+              ;;
+          esac
+          if [ -n "${QEMU_ARCH}" ]; then
+            docker run --rm --privileged --volume qemu-user-static:/usr/bin:ro multiarch/qemu-user-static:register --reset
+          fi
       - name: SHA256Sum of ${{ matrix.dist.name }} ${{ matrix.dist.arch }} package(daily build)
         run: |
           sha256sum $GITHUB_WORKSPACE/build/${PRODUCT}-${VERSION}-${RELEASE}.${{ matrix.dist.name }}.${{ matrix.dist.arch }}.deb
@@ -243,9 +329,9 @@ jobs:
       - name: Get packpack tool
         uses: actions/checkout@v2
         with:
-          # flameshot-org/packpack or packpack/packpack
-          repository: flameshot-org/packpack
+          repository: ${{ env.PACKPACK_REPO }}
           path: tools
+          ref: master
       - name: Packaging on ${{ matrix.dist.name }} ${{ matrix.dist.arch }}
         run: |
           cp -r $GITHUB_WORKSPACE/packaging/rpm $GITHUB_WORKSPACE


### PR DESCRIPTION
#### ARM support for debian & [Raspberry Pi OS](https://www.raspberrypi.org/software/)

Since Github Actions provides only x86_64 VMs, this uses Docker and QEMU to be able to build, test and create packages for aarch64 & arm. This is accomplished by registering [qemu-user-static](https://github.com/multiarch/qemu-user-static).

It's super slow on other Linux distributions based on the QEMU emulator.
