### PR TITLE
improve screenshot saver copy

### DIFF
--- a/src/utils/screenshotsaver.cpp
+++ b/src/utils/screenshotsaver.cpp
@@ -26,7 +26,8 @@ ScreenshotSaver::ScreenshotSaver(const unsigned id)
   : m_id(id)
 {}
 
-void ScreenshotSaver::saveToClipboardMime(const QPixmap& capture, const QString& imageType)
+void ScreenshotSaver::saveToClipboardMime(const QPixmap& capture,
+                                          const QString& imageType)
 {
     QByteArray array;
     QBuffer buffer{ &array };
@@ -34,8 +35,10 @@ void ScreenshotSaver::saveToClipboardMime(const QPixmap& capture, const QString&
     imageWriter.write(capture.toImage());
 
     QPixmap pngPixmap;
-    bool isLoaded = pngPixmap.loadFromData(
-      reinterpret_cast<uchar*>(array.data()), array.size(), imageType.toUpper().toUtf8());
+    bool isLoaded =
+      pngPixmap.loadFromData(reinterpret_cast<uchar*>(array.data()),
+                             array.size(),
+                             imageType.toUpper().toUtf8());
     if (isLoaded) {
         QMimeData* mimeData = new QMimeData;
         mimeData->setData("image/" + imageType, array);
@@ -58,7 +61,8 @@ void ScreenshotSaver::saveToClipboard(const QPixmap& capture)
                          ConfigHandler().savePath(),
                          QObject::tr("Capture saved to clipboard."));
     } else {
-        SystemNotification().sendMessage(QObject::tr("Capture saved to clipboard."));
+        SystemNotification().sendMessage(
+          QObject::tr("Capture saved to clipboard."));
     }
     if (ConfigHandler().useJpgForClipboard()) {
         // FIXME - it doesn't work on MacOS

--- a/src/utils/screenshotsaver.cpp
+++ b/src/utils/screenshotsaver.cpp
@@ -26,28 +26,23 @@ ScreenshotSaver::ScreenshotSaver(const unsigned id)
   : m_id(id)
 {}
 
-void ScreenshotSaver::saveToClipboardPng(const QPixmap& capture)
+void ScreenshotSaver::saveToClipboardMime(const QPixmap& capture, const QString& imageType)
 {
     QByteArray array;
     QBuffer buffer{ &array };
-    QImageWriter imageWriter{ &buffer, "PNG" };
+    QImageWriter imageWriter{ &buffer, imageType.toUpper().toUtf8() };
     imageWriter.write(capture.toImage());
 
     QPixmap pngPixmap;
     bool isLoaded = pngPixmap.loadFromData(
-      reinterpret_cast<uchar*>(array.data()), array.size(), "PNG");
+      reinterpret_cast<uchar*>(array.data()), array.size(), imageType.toUpper().toUtf8());
     if (isLoaded) {
-        // Need to send message before copying to clipboard
-        SystemNotification().sendMessage(
-          QObject::tr("Capture saved to clipboard"));
-
         QMimeData* mimeData = new QMimeData;
-        mimeData->setData("image/png", array);
+        mimeData->setData("image/" + imageType, array);
         QApplication::clipboard()->setMimeData(mimeData);
     } else {
         SystemNotification().sendMessage(
           QObject::tr("Error while saving to clipboard"));
-        return;
     }
 }
 
@@ -62,56 +57,23 @@ void ScreenshotSaver::saveToClipboard(const QPixmap& capture)
         saveToFilesystem(capture,
                          ConfigHandler().savePath(),
                          QObject::tr("Capture saved to clipboard."));
+    } else {
+        SystemNotification().sendMessage(QObject::tr("Capture saved to clipboard."));
+    }
+    if (ConfigHandler().useJpgForClipboard()) {
+        // FIXME - it doesn't work on MacOS
+        saveToClipboardMime(capture, "jpeg");
+    } else {
+        // Need to send message before copying to clipboard
 #if defined(Q_OS_LINUX) || defined(Q_OS_UNIX)
         if (DesktopInfo().waylandDectected()) {
-            saveToClipboardPng(capture);
+            saveToClipboardMime(capture, "png");
         } else {
             QApplication::clipboard()->setPixmap(capture);
         }
 #else
         QApplication::clipboard()->setPixmap(capture);
 #endif
-
-    }
-    // Otherwise only save to clipboard
-    else {
-        if (ConfigHandler().useJpgForClipboard()) {
-            // FIXME - it doesn't work on MacOS
-            QByteArray array;
-            QBuffer buffer{ &array };
-            QImageWriter imageWriter{ &buffer, "JPEG" };
-            imageWriter.write(capture.toImage());
-
-            QPixmap jpgPixmap;
-            bool isLoaded = jpgPixmap.loadFromData(
-              reinterpret_cast<uchar*>(array.data()), array.size(), "JPEG");
-            if (isLoaded) {
-                // Need to send message before copying to clipboard
-                SystemNotification().sendMessage(
-                  QObject::tr("Capture saved to clipboard"));
-
-                QMimeData* mimeData = new QMimeData;
-                mimeData->setData("image/jpeg", array);
-                QApplication::clipboard()->setMimeData(mimeData);
-            } else {
-                SystemNotification().sendMessage(
-                  QObject::tr("Error while saving to clipboard"));
-                return;
-            }
-        } else {
-            // Need to send message before copying to clipboard
-            SystemNotification().sendMessage(
-              QObject::tr("Capture saved to clipboard"));
-#if defined(Q_OS_LINUX) || defined(Q_OS_UNIX)
-            if (DesktopInfo().waylandDectected()) {
-                saveToClipboardPng(capture);
-            } else {
-                QApplication::clipboard()->setPixmap(capture);
-            }
-#else
-            QApplication::clipboard()->setPixmap(capture);
-#endif
-        }
     }
 }
 

--- a/src/utils/screenshotsaver.h
+++ b/src/utils/screenshotsaver.h
@@ -15,7 +15,7 @@ public:
     ScreenshotSaver(const unsigned id);
 
     void saveToClipboard(const QPixmap& capture);
-    void saveToClipboardPng(const QPixmap& capture);
+    void saveToClipboardMime(const QPixmap& capture, const QString& imageType);
     bool saveToFilesystem(const QPixmap& capture,
                           const QString& path,
                           const QString& messagePrefix);


### PR DESCRIPTION
screenshot saver had some duplicate code so I cleaned it up a bit.

- when "save after image is copied" is enabled, respect the JPEG clipboard option
- fix double notification when wayland workaround is in place
- unify jpeg and png workaround code paths