### PR TITLE
fix: link to issue reporting

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -9,7 +9,7 @@ First read the FAQ: https://flameshot.org/guide/faq/
 
 If you don't know how to get some of the following information from your
 computer, visit:
-https://flameshot.org/issue-reporting/
+https://flameshot.org/guide/issue-reporting/
 
 **Note** that if you don't provide the requested information, the bugreport most
 probably will considered as invalid and will be closed unless you provide


### PR DESCRIPTION
The page must have been moved because the previous link is 404. I replaced the
link with the correct one.