### PR TITLE
Remove imgur hotkey

### DIFF
--- a/src/utils/configshortcuts.cpp
+++ b/src/utils/configshortcuts.cpp
@@ -12,11 +12,11 @@ const QVector<QStringList>& ConfigShortcuts::captureShortcutsDefault(
         CaptureToolButton* b = new CaptureToolButton(t, nullptr);
         QString shortcutName = QVariant::fromValue(t).toString();
         QKeySequence ks = captureShortcutDefault(t);
-        if (shortcutName != "TYPE_IMAGEUPLOADER"){
-                    m_shortcuts << (QStringList()
+        if (shortcutName != "TYPE_IMAGEUPLOADER") {
+            m_shortcuts << (QStringList()
                             << shortcutName << b->tool()->description()
                             << ks.toString());
-            }
+        }
         delete b;
     }
 

--- a/src/utils/configshortcuts.cpp
+++ b/src/utils/configshortcuts.cpp
@@ -12,9 +12,11 @@ const QVector<QStringList>& ConfigShortcuts::captureShortcutsDefault(
         CaptureToolButton* b = new CaptureToolButton(t, nullptr);
         QString shortcutName = QVariant::fromValue(t).toString();
         QKeySequence ks = captureShortcutDefault(t);
-        m_shortcuts << (QStringList()
-                        << shortcutName << b->tool()->description()
-                        << ks.toString());
+        if (shortcutName != "TYPE_IMAGEUPLOADER"){
+                    m_shortcuts << (QStringList()
+                            << shortcutName << b->tool()->description()
+                            << ks.toString());
+            }
         delete b;
     }
 

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -221,6 +221,7 @@ void CaptureWidget::updateButtons()
             case CaptureToolButton::ButtonType::TYPE_SAVE:
             case CaptureToolButton::ButtonType::TYPE_COPY:
             case CaptureToolButton::ButtonType::TYPE_UNDO:
+            case CaptureToolButton::ButtonType::TYPE_IMAGEUPLOADER:
             case CaptureToolButton::ButtonType::TYPE_REDO:
                 // nothing to do, just skip non-dynamic buttons with existing
                 // hard coded slots


### PR DESCRIPTION
The purpose of this PR is to remove the ability to bind upload to a hotkey. Many users are accidentally uploading images and this is a security risk. 