### PR TITLE
Copy/save selected region even before mouse release

### DIFF
--- a/src/widgets/capture/capturewidget.h
+++ b/src/widgets/capture/capturewidget.h
@@ -120,6 +120,7 @@ private:
     void initPanel();
     void initSelection();
     void initShortcuts();
+    void updateGeometry();
     void updateSizeIndicator();
     void updateCursor();
     void pushToolToStack();


### PR DESCRIPTION
This fixes the counter-intuitive behaviour where copying/saving before releasing the mouse button (via shortcuts) copies/saves the entire screen instead of the region selected so far.

It does so by updating the selected region's geometry (in the manner handling of mouse release events does it) before performing the copy/save.

Since there is now repeated functionality, this updating is extracted to `CaptureWidget::updateGeometry()`.

---

Motivating issue: #1741

(Misread the intention of the issue...)

---

It's probably better (as @mmahmoudian mentioned in #1741, and as proposed by the issue in the first place) to disable these shortcuts during the selection phase instead, but since I'm done with this approach I'm opening this PR as an option.