### PR TITLE
Fix nullptr reference when trayicon is disabled

### DIFF
--- a/src/core/controller.cpp
+++ b/src/core/controller.cpp
@@ -196,7 +196,9 @@ void Controller::handleReplyCheckUpdates(QNetworkReply* reply)
             m_appLatestUrl = json["html_url"].toString();
             QString newVersion =
               tr("New version %1 is available").arg(m_appLatestVersion);
-            m_appUpdates->setText(newVersion);
+            if (m_appUpdates != nullptr) {
+                m_appUpdates->setText(newVersion);
+            }
             if (m_showCheckAppUpdateStatus) {
                 sendTrayNotification(newVersion, "Flameshot");
                 QDesktopServices::openUrl(QUrl(m_appLatestUrl));


### PR DESCRIPTION
Fix crash when the following criteria are met:

* `disabledTrayIcon=true`.
* `checkForUpdates=true` (either explicitly or implicitly).
* A new version is available.

closes: #1721 .
closes: #1730 .
See also: https://bugs.debian.org/991320