### PR TITLE
CMake: add option to use external singleapplication

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,7 +86,17 @@ enable_sanitizers(project_options)
 set(QAPPLICATION_CLASS
         QApplication
         CACHE STRING "Inheritance class for SingleApplication")
-add_subdirectory(external/singleapplication)
+
+if(USE_EXTERNAL_SINGLEAPPLICATION)
+  # look for external QtSingleApplication
+  # package dev-qt/qtsingleapplication provides no symlink to current version
+  set(qtsingleapplication_libs libQt5Solutions_SingleApplication-2.6 Qt5Solutions_SingleApplication-2.6)
+  find_library(QTSINGLEAPPLICATION_LIBRARY NAMES ${qtsingleapplication_libs})
+  message(STATUS "Using external SingleApplication library")
+else()
+  add_subdirectory(external/singleapplication)
+  set(QTSINGLEAPPLICATION_LIBRARY SingleApplication::SingleApplication)
+endif()
 
 if(USE_EXTERNAL_SPDLOG)
   find_package(spdlog REQUIRED)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -113,7 +113,7 @@ endif ()
 
 target_sources(
         flameshot
-        PRIVATE # ${CMAKE_CURRENT_SOURCE_DIR}/../external/singleapplication/singleapplication.cpp
+        PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/../external/Qt-Color-Widgets/src/color_utils.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../external/Qt-Color-Widgets/src/color_wheel.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../external/Qt-Color-Widgets/include/color_wheel.hpp
@@ -126,7 +126,6 @@ target_include_directories(
   flameshot
   PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../>
          $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/>
-         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../external/singleapplication/>
          $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../external/Qt-Color-Widgets/include>
          $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../dbus/>
          $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/cli>
@@ -161,6 +160,15 @@ target_include_directories(
          $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/widgets/capture>
          $<INSTALL_INTERFACE:include/mylib>)
 
+if (USE_EXTERNAL_SINGLEAPPLICATION)
+    add_compile_definitions(USE_EXTERNAL_SINGLEAPPLICATION=1)
+else ()
+    target_include_directories(
+        flameshot
+        PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../external/singleapplication>)
+endif()
+
 target_link_libraries(
         flameshot
         project_warnings
@@ -169,7 +177,7 @@ target_link_libraries(
         Qt5::DBus
         Qt5::Network
         Qt5::Widgets
-        SingleApplication::SingleApplication
+        ${QTSINGLEAPPLICATION_LIBRARY}
         spdlog::spdlog
 )
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,7 +1,12 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // SPDX-FileCopyrightText: 2017-2019 Alejandro Sirgo Rica & Contributors
 
+#ifndef USE_EXTERNAL_SINGLEAPPLICATION
 #include "singleapplication.h"
+#else
+#include "QtSolutions/qtsingleapplication.h"
+#endif
+
 #include "src/cli/commandlineparser.h"
 #include "src/config/styleoverride.h"
 #include "src/core/capturerequest.h"
@@ -65,7 +70,11 @@ int main(int argc, char* argv[])
 
     // no arguments, just launch Flameshot
     if (argc == 1) {
+#ifndef USE_EXTERNAL_SINGLEAPPLICATION
         SingleApplication app(argc, argv);
+#else
+        QtSingleApplication app(argc, argv);
+#endif
         QApplication::setStyle(new StyleOverride);
 
         QTranslator translator, qtTranslator;


### PR DESCRIPTION
- Look for QtSingleApplication in system. The version is hardcoded,
  because QtSingleApplication does not provide symlink to the current
  version
- Add ifdef that changes the included filename and SingleApplication
  class name depending on the option value

Signed-off-by: Pavel Kalugin <pavel@pavelthebest.me>