### PR TITLE
Add WebP support for saving captures

### DIFF
--- a/src/utils/screenshotsaver.cpp
+++ b/src/utils/screenshotsaver.cpp
@@ -174,8 +174,8 @@ bool ScreenshotSaver::saveToFilesystemGUI(const QPixmap& capture)
           nullptr,
           QObject::tr("Save screenshot"),
           FileNameHandler().absoluteSavePath(),
-          QString(pngFilter + separator + bmpFilter + separator + jpgFilter +
-                  separator + defaultFilter));
+          QString(pngFilter + separator + bmpFilter + separator + webpFilter +
+                  separator + jpgFilter + separator + defaultFilter));
     }
     if (savePath == "") {
         QString msg = QObject::tr("Saving canceled");
@@ -186,6 +186,8 @@ bool ScreenshotSaver::saveToFilesystemGUI(const QPixmap& capture)
         return ok;
     } else if (!savePath.endsWith(QLatin1String(".png"), Qt::CaseInsensitive) &&
                !savePath.endsWith(QLatin1String(".bmp"), Qt::CaseInsensitive) &&
+               !savePath.endsWith(QLatin1String(".webp"),
+                                  Qt::CaseInsensitive) &&
                !savePath.endsWith(QLatin1String(".jpg"), Qt::CaseInsensitive)) {
         savePath += QLatin1String(".png");
     }

--- a/src/utils/screenshotsaver.h
+++ b/src/utils/screenshotsaver.h
@@ -30,6 +30,7 @@ private:
 
     const QString pngFilter = "Portable Network Graphic file (PNG) (*.png)";
     const QString bmpFilter = "BMP file (*.bmp)";
+    const QString webpFilter = "WebP file (*.webp)";
     const QString jpgFilter = "JPEG file (*.jpg)";
     const QString defaultFilter = "By extension [default: *.png] (*.png)";
     const QString separator = ";;";


### PR DESCRIPTION
WebP can be selected to save an image in the "Save As" menu. Tested on Linux with KDE. This partially addresses #1640 