### PR TITLE
Fix save file name with '.'s in it (fixes #1722)

### DIFF
--- a/src/utils/screenshotsaver.cpp
+++ b/src/utils/screenshotsaver.cpp
@@ -142,7 +142,7 @@ QString ScreenshotSaver::ShowSaveFileDialog(QWidget* parent,
               dialog.selectedNameFilter().section('.', -1);
             selectedExtension.remove(QChar(')'));
             file_name =
-              info.path() + QLatin1String("/") + info.baseName() +
+              info.path() + QLatin1String("/") + info.completeBaseName() +
               QLatin1String(".") +
               selectedExtension; // recreate full filename with chosen suffix
         }


### PR DESCRIPTION
Using [`QFileInfo::baseName()`](https://doc.qt.io/qt-5/qfileinfo.html#baseName) discards everything after the first ., so filenames like 1.2.3.4.png would be changed to 1.png.

Changing this to [`QFileInfo::completeBaseName()`](https://doc.qt.io/qt-5/qfileinfo.html#completeBaseName) only discards the suffix, so we have 1.2.3.4.jpg becoming 1.2.3.4.png, for example.

Fixes #1722.