### PR TITLE
fixed invalid path when tilde is used as a param for key shortcut

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -206,7 +206,11 @@ int main(int argc, char* argv[])
     const QString pathErr =
       QObject::tr("Invalid path, it must be a real path in the system");
     auto pathChecker = [pathErr](const QString& pathValue) -> bool {
-        bool res = QDir(pathValue).exists();
+    	QString pathToCheck = pathValue;
+    	if ((pathValue == "~") || (pathValue.startsWith("~/"))) {
+            pathToCheck.replace (0, 1, QDir::homePath());
+    	}
+        bool res = QDir(pathToCheck).exists();
         if (!res) {
             SystemNotification().sendMessage(
               QObject::tr(pathErr.toLatin1().data()));


### PR DESCRIPTION
Fixes #1465 "Using "-p ~" gives "Invalid path, it must be a real path in the system"

Why problem occured?  The "~" as path argument is replaced (by home dir) performed by shell - not by language, not by Qt. 
My propose to fix? There is need to add checking if tilda is used as a path (and replace it with home path if needed).
Tested on: Ubuntu 20.10, 5.8.0-44-generic