### PR TITLE
Use image/png on Wayland to improve copy support

### DIFF
--- a/src/utils/screenshotsaver.cpp
+++ b/src/utils/screenshotsaver.cpp
@@ -65,7 +65,7 @@ void ScreenshotSaver::saveToClipboard(const QPixmap& capture)
         if (DesktopInfo().waylandDectected()) saveToClipboardPng(capture);
         else
 #endif
-        saveToClipboardPng(capture);
+        QApplication::clipboard()->setPixmap(capture);
     }
     // Otherwise only save to clipboard
     else {

--- a/src/utils/screenshotsaver.cpp
+++ b/src/utils/screenshotsaver.cpp
@@ -2,11 +2,11 @@
 // SPDX-FileCopyrightText: 2017-2019 Alejandro Sirgo Rica & Contributors
 
 #include "screenshotsaver.h"
-#include "utils/desktopinfo.h"
 #include "src/core/controller.h"
 #include "src/utils/confighandler.h"
 #include "src/utils/filenamehandler.h"
 #include "src/utils/systemnotification.h"
+#include "utils/desktopinfo.h"
 #include <QApplication>
 #include <QBuffer>
 #include <QClipboard>
@@ -26,7 +26,8 @@ ScreenshotSaver::ScreenshotSaver(const unsigned id)
   : m_id(id)
 {}
 
-void ScreenshotSaver::saveToClipboardPng(const QPixmap& capture) {
+void ScreenshotSaver::saveToClipboardPng(const QPixmap& capture)
+{
     QByteArray array;
     QBuffer buffer{ &array };
     QImageWriter imageWriter{ &buffer, "PNG" };
@@ -62,10 +63,15 @@ void ScreenshotSaver::saveToClipboard(const QPixmap& capture)
                          ConfigHandler().savePath(),
                          QObject::tr("Capture saved to clipboard."));
 #if defined(Q_OS_LINUX) || defined(Q_OS_UNIX)
-        if (DesktopInfo().waylandDectected()) saveToClipboardPng(capture);
-        else
-#endif
+        if (DesktopInfo().waylandDectected()) {
+            saveToClipboardPng(capture);
+        } else {
+            QApplication::clipboard()->setPixmap(capture);
+        }
+#else
         QApplication::clipboard()->setPixmap(capture);
+#endif
+
     }
     // Otherwise only save to clipboard
     else {
@@ -97,10 +103,14 @@ void ScreenshotSaver::saveToClipboard(const QPixmap& capture)
             SystemNotification().sendMessage(
               QObject::tr("Capture saved to clipboard"));
 #if defined(Q_OS_LINUX) || defined(Q_OS_UNIX)
-            if (DesktopInfo().waylandDectected()) saveToClipboardPng(capture);
-            else
-#endif
+            if (DesktopInfo().waylandDectected()) {
+                saveToClipboardPng(capture);
+            } else {
+                QApplication::clipboard()->setPixmap(capture);
+            }
+#else
             QApplication::clipboard()->setPixmap(capture);
+#endif
         }
     }
 }

--- a/src/utils/screenshotsaver.h
+++ b/src/utils/screenshotsaver.h
@@ -15,7 +15,7 @@ public:
     ScreenshotSaver(const unsigned id);
 
     void saveToClipboard(const QPixmap& capture);
-    void saveToClipboardPng(const QPixmap &capture);
+    void saveToClipboardPng(const QPixmap& capture);
     bool saveToFilesystem(const QPixmap& capture,
                           const QString& path,
                           const QString& messagePrefix);

--- a/src/utils/screenshotsaver.h
+++ b/src/utils/screenshotsaver.h
@@ -15,6 +15,7 @@ public:
     ScreenshotSaver(const unsigned id);
 
     void saveToClipboard(const QPixmap& capture);
+    void saveToClipboardPng(const QPixmap &capture);
     bool saveToFilesystem(const QPixmap& capture,
                           const QString& path,
                           const QString& messagePrefix);


### PR DESCRIPTION
uses image/png only when wayland is detected on linux. works around a Qt bug where all images formats declared by Qt return an image in BMP format