### PR TITLE
Remove imgur image title

### DIFF
--- a/src/tools/imgur/imguruploader.cpp
+++ b/src/tools/imgur/imguruploader.cpp
@@ -129,7 +129,7 @@ void ImgurUploader::upload()
 
     QUrlQuery urlQuery;
     urlQuery.addQueryItem(QStringLiteral("title"),
-                          QStringLiteral("flameshot_screenshot"));
+                          QStringLiteral(""));
     QString description = FileNameHandler().parsedPattern();
     urlQuery.addQueryItem(QStringLiteral("description"), description);
 


### PR DESCRIPTION
Removes the image title to make embedding images in discord much nicer.
Without changes to set a custom title this is a reasonable solution to issue #466 