### PR TITLE
desktop: Specify StartupWMClass

### DIFF
--- a/data/desktopEntry/package/org.flameshot.Flameshot.desktop
+++ b/data/desktopEntry/package/org.flameshot.Flameshot.desktop
@@ -43,6 +43,7 @@ Terminal=false
 Type=Application
 Categories=Graphics;
 StartupNotify=false
+StartupWMClass=flameshot
 Actions=Configure;Capture;Launcher;
 X-DBUS-StartupType=Unique
 X-DBUS-ServiceName=org.flameshot.Flameshot


### PR DESCRIPTION
Specifying correct StartupWMClass in desktop file could prevent duplicated icons from appearing on GNOME platform when config window, launcher window and about window are being shown.

Ref: https://specifications.freedesktop.org/desktop-entry-spec/latest/ar01s06.html