### PR TITLE
flameshot to dharkael

### DIFF
--- a/docs/shortcuts-config/flameshot-shortcuts-kde
+++ b/docs/shortcuts-config/flameshot-shortcuts-kde
@@ -26,7 +26,7 @@ ActionsCount=1
 [Data_1_1Actions0]
 Arguments='Pictures/Screenshots' 0 0
 Call=graphicCapture
-RemoteApp=org.flameshot.Flameshot
+RemoteApp=org.dharkael.Flameshot
 RemoteObj=/
 Type=DBUS
 
@@ -55,7 +55,7 @@ ActionsCount=1
 [Data_1_2Actions0]
 Arguments='Pictures/Screenshots' 3000 0
 Call=graphicCapture
-RemoteApp=org.flameshot.Flameshot
+RemoteApp=org.dharkael.Flameshot
 RemoteObj=/
 Type=DBUS
 
@@ -84,7 +84,7 @@ ActionsCount=1
 [Data_1_3Actions0]
 Arguments='Pictures/Screenshots' false 0 0
 Call=fullScreen
-RemoteApp=org.flameshot.Flameshot
+RemoteApp=org.dharkael.Flameshot
 RemoteObj=/
 Type=DBUS
 
@@ -113,7 +113,7 @@ ActionsCount=1
 [Data_1_4Actions0]
 Arguments='' true 0 0
 Call=fullScreen
-RemoteApp=org.flameshot.Flameshot
+RemoteApp=org.dharkael.Flameshot
 RemoteObj=/
 Type=DBUS
 


### PR DESCRIPTION
On my Kubuntu machine. Global shortcuts didn't work. I went to the (Global Shortcuts) window and triggered the (Take Screenshot) action: ![Global Shortcut for Flameshot](https://user-images.githubusercontent.com/40805353/127523105-cf915f80-d8b0-406c-8bf2-9dc28b2963a3.png)
I saw in the D-Bus Browser that the call was to (org.dharkael.Flameshot) instead of org.flameshot.Flameshot).
![d-bus browser](https://user-images.githubusercontent.com/40805353/127523463-d846790b-e533-46c7-b9a3-5e7c451e729e.png)
