### PR TITLE
Fix broken FAQ link in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -5,7 +5,7 @@ about: Create a report to help us improve
 ---
 
 <!--
-First read the FAQ: https://flameshot.org/faq/
+First read the FAQ: https://flameshot.org/guide/faq/
 
 If you don't know how to get some of the following information from your
 computer, visit:


### PR DESCRIPTION
The current link https://flameshot.org/faq/ is broken, and the correct link is https://flameshot.org/guide/faq (as far as I can tell). I think that either the 404 at the former address needs to be fixed, or the template should be made to point to the working link (this PR).

Also see #1727.