### PR TITLE
Windowed capture mode

### DIFF
--- a/src/config/generalconf.cpp
+++ b/src/config/generalconf.cpp
@@ -5,6 +5,7 @@
 #include "src/core/controller.h"
 #include "src/utils/confighandler.h"
 #include <QCheckBox>
+#include <QComboBox>
 #include <QFile>
 #include <QFileDialog>
 #include <QGroupBox>
@@ -41,6 +42,7 @@ GeneralConf::GeneralConf(QWidget* parent)
     initCopyAndCloseAfterUpload();
     initCopyPathAfterSave();
     initUseJpgForClipboard();
+    initWindowMode();
     initSaveAfterCopy();
     inituploadHistoryMax();
     initUndoLimit();
@@ -68,6 +70,13 @@ void GeneralConf::_updateComponents(bool allowEmptySavePath)
     m_checkForUpdates->setChecked(config.checkForUpdates());
     m_showStartupLaunchMessage->setChecked(config.showStartupLaunchMessage());
     m_screenshotPathFixedCheck->setChecked(config.savePathFixed());
+    auto configWindowMode = config.windowMode();
+    for (int i = 0; i < m_windowMode->count(); i++) {
+        if (m_windowMode->itemData(i) == configWindowMode) {
+            m_windowMode->setCurrentIndex(i);
+            break;
+        }
+    }
     m_uploadHistoryMax->setValue(config.uploadHistoryMax());
     m_undoLimit->setValue(config.undoLimit());
 
@@ -461,6 +470,44 @@ void GeneralConf::initUseJpgForClipboard()
             &QCheckBox::clicked,
             this,
             &GeneralConf::useJpgForClipboardChanged);
+}
+
+void GeneralConf::initWindowMode()
+{
+    m_windowMode = new QComboBox(this);
+    m_layout->addWidget(m_windowMode);
+    struct
+    {
+        QString label;
+        CaptureConfig::CaptureWindowMode mode;
+    } modes[] = {
+#if !defined(Q_OS_MACOS)
+        { tr("All screens"), CaptureConfig::CaptureWindowMode::FullScreenAll },
+#endif
+        { tr("Current screen"),
+          CaptureConfig::CaptureWindowMode::FullScreenCurrent },
+        { tr("Maximized window"),
+          CaptureConfig::CaptureWindowMode::MaximizeWindow },
+        { tr("Debug window"),
+          CaptureConfig::CaptureWindowMode::DebugNonFullScreen },
+    };
+    for (auto& item : modes) {
+        m_windowMode->addItem(item.label, item.mode);
+    }
+    connect(m_windowMode,
+            QOverload<int>::of(&QComboBox::currentIndexChanged),
+            this,
+            &GeneralConf::windowModeChanged);
+}
+
+void GeneralConf::windowModeChanged()
+{
+    auto selectedData = m_windowMode->currentData();
+    if (selectedData.canConvert<CaptureConfig::CaptureWindowMode>()) {
+        auto selectedMode =
+          selectedData.value<CaptureConfig::CaptureWindowMode>();
+        ConfigHandler().setWindowMode(selectedMode);
+    }
 }
 
 void GeneralConf::saveAfterCopyChanged(bool checked)

--- a/src/config/generalconf.h
+++ b/src/config/generalconf.h
@@ -12,6 +12,7 @@ class QPushButton;
 class QLabel;
 class QLineEdit;
 class QSpinBox;
+class QComboBox;
 
 class GeneralConf : public QWidget
 {
@@ -39,6 +40,7 @@ private slots:
     void resetConfiguration();
     void togglePathFixed();
     void useJpgForClipboardChanged(bool checked);
+    void windowModeChanged();
 
 private:
     const QString chooseFolder(const QString currentPath = "");
@@ -59,6 +61,7 @@ private:
     void initSaveAfterCopy();
     void initCopyPathAfterSave();
     void initUseJpgForClipboard();
+    void initWindowMode();
 
     void _updateComponents(bool allowEmptySavePath);
 
@@ -84,6 +87,7 @@ private:
     QCheckBox* m_screenshotPathFixedCheck;
     QCheckBox* m_historyConfirmationToDelete;
     QCheckBox* m_useJpgForClipboard;
+    QComboBox* m_windowMode;
     QSpinBox* m_uploadHistoryMax;
     QSpinBox* m_undoLimit;
 };

--- a/src/core/controller.cpp
+++ b/src/core/controller.cpp
@@ -285,7 +285,7 @@ void Controller::startVisualCapture(const uint id,
             return;
         }
 
-        m_captureWindow = new CaptureWidget(id, forcedSavePath);
+        m_captureWindow = new CaptureWidget(id, forcedSavePath, ConfigHandler().windowMode());
         // m_captureWindow = new CaptureWidget(id, forcedSavePath, false); //
         // debug
         connect(m_captureWindow,
@@ -297,17 +297,8 @@ void Controller::startVisualCapture(const uint id,
                 this,
                 &Controller::captureTaken);
 
-#ifdef Q_OS_WIN
-        m_captureWindow->show();
-#elif defined(Q_OS_MACOS)
-        // In "Emulate fullscreen mode"
-        m_captureWindow->showFullScreen();
-        m_captureWindow->activateWindow();
-        m_captureWindow->raise();
-#else
-        m_captureWindow->showFullScreen();
-//        m_captureWindow->show(); // For CaptureWidget Debugging under Linux
-#endif
+        m_captureWindow->OpenAndShow();
+
         if (!m_appLatestUrl.isEmpty() &&
             ConfigHandler().ignoreUpdateToVersion().compare(
               m_appLatestVersion) < 0) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -49,7 +49,8 @@ void wayland_hacks()
 {
     // Workaround to https://github.com/ksnip/ksnip/issues/416
     DesktopInfo info;
-    if (info.windowManager() == DesktopInfo::GNOME) {
+    if (info.windowManager() == DesktopInfo::GNOME /*&&
+         QT_VERSION < QT_VERSION_CHECK(5, 15, 2)*/) {
         qputenv("QT_QPA_PLATFORM", "xcb");
     }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -60,11 +60,7 @@ void wayland_hacks()
 void windowsHighDPIHack() 
 {
     // On Windows when main screen is set to highDPI one or there is only highDPI screen
-    // the default font size gets set incorectly. In the observations it was set to
-    // 8.25 / scaleFactor. It might be too small ont the high dpi screen, but even
-    // worse moving the window to normal DPI screen applies the difference in DPI
-    // resulting in 8.25 / (scaleFactor^2) which is wrong.
-    // Doesn't seem to happen when the low DPI screen is chosen as main one.
+    // the default font size gets set incorectly.
     // 
     // Likely related to https://bugreports.qt.io/browse/QTBUG-58610 and
     // https://codereview.qt-project.org/c/qt/qtbase/+/264388
@@ -74,7 +70,7 @@ void windowsHighDPIHack()
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     QFont font;
     font.resolve();
-    if (font.pointSizeF() < 8) {
+    if (font.pointSizeF() < 8 || font.pointSizeF() > 9.5) {
         font.setPointSizeF(8);
         QApplication::setFont(font);
     }

--- a/src/utils/confighandler.cpp
+++ b/src/utils/confighandler.cpp
@@ -112,6 +112,7 @@ static QMap<class QString, QSharedPointer<ValueHandler>>
     OPTION("keepOpenAppLauncher"         ,Bool               ( false         )),
     OPTION("fontFamily"                  ,String             ( ""            )),
     OPTION("setSaveAsFileExtension"      ,String             ( ""            )),
+    OPTION("windowMode"                  ,String             ( ""            )),
   };
 
 static QMap<QString, QSharedPointer<KeySequence>> recognizedShortcuts = {

--- a/src/utils/confighandler.cpp
+++ b/src/utils/confighandler.cpp
@@ -18,6 +18,7 @@
 #include <QVector>
 #include <QMetaEnum>
 #include <algorithm>
+#include <stdexcept>
 #if defined(Q_OS_MACOS)
 #include <QProcess>
 #endif

--- a/src/utils/confighandler.cpp
+++ b/src/utils/confighandler.cpp
@@ -16,6 +16,7 @@
 #include <QStandardPaths>
 #include <QTextStream>
 #include <QVector>
+#include <QMetaEnum>
 #include <algorithm>
 #if defined(Q_OS_MACOS)
 #include <QProcess>
@@ -310,6 +311,27 @@ void ConfigHandler::setAllTheButtons()
     QList<CaptureTool::Type> buttons =
       CaptureToolButton::getIterableButtonTypes();
     setValue(QStringLiteral("buttons"), QVariant::fromValue(buttons));
+}
+
+CaptureConfig::CaptureWindowMode ConfigHandler::windowMode()
+{
+    auto modeEnum = QMetaEnum::fromType<CaptureConfig::CaptureWindowMode>();
+    auto modeString = m_settings.value("windowMode", "").toString().toUtf8();
+    bool ok = false;
+    CaptureConfig::CaptureWindowMode result = static_cast<CaptureConfig::CaptureWindowMode>(modeEnum.keyToValue(modeString.constData(), &ok));
+    if (ok) {
+        return result;
+    }
+#if defined(Q_OS_MACOS)
+    return CaptureConfig::CaptureWindowMode::FullScreenCurrent;
+#endif
+    return CaptureConfig::CaptureWindowMode::FullScreenAll;
+}
+
+void ConfigHandler::setWindowMode(CaptureConfig::CaptureWindowMode mode)
+{
+    auto modeEnum = QMetaEnum::fromType<CaptureConfig::CaptureWindowMode>();
+    m_settings.setValue("windowMode", modeEnum.valueToKey(static_cast<int>(mode)));
 }
 
 // DEFAULTS

--- a/src/utils/confighandler.h
+++ b/src/utils/confighandler.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "src/widgets/capture/capturetoolbutton.h"
+#include "src/widgets/capture/captureconfig.h"
 #include <QSettings>
 #include <QStringList>
 #include <QVariant>
@@ -101,6 +102,8 @@ public:
     QString saveAsFileExtension();
     CONFIG_SETTER(setSaveAsFileExtension, setSaveAsFileExtension, QString)
     void setAllTheButtons();
+    CaptureConfig::CaptureWindowMode windowMode();
+    void setWindowMode(CaptureConfig::CaptureWindowMode);
 
     // DEFAULTS
     QString filenamePatternDefault();

--- a/src/utils/screengrabber.cpp
+++ b/src/utils/screengrabber.cpp
@@ -166,6 +166,19 @@ QPixmap ScreenGrabber::grabEntireDesktop(bool& ok)
 #endif
 }
 
+QPixmap ScreenGrabber::grabScreen(bool& ok)
+{
+    auto current = QGuiAppCurrentScreen().currentScreen();
+    int number = 0;
+    for (QScreen* const screen : QGuiApplication::screens()) {
+        if (screen == current) {
+            return grabScreen(number, ok);
+        }
+        number++;
+    }
+    return grabScreen(-1, ok);
+}
+
 QPixmap ScreenGrabber::grabScreen(int screenNumber, bool& ok)
 {
     QPixmap p;

--- a/src/utils/screengrabber.h
+++ b/src/utils/screengrabber.h
@@ -13,6 +13,7 @@ public:
     explicit ScreenGrabber(QObject* parent = nullptr);
     QPixmap grabEntireDesktop(bool& ok);
     QPixmap grabScreen(int screenNumber, bool& ok);
+    QPixmap grabScreen(bool& ok);
 
 private:
     DesktopInfo m_info;

--- a/src/utils/screengrabber.h
+++ b/src/utils/screengrabber.h
@@ -5,6 +5,7 @@
 
 #include "src/utils/desktopinfo.h"
 #include <QObject>
+#include <QScreen>
 
 class ScreenGrabber : public QObject
 {
@@ -12,6 +13,7 @@ class ScreenGrabber : public QObject
 public:
     explicit ScreenGrabber(QObject* parent = nullptr);
     QPixmap grabEntireDesktop(bool& ok);
+    QPixmap grabScreen(QScreen* screen, bool& ok);
     QPixmap grabScreen(int screenNumber, bool& ok);
     QPixmap grabScreen(bool& ok);
 

--- a/src/widgets/capture/CMakeLists.txt
+++ b/src/widgets/capture/CMakeLists.txt
@@ -4,6 +4,7 @@ target_sources(
         PRIVATE buttonhandler.h
         capturebutton.h
         capturetoolbutton.h
+        captureconfig.h
         capturewidget.h
         colorpicker.h
         hovereventfilter.h

--- a/src/widgets/capture/captureconfig.h
+++ b/src/widgets/capture/captureconfig.h
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+
+#pragma once
+
+#include <QObject>
+
+namespace CaptureConfig {
+    Q_NAMESPACE
+
+    enum CaptureWindowMode {
+        FullScreenAll,
+        FullScreenCurrent,
+        MaximizeWindow,
+        DebugNonFullScreen // TODO: interaction with FLAMESHOT_DEBUG_CAPTURE
+    };
+    Q_ENUM_NS(CaptureWindowMode)
+}

--- a/src/widgets/capture/capturetoolobjects.cpp
+++ b/src/widgets/capture/capturetoolobjects.cpp
@@ -55,6 +55,9 @@ int CaptureToolObjects::find(const QPoint& pos, const QSize& captureSize)
     if (m_captureToolObjects.empty()) {
         return -1;
     }
+    if (!QRect(QPoint(0, 0), captureSize).contains(pos)) {
+        return -1;
+    }
     QPixmap pixmap(captureSize);
     pixmap.fill(Qt::transparent);
     QPainter painter(&pixmap);

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -176,6 +176,11 @@ CaptureWidget::CaptureWidget(uint id,
     setWidget(new PaintBackground(this));
     widget()->resize(m_context.screenshot.size());
     widget()->setMouseTracking(true);
+    if (windowMode == CaptureWindowMode::FullScreenAll ||
+        windowMode == CaptureWindowMode::FullScreenCurrent) {
+        setContentsMargins(0, 0, 0, 0);
+        setFrameShape(QFrame::NoFrame);
+    }
 
     // Create buttons
     m_buttonHandler = new ButtonHandler(this);

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+﻿// SPDX-License-Identifier: GPL-3.0-or-later
 // SPDX-FileCopyrightText: 2017-2019 Alejandro Sirgo Rica & Contributors
 
 // Based on Lightscreen areadialog.cpp, Copyright 2017  Christian Kaiser
@@ -127,7 +127,11 @@ CaptureWidget::CaptureWidget(uint id,
     if (windowMode != CaptureWindowMode::DebugNonFullScreen) {
         // Grab Screenshot
         bool ok = true;
-        m_context.screenshot = ScreenGrabber().grabEntireDesktop(ok);
+        if (m_captureCurrentScreen) {
+            m_context.screenshot = ScreenGrabber().grabScreen(ok);
+        } else {
+            m_context.screenshot = ScreenGrabber().grabEntireDesktop(ok);
+        }
         if (!ok) {
             SystemNotification().sendMessage(tr("Unable to capture screen"));
             this->close();
@@ -702,10 +706,6 @@ void CaptureWidget::mouseMoveEvent(QMouseEvent* e)
                 m_buttonHandler->show();
             }
         }
-    } else if (m_middleClickDrag) {
-        m_viewOffset = (m_initialOffset + -(e->pos() - m_viewDragStartPoint));
-        updateViewTransform();
-        repaint();
     }
     updateCursor();
 }

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -840,6 +840,7 @@ void CaptureWidget::resizeEvent(QResizeEvent* e)
     QWidget::resizeEvent(e);
     m_context.widgetOffset = mapToGlobal(QPoint(0, 0));
     updateButtonRegions();
+    OverlayMessage::UpdateTargetArea(viewport()->rect());
 }
 
 void CaptureWidget::moveEvent(QMoveEvent* e)

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -636,11 +636,13 @@ void CaptureWidget::leaveEvent(QEvent *event)
 {
     m_mouseOutside = true;
     redrawErrorMessage();
+    QScrollArea::leaveEvent(event);
 }
 
 void CaptureWidget::enterEvent(QEvent *event)
 {
     m_mouseOutside = false;
+    QScrollArea::enterEvent(event);
 }
 
 void CaptureWidget::mouseMoveEvent(QMouseEvent* e)
@@ -757,10 +759,14 @@ void CaptureWidget::updateThickness(int thickness)
     updateTool(tool);
     m_context.thickness = qBound(1, thickness, maxDrawThickness);
 
-    QPoint topLeft =
-      QGuiAppCurrentScreen().currentScreen()->geometry().topLeft();
     int offset = m_notifierBox->width() / 4;
-    m_notifierBox->move(mapFromGlobal(topLeft) + QPoint(offset, offset));
+    QPoint notifierBoxPosition(offset, offset);
+    if (windowMode == CaptureWindowMode::FullScreenAll) {
+        QPoint topLeft =
+          QGuiAppCurrentScreen().currentScreen()->geometry().topLeft();
+        notifierBoxPosition += mapFromGlobal(topLeft);
+    }
+    m_notifierBox->move(notifierBoxPosition);
     m_notifierBox->showMessage(QString::number(m_context.thickness));
 
     if (tool && tool->showMousePreview()) {
@@ -854,7 +860,7 @@ void CaptureWidget::wheelEvent(QWheelEvent* e)
 
 void CaptureWidget::resizeEvent(QResizeEvent* e)
 {
-    QWidget::resizeEvent(e);
+    QScrollArea::resizeEvent(e);
     m_context.widgetOffset = mapToGlobal(QPoint(0, 0));
     updateButtonRegions();
     OverlayMessage::UpdateTargetArea(viewport()->rect());
@@ -862,12 +868,13 @@ void CaptureWidget::resizeEvent(QResizeEvent* e)
 
 void CaptureWidget::moveEvent(QMoveEvent* e)
 {
-    QWidget::moveEvent(e);
+    QScrollArea::moveEvent(e);
     m_context.widgetOffset = mapToGlobal(QPoint(0, 0));
 }
 
 void CaptureWidget::changeEvent(QEvent* e)
 {
+    QScrollArea::changeEvent(e);
     if (e->type() == QEvent::ActivationChange) {
         redrawErrorMessage();
     }

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -1220,7 +1220,7 @@ void CaptureWidget::updateActiveLayer(int layer)
 void CaptureWidget::selectAll()
 {
     m_selection->show();
-    m_selection->setGeometry(rect());
+    m_selection->setCaptureGeometry(m_context.screenshot.rect());
     m_buttonHandler->show();
     updateSelectionState();
 }

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -163,7 +163,7 @@ CaptureWidget::CaptureWidget(uint id,
                 }
             }
             move(topLeft);
-            resize(m_context.screenshot.size());
+            setFixedSize(m_context.screenshot.size());
         } else if (windowMode == CaptureWindowMode::FullScreenCurrent) {
             // Emulate fullscreen mode
             //        setWindowFlags(Qt::WindowStaysOnTopHint |f

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -1472,6 +1472,7 @@ void CaptureWidget::drawToolsData()
     // TODO refactor this for performance. The objects should not all be updated
     // at once every time
     QPixmap pixmapItem = m_context.origScreenshot;
+    pixmapItem.setDevicePixelRatio(1);
     int circleCount = 1;
     for (auto toolItem : m_captureToolObjects.captureToolObjects()) {
         if (toolItem->type() == CaptureTool::TYPE_CIRCLECOUNT) {
@@ -1624,9 +1625,7 @@ void CaptureWidget::updateUtilityPanelSize()
 
 void CaptureWidget::updateScale()
 {
-    qDebug() << "update scale " << devicePixelRatioF();
     QSizeF size = m_context.screenshot.rect().size() / devicePixelRatioF();
-    qDebug() << "size.tosize " << size.toSize();
     widget()->resize(size.toSize());
 }
 

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -35,7 +35,9 @@
 #include <QPaintEvent>
 #include <QPainter>
 #include <QScreen>
+#include <QScrollBar>
 #include <QShortcut>
+#include <QtDebug>
 #include <draggablewidgetmaker.h>
 
 #define SPDLOG_ACTIVE_LEVEL SPDLOG_LEVEL_DEBUG
@@ -46,12 +48,34 @@
 // CaptureWidget is the main component used to capture the screen. It contains
 // an area of selection with its respective buttons.
 
+using namespace CaptureConfig;
+
+class PaintBackground : public QWidget
+{
+    CaptureWidget* captureWidget;
+
+public:
+    PaintBackground(CaptureWidget* parent)
+      : QWidget(parent)
+    {
+        captureWidget = parent;
+        setAutoFillBackground(false);
+    }
+
+    void paintEvent(QPaintEvent*) override
+    {
+        QPainter p(this);
+        captureWidget->drawContent(p);
+    }
+};
+
 // enableSaveWindow
 CaptureWidget::CaptureWidget(uint id,
                              const QString& savePath,
-                             bool fullScreen,
+                             CaptureConfig::CaptureWindowMode windowMode,
                              QWidget* parent)
-  : QWidget(parent)
+  : QScrollArea(parent)
+  , windowMode(windowMode)
   , m_mouseIsClicked(false)
   , m_captureDone(false)
   , m_previewEnabled(true)
@@ -72,6 +96,7 @@ CaptureWidget::CaptureWidget(uint id,
   , m_existingObjectIsChanged(false)
   , m_startMove(false)
   , m_thicknessByKeyboard(0)
+  , m_middleClickDrag(false)
 {
     m_undoStack.setUndoLimit(ConfigHandler().undoLimit());
 
@@ -90,14 +115,18 @@ CaptureWidget::CaptureWidget(uint id,
     m_uiColor = m_config.uiColor();
     m_contrastUiColor = m_config.contrastUiColor();
     setMouseTracking(true);
-    initContext(savePath, fullScreen);
+
+    m_captureCurrentScreen = windowMode == CaptureWindowMode::FullScreenCurrent;
+    initContext(savePath,
+                windowMode == CaptureWindowMode::FullScreenAll ||
+                  windowMode == CaptureWindowMode::FullScreenCurrent);
     initSelection();
-    initShortcuts(); // must be called after initSelection
-#if (defined(Q_OS_WIN) || defined(Q_OS_MACOS))
+    initShortcuts();
+
     // Top left of the whole set of screens
     QPoint topLeft(0, 0);
-#endif
-    if (fullScreen) {
+
+    if (windowMode != CaptureWindowMode::DebugNonFullScreen) {
         // Grab Screenshot
         bool ok = true;
         m_context.screenshot = ScreenGrabber().grabEntireDesktop(ok);
@@ -107,72 +136,77 @@ CaptureWidget::CaptureWidget(uint id,
         }
         m_context.origScreenshot = m_context.screenshot;
 
+        if (windowMode == CaptureWindowMode::FullScreenAll) {
 #if defined(Q_OS_WIN)
-        setWindowFlags(Qt::WindowStaysOnTopHint | Qt::FramelessWindowHint |
-                       Qt::Popup);
-
-        for (QScreen* const screen : QGuiApplication::screens()) {
-            QPoint topLeftScreen = screen->geometry().topLeft();
-
-            if (topLeftScreen.x() < topLeft.x()) {
-                topLeft.setX(topLeftScreen.x());
-            }
-            if (topLeftScreen.y() < topLeft.y()) {
-                topLeft.setY(topLeftScreen.y());
-            }
-        }
-        move(topLeft);
-        resize(pixmap().size());
-#elif defined(Q_OS_MACOS)
-        // Emulate fullscreen mode
-        //        setWindowFlags(Qt::WindowStaysOnTopHint |
-        //        Qt::BypassWindowManagerHint |
-        //                       Qt::FramelessWindowHint |
-        //                       Qt::NoDropShadowWindowHint | Qt::ToolTip |
-        //                       Qt::Popup
-        //                       );
-        QScreen* currentScreen = QGuiAppCurrentScreen().currentScreen();
-        move(currentScreen->geometry().x(), currentScreen->geometry().y());
-        resize(currentScreen->size());
+            setWindowFlags(Qt::WindowStaysOnTopHint | Qt::FramelessWindowHint |
+                           Qt::Popup);
 #else
-// Call cmake with -DFLAMESHOT_DEBUG_CAPTURE=ON to enable easier debugging
-#if !defined(FLAMESHOT_DEBUG_CAPTURE)
-        setWindowFlags(Qt::BypassWindowManagerHint | Qt::WindowStaysOnTopHint |
-                       Qt::FramelessWindowHint | Qt::Tool);
-        resize(pixmap().size());
+            setWindowFlags(Qt::BypassWindowManagerHint |
+                           Qt::WindowStaysOnTopHint | Qt::FramelessWindowHint |
+                           Qt::Tool);
 #endif
-#endif
+
+            for (QScreen* const screen : QGuiApplication::screens()) {
+                QPoint topLeftScreen = screen->geometry().topLeft();
+
+                if (topLeftScreen.x() < topLeft.x()) {
+                    topLeft.setX(topLeftScreen.x());
+                }
+                if (topLeftScreen.y() < topLeft.y()) {
+                    topLeft.setY(topLeftScreen.y());
+                }
+            }
+            move(topLeft);
+            resize(m_context.screenshot.size());
+        } else if (windowMode == CaptureWindowMode::FullScreenCurrent) {
+            // Emulate fullscreen mode
+            //        setWindowFlags(Qt::WindowStaysOnTopHint |f
+            //        Qt::BypassWindowManagerHint |
+            //                       Qt::FramelessWindowHint |
+            //                       Qt::NoDropShadowWindowHint | Qt::ToolTip |
+            //                       Qt::Popup
+            //                       );
+            QScreen* currentScreen = QGuiAppCurrentScreen().currentScreen();
+            move(currentScreen->geometry().x(), currentScreen->geometry().y());
+            resize(currentScreen->size());
+        } else if (windowMode == CaptureWindowMode::MaximizeWindow) {
+        }
     }
+
+    setWidget(new PaintBackground(this));
+    widget()->resize(m_context.screenshot.size());
+    widget()->setMouseTracking(true);
+
     // Create buttons
     m_buttonHandler = new ButtonHandler(this);
     initButtons();
     QVector<QRect> areas;
-    if (m_context.fullscreen) {
+    if (windowMode != DebugNonFullScreen) {
         QPoint topLeftOffset = QPoint(0, 0);
 #if defined(Q_OS_WIN)
         topLeftOffset = topLeft;
 #endif
 
-#if defined(Q_OS_MACOS)
-        // MacOS works just with one active display, so we need to append
-        // just one current display and keep multiple displays logic for
-        // other OS
-        QRect r;
-        QScreen* screen = QGuiAppCurrentScreen().currentScreen();
-        r = screen->geometry();
-        // all calculations are processed according to (0, 0) start
-        // point so we need to move current object to (0, 0)
-        r.moveTo(0, 0);
-        areas.append(r);
-#else
-        for (QScreen* const screen : QGuiApplication::screens()) {
-            QRect r = screen->geometry();
-            r.moveTo(r.x() / screen->devicePixelRatio(),
-                     r.y() / screen->devicePixelRatio());
-            r.moveTo(r.topLeft() - topLeftOffset);
+        if (m_captureCurrentScreen) {
+            // MacOS works just with one active display, so we need to append
+            // just one current display and keep multiple displays logic for
+            // other OS
+            QRect r;
+            QScreen* screen = QGuiAppCurrentScreen().currentScreen();
+            r = screen->geometry();
+            // all calculations are processed according to (0, 0) start
+            // point so we need to move current object to (0, 0)
+            r.moveTo(0, 0);
             areas.append(r);
+        } else {
+            for (QScreen* const screen : QGuiApplication::screens()) {
+                QRect r = screen->geometry();
+                r.moveTo(r.x() / screen->devicePixelRatio(),
+                         r.y() / screen->devicePixelRatio());
+                r.moveTo(r.topLeft() - topLeftOffset);
+                areas.append(r);
+            }
         }
-#endif
     } else {
         areas.append(rect());
     }
@@ -198,6 +232,7 @@ CaptureWidget::CaptureWidget(uint id,
     });
 
     initPanel();
+    updateButtonRegions();
 
     m_config.checkAndHandleError();
     if (m_config.hasError()) {
@@ -256,7 +291,7 @@ void CaptureWidget::initButtons()
         b->hide();
         // must be enabled for SelectionWidget's eventFilter to work correctly
         b->setAttribute(Qt::WA_NoMousePropagation);
-        makeChild(b);
+        makeChildMoving(b);
 
         switch (t) {
             case CaptureTool::TYPE_EXIT:
@@ -381,8 +416,11 @@ void CaptureWidget::uncheckActiveTool()
 
 void CaptureWidget::paintEvent(QPaintEvent* paintEvent)
 {
-    Q_UNUSED(paintEvent)
-    QPainter painter(this);
+    QScrollArea::paintEvent(paintEvent);
+}
+
+void CaptureWidget::drawContent(QPainter& painter)
+{
     painter.drawPixmap(0, 0, m_context.screenshot);
 
     if (m_activeTool && m_mouseIsClicked) {
@@ -454,7 +492,8 @@ bool CaptureWidget::startDrawObjectTool(const QPoint& pos)
                 &CaptureTool::requestAction,
                 this,
                 &CaptureWidget::handleToolSignal);
-        m_context.mousePos = pos;
+        m_context.mousePos = widgetToCapturePoint(pos);
+
         m_activeTool->drawStart(m_context);
         // TODO this is the wrong place to do this
         if (m_activeTool->type() == CaptureTool::TYPE_CIRCLECOUNT) {
@@ -484,15 +523,16 @@ int CaptureWidget::selectToolItemAtPos(const QPoint& pos)
 {
     // Try to select existing tool, "-1" - no active tool
     int activeLayerIndex = -1;
-    auto selectionMouseSide = m_selection->getMouseSide(pos);
+    auto selectionMouseSide = m_selection->getMouseSide(scrollWidgetPoint(pos));
     if (m_activeButton.isNull() &&
         m_captureToolObjects.captureToolObjects().size() > 0 &&
         (selectionMouseSide == SelectionWidget::NO_SIDE ||
          selectionMouseSide == SelectionWidget::CENTER)) {
+        auto capturePoint = widgetToCapturePoint(pos);
         auto toolItem = activeToolObject();
         if (!toolItem ||
-            (toolItem && !toolItem->boundingRect().contains(pos))) {
-            activeLayerIndex = m_captureToolObjects.find(pos, size());
+            (toolItem && !toolItem->boundingRect().contains(capturePoint))) {
+            activeLayerIndex = m_captureToolObjects.find(capturePoint, m_context.screenshot.size());
             int thickness_old = m_context.thickness;
             m_panel->setActiveLayer(activeLayerIndex);
             drawObjectSelection();
@@ -515,9 +555,12 @@ void CaptureWidget::mousePressEvent(QMouseEvent* e)
         updateCursor();
         return;
     }
+    auto scrollWidgetPos = scrollWidgetPoint(
+      m_mousePressedPos); // position relative to ScrollArea::widget
+    auto capturePoint = widgetToCapturePoint(m_mousePressedPos);
 
     // reset object selection if capture area selection is active
-    if (m_selection->getMouseSide(e->pos()) != SelectionWidget::CENTER) {
+    if (m_selection->getMouseSide(scrollWidgetPos) != SelectionWidget::CENTER) {
         m_panel->setActiveLayer(-1);
     }
 
@@ -536,6 +579,13 @@ void CaptureWidget::mousePressEvent(QMouseEvent* e)
             // return if success
             return;
         }
+    } else if (e->button() == Qt::MiddleButton && allowMoving()) {
+        m_middleClickDrag = true;
+        m_viewDragStartPoint = e->pos();
+        m_initialOffset = m_viewOffset;
+        updateViewTransform();
+        updateCursor();
+        return;
     }
 
     // Commit current tool if it has edit widget and mouse click is outside
@@ -577,12 +627,16 @@ void CaptureWidget::mouseDoubleClickEvent(QMouseEvent* event)
 
 void CaptureWidget::mouseMoveEvent(QMouseEvent* e)
 {
-    m_context.mousePos = e->pos();
+    m_context.mousePos = widgetToCapturePoint(e->pos());
+    auto scrollWidgetPos = scrollWidgetPoint(e->pos()); // position relative to ScrollArea::widget
     if (e->buttons() != Qt::LeftButton) {
         updateTool(activeButtonTool());
         updateCursor();
         return;
     }
+
+    // Repaint to ensure that preview is displayed at correct position
+    widget()->repaint();
 
     // The rest assumes that left mouse button is clicked
     if (!m_activeButton && m_panel->activeLayerIndex() >= 0) {
@@ -601,7 +655,7 @@ void CaptureWidget::mouseMoveEvent(QMouseEvent* e)
             QPointer<CaptureTool> activeTool =
               m_captureToolObjects.at(m_panel->activeLayerIndex());
             if (m_activeToolOffsetToMouseOnStart.isNull()) {
-                setCursor(Qt::ClosedHandCursor);
+                widget()->setCursor(Qt::ClosedHandCursor);
                 m_activeToolOffsetToMouseOnStart =
                   e->pos() - *activeTool->pos();
             }
@@ -619,9 +673,9 @@ void CaptureWidget::mouseMoveEvent(QMouseEvent* e)
     } else if (m_activeTool) {
         // drawing with a tool
         if (m_adjustmentButtonPressed) {
-            m_activeTool->drawMoveWithAdjustment(e->pos());
+            m_activeTool->drawMoveWithAdjustment(m_context.mousePos);
         } else {
-            m_activeTool->drawMove(e->pos());
+            m_activeTool->drawMove(m_context.mousePos);
         }
         // update drawing object
         updateTool(m_activeTool);
@@ -629,13 +683,17 @@ void CaptureWidget::mouseMoveEvent(QMouseEvent* e)
         // them.
         if (m_buttonHandler->buttonsAreInside()) {
             const bool containsMouse =
-              m_buttonHandler->contains(m_context.mousePos);
+              m_buttonHandler->contains(m_context.mousePos); // TODO: probably wrong position
             if (containsMouse) {
                 m_buttonHandler->hide();
             } else if (m_selection->isVisible()) {
                 m_buttonHandler->show();
             }
         }
+    } else if (m_middleClickDrag) {
+        m_viewOffset = (m_initialOffset + -(e->pos() - m_viewDragStartPoint));
+        updateViewTransform();
+        repaint();
     }
     updateCursor();
 }
@@ -669,8 +727,10 @@ void CaptureWidget::mouseReleaseEvent(QMouseEvent* e)
             }
         }
     }
+
     m_mouseIsClicked = false;
     m_activeToolIsMoved = false;
+    m_middleClickDrag = false;
 
     updateSelectionState();
     updateCursor();
@@ -781,10 +841,7 @@ void CaptureWidget::resizeEvent(QResizeEvent* e)
 {
     QWidget::resizeEvent(e);
     m_context.widgetOffset = mapToGlobal(QPoint(0, 0));
-    if (!m_context.fullscreen) {
-        m_panel->setFixedHeight(height());
-        m_buttonHandler->updateScreenRegions(rect());
-    }
+    updateButtonRegions();
 }
 
 void CaptureWidget::moveEvent(QMoveEvent* e)
@@ -801,6 +858,19 @@ void CaptureWidget::changeEvent(QEvent* e)
         // used for the update rect
         update(QRect(bottomRight - QPoint(1000, 200), bottomRight));
     }
+}
+
+void CaptureWidget::scrollContentsBy(int dx, int dy)
+{
+    Q_UNUSED(dx);
+    Q_UNUSED(dy);
+
+    m_viewOffset =
+      (QPointF(horizontalScrollBar()->value(), verticalScrollBar()->value()) *
+       m_viewScale)
+        .toPoint();
+    updateViewTransform(false);
+    QScrollArea::scrollContentsBy(dx, dy);
 }
 
 void CaptureWidget::initContext(const QString& savePath, bool fullscreen)
@@ -939,14 +1009,15 @@ void CaptureWidget::showAppUpdateNotification(const QString& appLatestVersion,
 
 void CaptureWidget::initSelection()
 {
-    m_selection = new SelectionWidget(m_uiColor, this);
+    m_selection = new SelectionWidget(m_uiColor, widget());
     m_selection->setVisible(false);
-    m_selection->setGeometry(QRect());
+    m_selection->setCaptureGeometry(QRect());
     connect(m_selection, &SelectionWidget::geometryChanged, this, [this]() {
         m_buttonHandler->updatePosition(m_selection->geometry());
         QRect constrainedToCaptureArea =
-          m_selection->geometry().intersected(rect());
-        m_context.selection = extendedRect(constrainedToCaptureArea);
+          m_selection->captureGeometry().intersected(m_context.screenshot.rect());
+        //TODO: handle all
+        m_context.selection = constrainedToCaptureArea;
         updateSizeIndicator();
         m_buttonHandler->hide();
         updateCursor();
@@ -1277,17 +1348,17 @@ void CaptureWidget::updateSizeIndicator()
 void CaptureWidget::updateCursor()
 {
     if (m_colorPicker && m_colorPicker->isVisible()) {
-        setCursor(Qt::ArrowCursor);
+        widget()->setCursor(Qt::ArrowCursor);
     } else if (m_activeButton != nullptr &&
                activeButtonToolType() != CaptureTool::TYPE_MOVESELECTION) {
-        setCursor(Qt::CrossCursor);
-    } else if (m_selection->getMouseSide(mapFromGlobal(QCursor::pos())) !=
+        widget()->setCursor(Qt::CrossCursor);
+    } else if (m_selection->getMouseSide(scrollWidgetPoint(mapFromGlobal(QCursor::pos()))) !=
                SelectionWidget::NO_SIDE) {
-        setCursor(m_selection->cursor());
+        widget()->setCursor(m_selection->cursor());
     } else if (activeButtonToolType() == CaptureTool::TYPE_MOVESELECTION) {
-        setCursor(Qt::OpenHandCursor);
+        widget()->setCursor(Qt::OpenHandCursor);
     } else {
-        setCursor(Qt::CrossCursor);
+        widget()->setCursor(Qt::CrossCursor);
     }
 }
 
@@ -1439,6 +1510,61 @@ void CaptureWidget::makeChild(QWidget* w)
     w->installEventFilter(m_eventFilter);
 }
 
+void CaptureWidget::makeChildMoving(QWidget* w)
+{
+    w->setParent(this->widget());
+    w->installEventFilter(m_eventFilter);
+}
+
+bool CaptureWidget::allowMoving()
+{
+    return horizontalScrollBar()->isVisible() || verticalScrollBar()->isVisible();
+    //return windowMode == CaptureWindowMode::MaximizeWindow;
+}
+
+void CaptureWidget::updateViewTransform(bool updateScrollbars)
+{
+    if (!updateScrollbars) {
+        m_viewTransform =
+          QTransform::fromTranslate(m_viewOffset.x(), m_viewOffset.y());
+        m_viewTransform.scale(m_viewScale, m_viewScale);
+        m_selection->SetScale(m_viewScale);
+    } else {
+        auto b = m_viewOffset;
+        horizontalScrollBar()->setValue(b.x());
+        verticalScrollBar()->setValue(b.y());
+        m_viewOffset =
+          QPoint(horizontalScrollBar()->value(), verticalScrollBar()->value());
+    }
+    updateButtonRegions();
+    m_buttonHandler->updatePosition(m_selection->geometry());
+}
+
+QPoint CaptureWidget::widgetToCapturePoint(QPoint point)
+{
+    return m_viewTransform.map(point);
+    // return m_viewOffset + point * m_viewScale;
+}
+
+QPoint CaptureWidget::scrollWidgetPoint(QPoint p)
+{
+    return p - (viewport()->pos() + widget()->pos());
+}
+
+void CaptureWidget::updateButtonRegions()
+{
+    if (allowMoving()) {
+        m_panel->setFixedHeight(height());
+        QRect visibleRegion = viewport()->rect().translated(-widget()->pos());
+        m_buttonHandler->updateScreenRegions(visibleRegion);
+    }
+}
+
+QPoint CaptureWidget::scrollPosition() const
+{
+    return QPoint(horizontalScrollBar()->value(), verticalScrollBar()->value());
+}
+
 void CaptureWidget::togglePanel()
 {
     m_panel->toggle();
@@ -1497,6 +1623,30 @@ void CaptureWidget::setCaptureToolObjects(
     drawObjectSelection();
 }
 
+void CaptureWidget::OpenAndShow()
+{
+    switch (windowMode) {
+        case FullScreenAll:
+#if defined(Q_OS_WIN)
+            show();
+#else
+            showFullScreen();
+#endif
+            break;
+        case FullScreenCurrent:
+            showFullScreen();
+            activateWindow();
+            raise();
+            break;
+        case MaximizeWindow:
+            showMaximized();
+            break;
+        case DebugNonFullScreen:
+            show();
+            break;
+    }
+}
+
 void CaptureWidget::undo()
 {
     if (m_activeTool &&
@@ -1530,8 +1680,9 @@ QRect CaptureWidget::extendedSelection() const
     if (!m_selection->isVisible()) {
         return QRect();
     }
-    QRect r = m_selection->geometry();
-    return extendedRect(r);
+    return m_selection->captureGeomtry();
+    // QRect r = m_selection->geometry(); //TODO: cleanup
+    // return extendedRect(&r);
 }
 
 QRect CaptureWidget::extendedRect(const QRect& r) const
@@ -1570,15 +1721,18 @@ void CaptureWidget::drawErrorMessage(const QString& msg, QPainter* painter)
 
 void CaptureWidget::drawInactiveRegion(QPainter* painter)
 {
+    QTransform captureToView = m_viewTransform.inverted();
     QColor overlayColor(0, 0, 0, m_opacity);
     painter->setBrush(overlayColor);
     QRect r;
     if (m_selection->isVisible()) {
-        r = m_selection->geometry().normalized();
+        r = m_selection->captureGeomtry().normalized().adjusted(0, 0, -1, -1);
     }
-    QRegion grey(rect());
+    QRect visiblePart = m_viewTransform.mapRect(viewport()->rect());
+
+    QRegion grey(visiblePart);
     grey = grey.subtracted(r);
 
     painter->setClipRegion(grey);
-    painter->drawRect(-1, -1, rect().width() + 1, rect().height() + 1);
+    painter->drawRect(visiblePart.adjusted(-1, -1, 1, 1));
 }

--- a/src/widgets/capture/capturewidget.h
+++ b/src/widgets/capture/capturewidget.h
@@ -37,6 +37,7 @@ class HoverEventFilter;
 class UpdateNotificationWidget;
 class UtilityPanel;
 class SidePanelWidget;
+class DraggableWidgetMaker;
 
 class CaptureWidget : public QScrollArea
 {
@@ -133,6 +134,7 @@ private:
     void updateViewTransform(bool updateScrollbars = true);
     QPoint scrollPosition() const;
     void updateButtonRegions();
+    void updateUtilityPanelSize();
 
     void updateThickness(int thicknessOffset);
 
@@ -187,6 +189,8 @@ private:
 
     ButtonHandler* m_buttonHandler;
     UtilityPanel* m_panel;
+    QPushButton* m_panelButton = nullptr;
+    DraggableWidgetMaker* m_panelButtonMover = nullptr;
     SidePanelWidget* m_sidePanel;
     ColorPicker* m_colorPicker;
     ConfigHandler m_config;

--- a/src/widgets/capture/capturewidget.h
+++ b/src/widgets/capture/capturewidget.h
@@ -88,6 +88,7 @@ private slots:
 
 public:
     void removeToolObject(int index = -1);
+    QPoint widgetToCapturePoint(QPoint point);
 
 protected:
     void paintEvent(QPaintEvent* paintEvent) override;
@@ -127,7 +128,6 @@ private:
     void makeChildMoving(QWidget* w);
     bool allowMoving();
     void updateViewTransform(bool updateScrollbars = true);
-    QPoint widgetToCapturePoint(QPoint point);
     QPoint scrollWidgetPoint(QPoint);
     QPoint scrollPosition() const;
     void updateButtonRegions();

--- a/src/widgets/capture/capturewidget.h
+++ b/src/widgets/capture/capturewidget.h
@@ -89,7 +89,7 @@ private slots:
 
 public:
     void removeToolObject(int index = -1);
-    QPoint widgetToCapturePoint(QPoint point);
+    QPoint widgetToCapturePoint(QPointF point);
     QPoint scrollWidgetPoint(QPoint);
     QPoint scrollWidgetPointToThis(QPoint);
     QRect imageSize() const;
@@ -136,7 +136,10 @@ private:
     void updateViewTransform(bool updateScrollbars = true);
     QPoint scrollPosition() const;
     void updateButtonRegions();
+    void refreshToolButtonVisibility();
     void updateUtilityPanelSize();
+    void updateScale();
+    void handleScaleFactorChange();
 
     void updateThickness(int thicknessOffset);
 

--- a/src/widgets/capture/capturewidget.h
+++ b/src/widgets/capture/capturewidget.h
@@ -100,6 +100,8 @@ protected:
     void mouseMoveEvent(QMouseEvent* mouseEvent) override;
     void mouseReleaseEvent(QMouseEvent* mouseEvent) override;
     void mouseDoubleClickEvent(QMouseEvent* event) override;
+    void leaveEvent(QEvent *event) override;
+    void enterEvent(QEvent *event) override;
     void keyPressEvent(QKeyEvent* keyEvent) override;
     void keyReleaseEvent(QKeyEvent* keyEvent) override;
     void wheelEvent(QWheelEvent* wheelEvent) override;
@@ -145,6 +147,7 @@ private:
     void drawInactiveRegion(QPainter* painter);
     void drawToolsData();
     void drawObjectSelection();
+    void redrawErrorMessage();
 
     void processPixmapWithTool(QPixmap* pixmap, CaptureTool* tool);
 
@@ -177,6 +180,8 @@ private:
     bool m_adjustmentButtonPressed;
     bool m_configError;
     bool m_configErrorResolved;
+    bool m_mouseOutside = false;
+    bool m_hadErrorMessage = false;
 
     UpdateNotificationWidget* m_updateNotificationWidget;
     quint64 m_lastMouseWheel;

--- a/src/widgets/capture/capturewidget.h
+++ b/src/widgets/capture/capturewidget.h
@@ -89,6 +89,9 @@ private slots:
 public:
     void removeToolObject(int index = -1);
     QPoint widgetToCapturePoint(QPoint point);
+    QPoint scrollWidgetPoint(QPoint);
+    QPoint scrollWidgetPointToThis(QPoint);
+    QRect imageSize() const;
 
 protected:
     void paintEvent(QPaintEvent* paintEvent) override;
@@ -128,7 +131,6 @@ private:
     void makeChildMoving(QWidget* w);
     bool allowMoving();
     void updateViewTransform(bool updateScrollbars = true);
-    QPoint scrollWidgetPoint(QPoint);
     QPoint scrollPosition() const;
     void updateButtonRegions();
 

--- a/src/widgets/capture/capturewidget.h
+++ b/src/widgets/capture/capturewidget.h
@@ -138,8 +138,10 @@ private:
     void updateButtonRegions();
     void refreshToolButtonVisibility();
     void updateUtilityPanelSize();
-    void updateScale();
+    void updateScale(int iteration = 0);
     void handleScaleFactorChange();
+    QRect preferredWindowGeometry(QScreen *screen = nullptr) const;
+    QScreen* guessFullscreenScreen();
 
     void updateThickness(int thicknessOffset);
 
@@ -209,6 +211,8 @@ private:
     QPoint m_viewDragStartPoint; // widget coordinates
     SelectionWidget::SideType m_mouseOverHandle;
     uint m_id;
+    QPoint m_topLeftCorner; // position of top left image corner relative to screen geomtry 0,0
+    int windowGeometryUpdateActive = 0;
 
     CaptureToolObjects m_captureToolObjects;
     CaptureToolObjects m_captureToolObjectsBackup;

--- a/src/widgets/capture/colorpicker.cpp
+++ b/src/widgets/capture/colorpicker.cpp
@@ -125,6 +125,14 @@ void ColorPicker::mouseMoveEvent(QMouseEvent* e)
     }
 }
 
+void ColorPicker::mouseReleaseEvent(QMouseEvent *event)
+{
+    if (event->button() == Qt::MouseButton::LeftButton) {
+        hide();
+        emit colorSelected(m_colorList.at(m_selectedIndex));
+    }
+}
+
 void ColorPicker::showEvent(QShowEvent* event)
 {
     grabMouse();
@@ -133,5 +141,4 @@ void ColorPicker::showEvent(QShowEvent* event)
 void ColorPicker::hideEvent(QHideEvent* event)
 {
     releaseMouse();
-    emit colorSelected(m_colorList.at(m_selectedIndex));
 }

--- a/src/widgets/capture/colorpicker.h
+++ b/src/widgets/capture/colorpicker.h
@@ -18,6 +18,7 @@ protected:
     void paintEvent(QPaintEvent* event) override;
     void repaint(int i, QPainter& painter);
     void mouseMoveEvent(QMouseEvent*);
+    void mouseReleaseEvent(QMouseEvent *);
     void showEvent(QShowEvent* event) override;
     void hideEvent(QHideEvent* event) override;
 

--- a/src/widgets/capture/overlaymessage.cpp
+++ b/src/widgets/capture/overlaymessage.cpp
@@ -27,6 +27,12 @@ void OverlayMessage::init(QWidget* parent, const QRect& targetArea)
     new OverlayMessage(parent, targetArea);
 }
 
+void OverlayMessage::UpdateTargetArea(const QRect &targetArea)
+{
+    m_instance->m_targetArea = targetArea;
+    m_instance->updateGeometry();
+}
+
 void OverlayMessage::push(const QString& msg)
 {
     m_instance->m_messageStack.push(msg);

--- a/src/widgets/capture/overlaymessage.h
+++ b/src/widgets/capture/overlaymessage.h
@@ -23,6 +23,7 @@ public:
     OverlayMessage() = delete;
 
     static void init(QWidget* parent, const QRect& targetArea);
+    static void UpdateTargetArea(const QRect& targetArea);
     static void push(const QString& msg);
     static void pop();
     static void setVisibility(bool visible);

--- a/src/widgets/capture/selectionwidget.cpp
+++ b/src/widgets/capture/selectionwidget.cpp
@@ -148,6 +148,11 @@ QRect SelectionWidget::fullGeometry() const
     return QWidget::geometry();
 }
 
+void SelectionWidget::refreshGeometry()
+{
+    setGeometry(captureToWidgetRect(m_captureGeometry));
+}
+
 QRect SelectionWidget::rect() const
 {
     return QWidget::rect() - QMargins(MARGIN, MARGIN, MARGIN, MARGIN);
@@ -266,7 +271,7 @@ void SelectionWidget::parentMouseMoveEvent(QMouseEvent* e)
                 auto captureMoveAmount = captureWidget->widgetToCapturePoint(dragAmount)
                          - captureWidget->widgetToCapturePoint(QPoint(0, 0));
                 m_captureGeometry.translate(captureMoveAmount);
-                move(this->pos() + dragAmount);
+                move(m_captureToWidgetTransform.map(m_captureGeometry.topLeft()) - QPoint(MARGIN, MARGIN));
                 m_dragStartPos = pos;
             }
             return;
@@ -287,7 +292,7 @@ void SelectionWidget::parentMouseMoveEvent(QMouseEvent* e)
     m_dragStartPos = pos;
 }
 
-QRect SelectionWidget::captureGeomtry()
+QRect SelectionWidget::captureGeomtry() const
 {
     return m_captureGeometry;
 }
@@ -295,17 +300,18 @@ QRect SelectionWidget::captureGeomtry()
 void SelectionWidget::setCaptureGeometry(QRect rect)
 {
     m_captureGeometry = rect;
-    setGeometry(captureToWidgetRect(rect));
+    refreshGeometry();
 }
 
 void SelectionWidget::SetScale(float v)
 {
-    transform = QTransform::fromScale(v, v);
+    v = 1 / v;
+    m_captureToWidgetTransform = QTransform::fromScale(v, v);
 }
 
 QRect SelectionWidget::captureToWidgetRect(QRect rect)
 {
-    return transform.mapRect(rect);
+    return m_captureToWidgetTransform.mapRect(rect);
 }
 
 void SelectionWidget::paintEvent(QPaintEvent*)

--- a/src/widgets/capture/selectionwidget.cpp
+++ b/src/widgets/capture/selectionwidget.cpp
@@ -121,9 +121,10 @@ void SelectionWidget::setIdleCentralCursor(const QCursor& cursor)
 
 void SelectionWidget::setGeometryAnimated(const QRect& r)
 {
+    m_captureGeometry = r;
     if (isVisible()) {
         m_animation->setStartValue(geometry());
-        m_animation->setEndValue(r);
+        m_animation->setEndValue(captureToWidgetRect(r));
         m_animation->start();
     }
 }
@@ -272,6 +273,28 @@ void SelectionWidget::parentMouseMoveEvent(QMouseEvent* e)
         m_activeSide = getProperSide(m_activeSide, geom);
     }
     m_dragStartPos = pos;
+}
+
+QRect SelectionWidget::captureGeomtry()
+{
+    return m_captureGeometry;
+}
+
+void SelectionWidget::setCaptureGeometry(QRect rect)
+{
+    m_captureGeometry = rect;
+    setGeometry(captureToWidgetRect(rect));
+    emit resized();
+}
+
+void SelectionWidget::SetScale(float v)
+{
+    transform = QTransform::fromScale(v, v);
+}
+
+QRect SelectionWidget::captureToWidgetRect(QRect rect)
+{
+    return transform.mapRect(rect);
 }
 
 void SelectionWidget::paintEvent(QPaintEvent*)

--- a/src/widgets/capture/selectionwidget.h
+++ b/src/widgets/capture/selectionwidget.h
@@ -38,10 +38,11 @@ public:
     void setGeometry(const QRect& r);
     QRect geometry() const;
     QRect fullGeometry() const;
+    void refreshGeometry();
 
     QRect rect() const;
 
-    QRect captureGeomtry();
+    QRect captureGeomtry() const;
     void setCaptureGeometry(QRect rect);
     void SetScale(float v);
     QRect captureToWidgetRect(QRect rect);
@@ -93,7 +94,7 @@ private:
     bool m_mouseStartMove;
 
     QRect m_captureGeometry;
-    QTransform transform;
+    QTransform m_captureToWidgetTransform;
 
     // naming convention for handles
     // T top, B bottom, R Right, L left

--- a/src/widgets/capture/selectionwidget.h
+++ b/src/widgets/capture/selectionwidget.h
@@ -40,6 +40,11 @@ public:
 
     QRect rect() const;
 
+    QRect captureGeomtry();
+    void setCaptureGeometry(QRect rect);
+    void SetScale(float v);
+    QRect captureToWidgetRect(QRect rect);
+
 protected:
     bool eventFilter(QObject*, QEvent*) override;
     void parentMousePressEvent(QMouseEvent* e);
@@ -84,6 +89,9 @@ private:
     QCursor m_idleCentralCursor;
     bool m_ignoreMouse;
     bool m_mouseStartMove;
+
+    QRect m_captureGeometry;
+    QTransform transform;
 
     // naming convention for handles
     // T top, B bottom, R Right, L left

--- a/src/widgets/capture/selectionwidget.h
+++ b/src/widgets/capture/selectionwidget.h
@@ -6,6 +6,7 @@
 #include <QWidget>
 
 class QPropertyAnimation;
+class CaptureWidget;
 
 class SelectionWidget : public QWidget
 {
@@ -25,7 +26,7 @@ public:
         CENTER = 0b10000,
     };
 
-    explicit SelectionWidget(const QColor& c, QWidget* parent = nullptr);
+    explicit SelectionWidget(const QColor& c, QWidget* parent, CaptureWidget *captureWidget);
 
     SideType getMouseSide(const QPoint& mousePos) const;
     QVector<QRect> handlerAreas();
@@ -77,6 +78,7 @@ private:
     void updateAreas();
     void updateCursor();
     void setGeometryByKeyboard(const QRect& r);
+    QPoint scrollToCapturePoint(QPoint);
 
     QPropertyAnimation* m_animation;
 
@@ -102,4 +104,5 @@ private:
 
     QRect m_TLArea, m_TRArea, m_BLArea, m_BRArea;
     QRect m_LArea, m_TArea, m_RArea, m_BArea;
+    CaptureWidget *captureWidget;
 };

--- a/src/widgets/draggablewidgetmaker.cpp
+++ b/src/widgets/draggablewidgetmaker.cpp
@@ -45,6 +45,7 @@ bool DraggableWidgetMaker::eventFilter(QObject* obj, QEvent* event)
                     QPoint totalMovedDiff = eventPos - m_mousePressPos;
                     if (totalMovedDiff.manhattanLength() > 3) {
                         m_isDragging = true;
+                        m_hasMoved = true;
                     }
                 }
 

--- a/src/widgets/draggablewidgetmaker.h
+++ b/src/widgets/draggablewidgetmaker.h
@@ -15,6 +15,7 @@ public:
     DraggableWidgetMaker(QObject* parent = nullptr);
 
     void makeDraggable(QWidget* widget);
+    bool hasMoved() const { return m_hasMoved; }
 
 protected:
     bool eventFilter(QObject* obj, QEvent* event) override;
@@ -22,6 +23,7 @@ protected:
 private:
     bool m_isPressing = false;
     bool m_isDragging = false;
+    bool m_hasMoved = false;
     QPoint m_mouseMovePos;
     QPoint m_mousePressPos;
 };

--- a/src/widgets/panel/colorgrabwidget.cpp
+++ b/src/widgets/panel/colorgrabwidget.cpp
@@ -115,8 +115,9 @@ bool ColorGrabWidget::eventFilter(QObject*, QEvent* event)
 
         // Hide overlay message when cursor is over it
         OverlayMessage* overlayMsg = OverlayMessage::instance();
+        auto overlayCursorPos = overlayMsg->parentWidget()->mapFromGlobal(cursorPos());
         overlayMsg->setVisibility(
-          !overlayMsg->geometry().contains(cursorPos()));
+          !overlayMsg->geometry().contains(overlayCursorPos));
 
         m_color = getColorAtPoint(cursorPos());
         emit colorUpdated(m_color);

--- a/src/widgets/panel/colorgrabwidget.h
+++ b/src/widgets/panel/colorgrabwidget.h
@@ -5,14 +5,16 @@
 
 class SidePanelWidget;
 class OverlayMessage;
+class CaptureWidget;
 
 class ColorGrabWidget : public QWidget
 {
     Q_OBJECT
 public:
-    ColorGrabWidget(QPixmap* p, QWidget* parent = nullptr);
+    ColorGrabWidget(QPixmap* p, CaptureWidget *captureWidget, QWidget* parent = nullptr);
 
     void startGrabbing();
+    void abort();
 
     QColor color();
 
@@ -32,10 +34,13 @@ private:
     void setMagnifierActive(bool active);
     void updateWidget();
     void finalize();
+    void UpdateCapturePoint(QMouseEvent* event);
 
     QPixmap* m_pixmap;
+    CaptureWidget* m_captureWidget;
     QImage m_previewImage;
     QColor m_color;
+    QPoint m_capturePoint;
 
     bool m_mousePressReceived;
     bool m_extraZoomActive;

--- a/src/widgets/panel/sidepanelwidget.cpp
+++ b/src/widgets/panel/sidepanelwidget.cpp
@@ -126,7 +126,7 @@ void SidePanelWidget::updateThickness(const int& t)
 void SidePanelWidget::startColorGrab()
 {
     m_revertColor = m_color;
-    m_colorGrabber = new ColorGrabWidget(m_pixmap, m_captureWidget);
+    m_colorGrabber = new ColorGrabWidget(m_pixmap, m_captureWidget, m_captureWidget);
     connect(m_colorGrabber,
             &ColorGrabWidget::colorUpdated,
             this,

--- a/src/widgets/panel/sidepanelwidget.h
+++ b/src/widgets/panel/sidepanelwidget.h
@@ -14,6 +14,8 @@ class ColorGrabWidget;
 class QColorPickingEventFilter;
 class QSlider;
 
+class CaptureWidget;
+
 constexpr int maxDrawThickness = 50;
 
 class SidePanelWidget : public QWidget
@@ -23,7 +25,8 @@ class SidePanelWidget : public QWidget
     friend class QColorPickingEventFilter;
 
 public:
-    explicit SidePanelWidget(QPixmap* p, QWidget* parent = nullptr);
+    explicit SidePanelWidget(QPixmap* p, CaptureWidget* parent = nullptr);
+    ~SidePanelWidget();
 
 signals:
     void colorChanged(const QColor& c);
@@ -54,6 +57,7 @@ private:
     QLabel* m_colorLabel;
     QLineEdit* m_colorHex;
     QPixmap* m_pixmap;
+    CaptureWidget* m_captureWidget;
     QColor m_color;
     QColor m_revertColor;
     QSlider* m_thicknessSlider;

--- a/src/widgets/panel/sidepanelwidget.h
+++ b/src/widgets/panel/sidepanelwidget.h
@@ -52,7 +52,7 @@ private:
 
     QVBoxLayout* m_layout;
     QPushButton* m_colorGrabButton;
-    ColorGrabWidget* m_colorGrabber;
+    ColorGrabWidget* m_colorGrabber = nullptr;
     color_widgets::ColorWheel* m_colorWheel;
     QLabel* m_colorLabel;
     QLineEdit* m_colorHex;

--- a/src/widgets/panel/utilitypanel.cpp
+++ b/src/widgets/panel/utilitypanel.cpp
@@ -12,7 +12,6 @@
 
 UtilityPanel::UtilityPanel(CaptureWidget* captureWidget)
   : QWidget(captureWidget)
-  , m_captureWidget(captureWidget)
   , m_internalPanel(nullptr)
   , m_upLayout(nullptr)
   , m_bottomLayout(nullptr)
@@ -22,6 +21,7 @@ UtilityPanel::UtilityPanel(CaptureWidget* captureWidget)
   , m_layersLayout(nullptr)
   , m_captureTools(nullptr)
   , m_buttonDelete(nullptr)
+  , m_captureWidget(captureWidget)
 {
     initInternalPanel();
     setAttribute(Qt::WA_TransparentForMouseEvents);
@@ -198,6 +198,12 @@ void UtilityPanel::onCurrentRowChanged(int currentRow)
         m_buttonDelete->setDisabled(true);
     }
     emit layerChanged(activeLayerIndex());
+}
+
+void UtilityPanel::resizeEvent(QResizeEvent *event)
+{
+    m_internalPanel->setFixedSize(size());
+    QWidget::resizeEvent(event);
 }
 
 void UtilityPanel::slotButtonDelete(bool clicked)

--- a/src/widgets/panel/utilitypanel.cpp
+++ b/src/widgets/panel/utilitypanel.cpp
@@ -26,7 +26,7 @@ UtilityPanel::UtilityPanel(CaptureWidget* captureWidget)
     initInternalPanel();
     setAttribute(Qt::WA_TransparentForMouseEvents);
     setCursor(Qt::ArrowCursor);
-
+    
     m_showAnimation = new QPropertyAnimation(m_internalPanel, "geometry", this);
     m_showAnimation->setEasingCurve(QEasingCurve::InOutQuad);
     m_showAnimation->setDuration(300);
@@ -85,9 +85,6 @@ void UtilityPanel::show()
     m_showAnimation->setEndValue(QRect(0, 0, width(), height()));
     m_internalPanel->show();
     m_showAnimation->start();
-#if (defined(Q_OS_WIN) || defined(Q_OS_MACOS))
-    move(0, 0);
-#endif
     QWidget::show();
 }
 

--- a/src/widgets/panel/utilitypanel.h
+++ b/src/widgets/panel/utilitypanel.h
@@ -41,6 +41,9 @@ public slots:
     void slotButtonDelete(bool clicked);
     void onCurrentRowChanged(int currentRow);
 
+protected:
+    void resizeEvent(QResizeEvent *event) override;
+
 private:
     void initInternalPanel();
 


### PR DESCRIPTION
Properly handling multiple screens with varying scaling factors is challenging. I saw few attempts fixing it, but I am not sure if a sufficiently robust solution which works in all configurations on all the desktop operating systems will be reached anytime soon. That doesn't mean people shouldn't try.

I am suggesting an alternative simpler approach which could be user selected to make flameshot somewhat somewhat usable in setups where it couldn't be used otherwise. Instead of trying to show captured image on all the screens in fullscreen mode display it in a window with ability to move around and maybe zoom.

Having this mode might even help resolving some of the issues related to mixed display setups incrementally without solving all of them at the same time.

The code itself isn't ready yet, I wanted to discuss the approach first before spending more work on the code.

What's currently there:
* Added option for choosing one of 3 modes: all screen fullscreen, current screen fullscreen, maximized window. The first one is not available on macOS.
* CaptureWidget opens in selected mode
* In window mode view can be dragged around using middle click
* tools and preview are drawn taking current view offset into account

What's missing, needs to be done, known issues:

* Testing on all the platforms and various display configs.
* Cleanup the code to comply with this projects coding style and other contribution requirements
* in current screen fullscreen mode capture image from corresponding screen only (partially works)
* Cursor sometimes disapears in color picker
* Ctrl->C shortcut doesn't work. Copying to clipboard using tool button works.

Some other problems to consider related to multiple screens and their scaling, possibly for separate PRs:

**Single screen fullscreen mode** Similar to "all screen fullscreen" and "windowed" modes have third mode which captures image from single screen and displays it fullscreen on the same window. It preserves the inplace screen annotation functionality while avoiding challenging cases. From what I understand something similar Is already done for macOS. Having it as separate mode which can be selected on tested on any OS instead macOS specific fullscreen handling, would help some of Linux users. I assume that in many cases when you are selecting part of single screen anyway so doesn't need to be across mutliple screens.

**Scaling factor of resulting image.** It seems that currently flameshot currently creates single image consisting of all the screens scaled so that there is no information loss for highest DPI screen. This is fine when you are creating screenshot across multple screens, but if the selected rectangle is inside lower DPI screen it makes it unnecessarily upscaled.  That could be handled by advanced user option choosing betweeen following modes or choosing automatically based on selection rectangle.
* scaling aware mode -> current behavior, matches how user sees things in real world (or at least desktop config), capturing parts of lower DPI screens result in unwanted upscaling
* no scaling -> glue together images at the resolution of each display,  no scaling artifacts but captures across multiple screens  might not fit together. If QT doesn't provide information about such layout it might be nontrivial to decide how to layout all the screens.
* automatic mode based on selection rectangle -> If selection rectangle is across multiple screens behave like in "scaling aware mode", if rectangle is on single screen use take image from that screen thus avoiding upscaling issue. This approach will  require storing separate QPixmap for screencapture of each individual display in addition to current combined one since downscaling image which has been upscaled by fraction coefficient would cause some degradation.
