### PR TITLE
Refactor code related to CaptureWidget

### DIFF
--- a/src/tools/arrow/arrowtool.cpp
+++ b/src/tools/arrow/arrowtool.cpp
@@ -72,7 +72,7 @@ QString ArrowTool::name() const
     return tr("Arrow");
 }
 
-ToolType ArrowTool::nameID() const
+ToolType ArrowTool::type() const
 {
     return ToolType::ARROW;
 }

--- a/src/tools/arrow/arrowtool.h
+++ b/src/tools/arrow/arrowtool.h
@@ -23,7 +23,7 @@ public:
 
 protected:
     void copyParams(const ArrowTool* from, ArrowTool* to);
-    ToolType nameID() const override;
+    ToolType type() const override;
 
 public slots:
     void pressed(const CaptureContext& context) override;

--- a/src/tools/capturetool.h
+++ b/src/tools/capturetool.h
@@ -135,9 +135,6 @@ public:
     virtual int count() { return m_count; };
 
     // Called every time the tool has to draw
-    // recordUndo indicates when the tool should save the information
-    // for the undo(), if the value is false calling undo() after
-    // that process should not modify revert the changes.
     virtual void process(QPainter& painter, const QPixmap& pixmap) = 0;
     virtual void drawSearchArea(QPainter& painter, const QPixmap& pixmap)
     {

--- a/src/tools/capturetool.h
+++ b/src/tools/capturetool.h
@@ -107,7 +107,7 @@ public:
     virtual QString name() const = 0;
     // Codename for the tool, this shouldn't change as it is used as ID
     // for the tool in the internals of Flameshot
-    virtual ToolType nameID() const = 0;
+    virtual ToolType type() const = 0;
     // Short description of the tool.
     virtual QString description() const = 0;
     // Short tool item info

--- a/src/tools/circle/circletool.cpp
+++ b/src/tools/circle/circletool.cpp
@@ -20,7 +20,7 @@ QString CircleTool::name() const
     return tr("Circle");
 }
 
-ToolType CircleTool::nameID() const
+ToolType CircleTool::type() const
 {
     return ToolType::CIRCLE;
 }

--- a/src/tools/circle/circletool.h
+++ b/src/tools/circle/circletool.h
@@ -19,7 +19,7 @@ public:
     void process(QPainter& painter, const QPixmap& pixmap) override;
 
 protected:
-    ToolType nameID() const override;
+    ToolType type() const override;
 
 public slots:
     void pressed(const CaptureContext& context) override;

--- a/src/tools/circlecount/circlecounttool.cpp
+++ b/src/tools/circlecount/circlecounttool.cpp
@@ -33,7 +33,7 @@ QString CircleCountTool::name() const
     return tr("Circle Counter");
 }
 
-ToolType CircleCountTool::nameID() const
+ToolType CircleCountTool::type() const
 {
     return ToolType::CIRCLECOUNT;
 }

--- a/src/tools/circlecount/circlecounttool.h
+++ b/src/tools/circlecount/circlecounttool.h
@@ -23,7 +23,7 @@ public:
                            const CaptureContext& context) override;
 
 protected:
-    ToolType nameID() const override;
+    ToolType type() const override;
 
 public slots:
     void drawStart(const CaptureContext& context) override;

--- a/src/tools/copy/copytool.cpp
+++ b/src/tools/copy/copytool.cpp
@@ -24,7 +24,7 @@ QString CopyTool::name() const
     return tr("Copy");
 }
 
-ToolType CopyTool::nameID() const
+ToolType CopyTool::type() const
 {
     return ToolType::COPY;
 }

--- a/src/tools/copy/copytool.h
+++ b/src/tools/copy/copytool.h
@@ -20,7 +20,7 @@ public:
     CaptureTool* copy(QObject* parent = nullptr) override;
 
 protected:
-    ToolType nameID() const override;
+    ToolType type() const override;
 
 public slots:
     void pressed(const CaptureContext& context) override;

--- a/src/tools/exit/exittool.cpp
+++ b/src/tools/exit/exittool.cpp
@@ -23,7 +23,7 @@ QString ExitTool::name() const
     return tr("Exit");
 }
 
-ToolType ExitTool::nameID() const
+ToolType ExitTool::type() const
 {
     return ToolType::EXIT;
 }

--- a/src/tools/exit/exittool.h
+++ b/src/tools/exit/exittool.h
@@ -20,7 +20,7 @@ public:
     CaptureTool* copy(QObject* parent = nullptr) override;
 
 protected:
-    ToolType nameID() const override;
+    ToolType type() const override;
 
 public slots:
     void pressed(const CaptureContext& context) override;

--- a/src/tools/imgur/imguruploadertool.cpp
+++ b/src/tools/imgur/imguruploadertool.cpp
@@ -24,7 +24,7 @@ QString ImgurUploaderTool::name() const
     return tr("Image Uploader");
 }
 
-ToolType ImgurUploaderTool::nameID() const
+ToolType ImgurUploaderTool::type() const
 {
     return ToolType::IMGUR;
 }

--- a/src/tools/imgur/imguruploadertool.h
+++ b/src/tools/imgur/imguruploadertool.h
@@ -22,7 +22,7 @@ public:
     CaptureTool* copy(QObject* parent = nullptr) override;
 
 protected:
-    ToolType nameID() const override;
+    ToolType type() const override;
 
 public slots:
     void pressed(const CaptureContext& context) override;

--- a/src/tools/launcher/applaunchertool.cpp
+++ b/src/tools/launcher/applaunchertool.cpp
@@ -23,7 +23,7 @@ QString AppLauncher::name() const
     return tr("App Launcher");
 }
 
-ToolType AppLauncher::nameID() const
+ToolType AppLauncher::type() const
 {
     return ToolType::LAUNCHER;
 }

--- a/src/tools/launcher/applaunchertool.h
+++ b/src/tools/launcher/applaunchertool.h
@@ -22,7 +22,7 @@ public:
     CaptureTool* copy(QObject* parent = nullptr) override;
 
 protected:
-    ToolType nameID() const override;
+    ToolType type() const override;
 
 public slots:
     void pressed(const CaptureContext& context) override;

--- a/src/tools/line/linetool.cpp
+++ b/src/tools/line/linetool.cpp
@@ -22,7 +22,7 @@ QString LineTool::name() const
     return tr("Line");
 }
 
-ToolType LineTool::nameID() const
+ToolType LineTool::type() const
 {
     return ToolType::LINE;
 }

--- a/src/tools/line/linetool.h
+++ b/src/tools/line/linetool.h
@@ -19,7 +19,7 @@ public:
     void process(QPainter& painter, const QPixmap& pixmap) override;
 
 protected:
-    ToolType nameID() const override;
+    ToolType type() const override;
 
 public slots:
     void pressed(const CaptureContext& context) override;

--- a/src/tools/marker/markertool.cpp
+++ b/src/tools/marker/markertool.cpp
@@ -27,7 +27,7 @@ QString MarkerTool::name() const
     return tr("Marker");
 }
 
-ToolType MarkerTool::nameID() const
+ToolType MarkerTool::type() const
 {
     return ToolType::MARKER;
 }

--- a/src/tools/marker/markertool.h
+++ b/src/tools/marker/markertool.h
@@ -21,7 +21,7 @@ public:
                            const CaptureContext& context) override;
 
 protected:
-    ToolType nameID() const override;
+    ToolType type() const override;
 
 public slots:
     void drawStart(const CaptureContext& context) override;

--- a/src/tools/move/movetool.cpp
+++ b/src/tools/move/movetool.cpp
@@ -23,7 +23,7 @@ QString MoveTool::name() const
     return tr("Move");
 }
 
-ToolType MoveTool::nameID() const
+ToolType MoveTool::type() const
 {
     return ToolType::MOVE;
 }

--- a/src/tools/move/movetool.h
+++ b/src/tools/move/movetool.h
@@ -15,7 +15,7 @@ public:
 
     QIcon icon(const QColor& background, bool inEditor) const override;
     QString name() const override;
-    ToolType nameID() const override;
+    ToolType type() const override;
     QString description() const override;
     bool isSelectable() const override;
 

--- a/src/tools/pencil/penciltool.cpp
+++ b/src/tools/pencil/penciltool.cpp
@@ -18,7 +18,7 @@ QString PencilTool::name() const
     return tr("Pencil");
 }
 
-ToolType PencilTool::nameID() const
+ToolType PencilTool::type() const
 {
     return ToolType::PENCIL;
 }

--- a/src/tools/pencil/penciltool.h
+++ b/src/tools/pencil/penciltool.h
@@ -22,7 +22,7 @@ public:
                            const CaptureContext& context) override;
 
 protected:
-    ToolType nameID() const override;
+    ToolType type() const override;
 
 public slots:
     void drawStart(const CaptureContext& context) override;

--- a/src/tools/pin/pintool.cpp
+++ b/src/tools/pin/pintool.cpp
@@ -25,7 +25,7 @@ QString PinTool::name() const
     return tr("Pin Tool");
 }
 
-ToolType PinTool::nameID() const
+ToolType PinTool::type() const
 {
     return ToolType::PIN;
 }

--- a/src/tools/pin/pintool.h
+++ b/src/tools/pin/pintool.h
@@ -22,7 +22,7 @@ public:
     CaptureTool* copy(QObject* parent = nullptr) override;
 
 protected:
-    ToolType nameID() const override;
+    ToolType type() const override;
 
 public slots:
     void pressed(const CaptureContext& context) override;

--- a/src/tools/pixelate/pixelatetool.cpp
+++ b/src/tools/pixelate/pixelatetool.cpp
@@ -23,7 +23,7 @@ QString PixelateTool::name() const
     return tr("Pixelate");
 }
 
-ToolType PixelateTool::nameID() const
+ToolType PixelateTool::type() const
 {
     return ToolType::PIXELATE;
 }

--- a/src/tools/pixelate/pixelatetool.h
+++ b/src/tools/pixelate/pixelatetool.h
@@ -23,7 +23,7 @@ public:
     void drawObjectSelection(QPainter& painter) override;
 
 protected:
-    ToolType nameID() const override;
+    ToolType type() const override;
 
 public slots:
     void pressed(const CaptureContext& context) override;

--- a/src/tools/rectangle/rectangletool.cpp
+++ b/src/tools/rectangle/rectangletool.cpp
@@ -22,7 +22,7 @@ QString RectangleTool::name() const
     return tr("Rectangle");
 }
 
-ToolType RectangleTool::nameID() const
+ToolType RectangleTool::type() const
 {
     return ToolType::RECTANGLE;
 }

--- a/src/tools/rectangle/rectangletool.h
+++ b/src/tools/rectangle/rectangletool.h
@@ -19,7 +19,7 @@ public:
     void process(QPainter& painter, const QPixmap& pixmap) override;
 
 protected:
-    ToolType nameID() const override;
+    ToolType type() const override;
 
 public slots:
     void drawStart(const CaptureContext& context) override;

--- a/src/tools/redo/redotool.cpp
+++ b/src/tools/redo/redotool.cpp
@@ -23,7 +23,7 @@ QString RedoTool::name() const
     return tr("Redo");
 }
 
-ToolType RedoTool::nameID() const
+ToolType RedoTool::type() const
 {
     return ToolType::REDO;
 }

--- a/src/tools/redo/redotool.h
+++ b/src/tools/redo/redotool.h
@@ -20,7 +20,7 @@ public:
     CaptureTool* copy(QObject* parent = nullptr) override;
 
 protected:
-    ToolType nameID() const override;
+    ToolType type() const override;
 
 public slots:
     void pressed(const CaptureContext& context) override;

--- a/src/tools/save/savetool.cpp
+++ b/src/tools/save/savetool.cpp
@@ -29,7 +29,7 @@ QString SaveTool::name() const
     return tr("Save");
 }
 
-ToolType SaveTool::nameID() const
+ToolType SaveTool::type() const
 {
     return ToolType::SAVE;
 }

--- a/src/tools/save/savetool.h
+++ b/src/tools/save/savetool.h
@@ -20,7 +20,7 @@ public:
     CaptureTool* copy(QObject* parent = nullptr) override;
 
 protected:
-    ToolType nameID() const override;
+    ToolType type() const override;
 
 public slots:
     void pressed(const CaptureContext& context) override;

--- a/src/tools/selection/selectiontool.cpp
+++ b/src/tools/selection/selectiontool.cpp
@@ -25,7 +25,7 @@ QString SelectionTool::name() const
     return tr("Rectangular Selection");
 }
 
-ToolType SelectionTool::nameID() const
+ToolType SelectionTool::type() const
 {
     return ToolType::SELECTION;
 }

--- a/src/tools/selection/selectiontool.h
+++ b/src/tools/selection/selectiontool.h
@@ -21,7 +21,7 @@ public:
     void process(QPainter& painter, const QPixmap& pixmap) override;
 
 protected:
-    ToolType nameID() const override;
+    ToolType type() const override;
 
 public slots:
     void pressed(const CaptureContext& context) override;

--- a/src/tools/sizedecrease/sizedecreasetool.cpp
+++ b/src/tools/sizedecrease/sizedecreasetool.cpp
@@ -37,7 +37,7 @@ QString SizeDecreaseTool::name() const
     return tr("Decrease Tool Size");
 }
 
-ToolType SizeDecreaseTool::nameID() const
+ToolType SizeDecreaseTool::type() const
 {
     return ToolType::SIZEDECREASE;
 }

--- a/src/tools/sizedecrease/sizedecreasetool.h
+++ b/src/tools/sizedecrease/sizedecreasetool.h
@@ -34,7 +34,7 @@ public:
     CaptureTool* copy(QObject* parent = nullptr) override;
 
 protected:
-    ToolType nameID() const override;
+    ToolType type() const override;
 
 public slots:
     void pressed(const CaptureContext& context) override;

--- a/src/tools/sizeincrease/sizeincreasetool.cpp
+++ b/src/tools/sizeincrease/sizeincreasetool.cpp
@@ -37,7 +37,7 @@ QString SizeIncreaseTool::name() const
     return tr("Increase Tool Size");
 }
 
-ToolType SizeIncreaseTool::nameID() const
+ToolType SizeIncreaseTool::type() const
 {
     return ToolType::SIZEINCREASE;
 }

--- a/src/tools/sizeincrease/sizeincreasetool.h
+++ b/src/tools/sizeincrease/sizeincreasetool.h
@@ -34,7 +34,7 @@ public:
     CaptureTool* copy(QObject* parent = nullptr) override;
 
 protected:
-    ToolType nameID() const override;
+    ToolType type() const override;
 
 public slots:
     void pressed(const CaptureContext& context) override;

--- a/src/tools/sizeindicator/sizeindicatortool.cpp
+++ b/src/tools/sizeindicator/sizeindicatortool.cpp
@@ -23,7 +23,7 @@ QString SizeIndicatorTool::name() const
     return tr("Selection Size Indicator");
 }
 
-ToolType SizeIndicatorTool::nameID() const
+ToolType SizeIndicatorTool::type() const
 {
     return ToolType::SIZEINDICATOR;
 }

--- a/src/tools/sizeindicator/sizeindicatortool.h
+++ b/src/tools/sizeindicator/sizeindicatortool.h
@@ -20,7 +20,7 @@ public:
     CaptureTool* copy(QObject* parent = nullptr) override;
 
 protected:
-    ToolType nameID() const override;
+    ToolType type() const override;
 
 public slots:
     void pressed(const CaptureContext& context) override;

--- a/src/tools/text/texttool.cpp
+++ b/src/tools/text/texttool.cpp
@@ -80,7 +80,7 @@ QString TextTool::info()
     return name();
 }
 
-ToolType TextTool::nameID() const
+ToolType TextTool::type() const
 {
     return ToolType::TEXT;
 }

--- a/src/tools/text/texttool.h
+++ b/src/tools/text/texttool.h
@@ -43,7 +43,7 @@ public:
 
 protected:
     void copyParams(const TextTool* from, TextTool* to);
-    ToolType nameID() const override;
+    ToolType type() const override;
 
 public slots:
     void drawEnd(const QPoint& p) override;

--- a/src/tools/undo/undotool.cpp
+++ b/src/tools/undo/undotool.cpp
@@ -23,7 +23,7 @@ QString UndoTool::name() const
     return tr("Undo");
 }
 
-ToolType UndoTool::nameID() const
+ToolType UndoTool::type() const
 {
     return ToolType::UNDO;
 }

--- a/src/tools/undo/undotool.h
+++ b/src/tools/undo/undotool.h
@@ -20,7 +20,7 @@ public:
     CaptureTool* copy(QObject* parent = nullptr) override;
 
 protected:
-    ToolType nameID() const override;
+    ToolType type() const override;
 
 public slots:
     void pressed(const CaptureContext& context) override;

--- a/src/utils/confighandler.cpp
+++ b/src/utils/confighandler.cpp
@@ -36,25 +36,9 @@ QVector<CaptureToolButton::ButtonType> ConfigHandler::getButtons()
         buttons = fromIntToButton(buttonsInt);
     } else {
         // Default tools
-        buttons << CaptureToolButton::TYPE_PENCIL
-                << CaptureToolButton::TYPE_DRAWER
-                << CaptureToolButton::TYPE_ARROW
-                << CaptureToolButton::TYPE_SELECTION
-                << CaptureToolButton::TYPE_RECTANGLE
-                << CaptureToolButton::TYPE_CIRCLE
-                << CaptureToolButton::TYPE_MARKER
-                << CaptureToolButton::TYPE_PIXELATE
-                << CaptureToolButton::TYPE_SELECTIONINDICATOR
-                << CaptureToolButton::TYPE_MOVESELECTION
-                << CaptureToolButton::TYPE_UNDO << CaptureToolButton::TYPE_REDO
-                << CaptureToolButton::TYPE_COPY << CaptureToolButton::TYPE_SAVE
-                << CaptureToolButton::TYPE_EXIT
-                << CaptureToolButton::TYPE_IMAGEUPLOADER
-#if !defined(Q_OS_MACOS)
-                << CaptureToolButton::TYPE_OPEN_APP
-#endif
-                << CaptureToolButton::TYPE_PIN << CaptureToolButton::TYPE_TEXT
-                << CaptureToolButton::TYPE_CIRCLECOUNT;
+        buttons = CaptureToolButton::getIterableButtonTypes();
+        buttons.removeOne(CaptureToolButton::TYPE_SIZEDECREASE);
+        buttons.removeOne(CaptureToolButton::TYPE_SIZEINCREASE);
     }
 
     using bt = CaptureToolButton::ButtonType;
@@ -613,11 +597,8 @@ void ConfigHandler::setDefaultSettings()
 
 void ConfigHandler::setAllTheButtons()
 {
-    QVector<int> buttons;
-    auto listTypes = CaptureToolButton::getIterableButtonTypes();
-    for (const CaptureToolButton::ButtonType t : listTypes) {
-        buttons << static_cast<int>(t);
-    }
+    QVector<int> buttons =
+      fromButtonToInt(CaptureToolButton::getIterableButtonTypes());
     // TODO: remove toList in v1.0
     m_settings.setValue(QStringLiteral("buttons"),
                         QVariant::fromValue(buttons.toList()));
@@ -630,10 +611,8 @@ QString ConfigHandler::configFilePath() const
 
 bool ConfigHandler::normalizeButtons(QVector<int>& buttons)
 {
-    auto listTypes = CaptureToolButton::getIterableButtonTypes();
-    QVector<int> listTypesInt;
-    for (auto i : listTypes)
-        listTypesInt << static_cast<int>(i);
+    QVector<int> listTypesInt =
+      fromButtonToInt(CaptureToolButton::getIterableButtonTypes());
 
     bool hasChanged = false;
     for (int i = 0; i < buttons.size(); i++) {

--- a/src/widgets/capture/capturetoolobjects.cpp
+++ b/src/widgets/capture/capturetoolobjects.cpp
@@ -99,7 +99,7 @@ int CaptureToolObjects::findWithRadius(QPainter& painter,
             m_imageCache.insert(0, image);
         }
 
-        if (toolItem->nameID() == ToolType::TEXT) {
+        if (toolItem->type() == ToolType::TEXT) {
             if (currentRadius > SEARCH_RADIUS_NEAR) {
                 // Text already has a big currentRadius and no need to search
                 // with a bit bigger currentRadius than

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -1026,7 +1026,12 @@ void CaptureWidget::setState(CaptureToolButton* b)
         }
     }
     if (m_activeButton != b) {
-        processTool(b->tool());
+        auto backup = m_activeTool;
+        // The tool is active during the pressed().
+        // This must be done in order to handle tool requests correctly.
+        m_activeTool = b->tool();
+        m_activeTool->pressed(m_context);
+        m_activeTool = backup;
     }
 
     // Only close activated from button
@@ -1065,15 +1070,6 @@ void CaptureWidget::loadDrawThickness()
         m_context.thickness = m_config.drawThicknessValue();
     }
     m_sidePanel->thicknessChanged(m_context.thickness);
-}
-
-void CaptureWidget::processTool(CaptureTool* t)
-{
-    auto backup = m_activeTool;
-    // The tool is active during the pressed().
-    m_activeTool = t;
-    t->pressed(m_context);
-    m_activeTool = backup;
 }
 
 void CaptureWidget::handleToolSignal(CaptureTool::Request r)

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -129,9 +129,11 @@ CaptureWidget::CaptureWidget(uint id,
         move(currentScreen->geometry().x(), currentScreen->geometry().y());
         resize(currentScreen->size());
 #else
-        // Comment For CaptureWidget Debugging under Linux
+
+#if (defined(QT_NO_DEBUG) && defined(Q_OS_LINUX))
         setWindowFlags(Qt::BypassWindowManagerHint | Qt::WindowStaysOnTopHint |
                        Qt::FramelessWindowHint | Qt::Tool);
+#endif
         resize(pixmap().size());
 #endif
     }

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -1328,25 +1328,22 @@ void CaptureWidget::selectAll()
 
 void CaptureWidget::initShortcuts()
 {
-    QString shortcut = ConfigHandler().shortcut(
-      QVariant::fromValue(CaptureToolButton::ButtonType::TYPE_EXIT).toString());
-    new QShortcut(QKeySequence(shortcut), this, SLOT(close()));
+    new QShortcut(
+      QKeySequence(ConfigHandler().shortcut("TYPE_EXIT")), this, SLOT(close()));
 
-    shortcut = ConfigHandler().shortcut(
-      QVariant::fromValue(CaptureToolButton::ButtonType::TYPE_SAVE).toString());
-    new QShortcut(QKeySequence(shortcut), this, SLOT(saveScreenshot()));
+    new QShortcut(QKeySequence(ConfigHandler().shortcut("TYPE_SAVE")),
+                  this,
+                  SLOT(saveScreenshot()));
 
-    shortcut = ConfigHandler().shortcut(
-      QVariant::fromValue(CaptureToolButton::ButtonType::TYPE_COPY).toString());
-    new QShortcut(QKeySequence(shortcut), this, SLOT(copyScreenshot()));
+    new QShortcut(QKeySequence(ConfigHandler().shortcut("TYPE_COPY")),
+                  this,
+                  SLOT(copyScreenshot()));
 
-    shortcut = ConfigHandler().shortcut(
-      QVariant::fromValue(CaptureToolButton::ButtonType::TYPE_UNDO).toString());
-    new QShortcut(QKeySequence(shortcut), this, SLOT(undo()));
+    new QShortcut(
+      QKeySequence(ConfigHandler().shortcut("TYPE_UNDO")), this, SLOT(undo()));
 
-    shortcut = ConfigHandler().shortcut(
-      QVariant::fromValue(CaptureToolButton::ButtonType::TYPE_REDO).toString());
-    new QShortcut(QKeySequence(shortcut), this, SLOT(redo()));
+    new QShortcut(
+      QKeySequence(ConfigHandler().shortcut("TYPE_REDO")), this, SLOT(redo()));
 
     new QShortcut(QKeySequence(ConfigHandler().shortcut("TYPE_TOGGLE_PANEL")),
                   this,
@@ -1377,6 +1374,7 @@ void CaptureWidget::initShortcuts()
     new QShortcut(QKeySequence(ConfigHandler().shortcut("TYPE_MOVE_DOWN")),
                   this,
                   SLOT(moveDown()));
+
     new QShortcut(
       QKeySequence(ConfigHandler().shortcut("TYPE_DELETE_CURRENT_TOOL")),
       this,

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -388,7 +388,7 @@ void CaptureWidget::showColorPicker(const QPoint& pos)
 bool CaptureWidget::startDrawObjectTool(const QPoint& pos)
 {
     if (m_activeButton && m_activeButton->tool() &&
-        m_activeButton->tool()->nameID() != ToolType::MOVE) {
+        m_activeButton->tool()->type() != ToolType::MOVE) {
         if (commitCurrentTool()) {
             return false;
         }
@@ -408,7 +408,7 @@ bool CaptureWidget::startDrawObjectTool(const QPoint& pos)
                 &CaptureWidget::handleToolSignal);
         m_context.mousePos = pos;
         m_activeTool->drawStart(m_context);
-        if (m_activeTool->nameID() == ToolType::CIRCLECOUNT) {
+        if (m_activeTool->type() == ToolType::CIRCLECOUNT) {
             // While it is based on AbstractTwoPointTool it has the only one
             // point and shouldn't wait for second point and move event
             m_activeTool->drawEnd(m_context.mousePos);
@@ -524,7 +524,7 @@ void CaptureWidget::mouseDoubleClickEvent(QMouseEvent* event)
     if (activeLayerIndex != -1) {
         // Start object editing
         auto activeTool = m_captureToolObjects.at(activeLayerIndex);
-        if (activeTool && activeTool->nameID() == ToolType::TEXT) {
+        if (activeTool && activeTool->type() == ToolType::TEXT) {
             m_activeTool = activeTool;
             m_mouseIsClicked = false;
             m_context.mousePos = *m_activeTool->pos();
@@ -578,7 +578,7 @@ void CaptureWidget::mouseMoveEvent(QMouseEvent* e)
     } else if (m_mouseIsClicked &&
                (!m_activeButton ||
                 (m_activeButton && m_activeButton->tool() &&
-                 m_activeButton->tool()->nameID() == ToolType::MOVE))) {
+                 m_activeButton->tool()->type() == ToolType::MOVE))) {
         // Drawing, moving, or stretching a selection
         m_selection->setVisible(true);
         if (m_buttonHandler->isVisible()) {
@@ -1063,8 +1063,8 @@ void CaptureWidget::setState(CaptureToolButton* b)
 void CaptureWidget::loadDrawThickness()
 {
     if ((m_activeButton && m_activeButton->tool() &&
-         m_activeButton->tool()->nameID() == ToolType::TEXT) ||
-        (m_activeTool && m_activeTool->nameID() == ToolType::TEXT)) {
+         m_activeButton->tool()->type() == ToolType::TEXT) ||
+        (m_activeTool && m_activeTool->type() == ToolType::TEXT)) {
         m_context.thickness = m_config.drawFontSizeValue();
     } else {
         m_context.thickness = m_config.drawThicknessValue();
@@ -1191,7 +1191,7 @@ void CaptureWidget::updateActiveLayer(const int& layer)
 {
     // TODO - refactor this part, make all objects to work with
     // m_activeTool->isChanged() and remove m_existingObjectIsChanged
-    if (m_activeTool && m_activeTool->nameID() == ToolType::TEXT &&
+    if (m_activeTool && m_activeTool->type() == ToolType::TEXT &&
         m_activeTool->isChanged()) {
         commitCurrentTool();
     }
@@ -1214,7 +1214,7 @@ void CaptureWidget::removeToolObject(int index)
     --index;
     if (index >= 0 && index < m_captureToolObjects.size()) {
         const ToolType currentToolType =
-          m_captureToolObjects.at(index)->nameID();
+          m_captureToolObjects.at(index)->type();
         m_captureToolObjectsBackup = m_captureToolObjects;
         m_captureToolObjects.removeAt(index);
         if (currentToolType == ToolType::CIRCLECOUNT) {
@@ -1222,7 +1222,7 @@ void CaptureWidget::removeToolObject(int index)
             int circleCount = 1;
             for (int cnt = 0; cnt < m_captureToolObjects.size(); cnt++) {
                 auto toolItem = m_captureToolObjects.at(cnt);
-                if (toolItem->nameID() != ToolType::CIRCLECOUNT) {
+                if (toolItem->type() != ToolType::CIRCLECOUNT) {
                     continue;
                 }
                 if (cnt >= index) {
@@ -1242,7 +1242,7 @@ void CaptureWidget::setDrawThickness(const int& t)
     // save draw thickness for text and other tool separately
     if (m_activeButton) {
         if (m_activeButton->tool() &&
-            m_activeButton->tool()->nameID() == ToolType::TEXT) {
+            m_activeButton->tool()->type() == ToolType::TEXT) {
             m_config.setDrawFontSize(m_context.thickness);
         } else {
             m_config.setDrawThickness(m_context.thickness);
@@ -1409,7 +1409,7 @@ void CaptureWidget::updateCursor()
             setCursor(Qt::ArrowCursor);
         }
     } else if (m_activeButton && m_activeButton->tool() &&
-               m_activeButton->tool()->nameID() == ToolType::MOVE) {
+               m_activeButton->tool()->type() == ToolType::MOVE) {
         setCursor(Qt::OpenHandCursor);
     } else if (!m_activeButton) {
         using sw = SelectionWidget;
@@ -1496,7 +1496,7 @@ void CaptureWidget::drawToolsData(bool updateLayersPanel, bool drawSelection)
     QPixmap pixmapItem = m_context.origScreenshot.copy();
     int circleCount = 1;
     for (auto toolItem : m_captureToolObjects.captureToolObjects()) {
-        if (toolItem->nameID() == ToolType::CIRCLECOUNT) {
+        if (toolItem->type() == ToolType::CIRCLECOUNT) {
             toolItem->setCount(circleCount++);
         }
         processPixmapWithTool(&pixmapItem, toolItem);

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -1213,8 +1213,7 @@ void CaptureWidget::removeToolObject(int index)
 {
     --index;
     if (index >= 0 && index < m_captureToolObjects.size()) {
-        const ToolType currentToolType =
-          m_captureToolObjects.at(index)->type();
+        const ToolType currentToolType = m_captureToolObjects.at(index)->type();
         m_captureToolObjectsBackup = m_captureToolObjects;
         m_captureToolObjects.removeAt(index);
         if (currentToolType == ToolType::CIRCLECOUNT) {

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -131,10 +131,11 @@ CaptureWidget::CaptureWidget(uint id,
         move(currentScreen->geometry().x(), currentScreen->geometry().y());
         resize(currentScreen->size());
 #else
-        // Comment For CaptureWidget Debugging under Linux
+#if !(defined(QT_DEBUG) && defined(Q_OS_LINUX))
         setWindowFlags(Qt::BypassWindowManagerHint | Qt::WindowStaysOnTopHint |
                        Qt::FramelessWindowHint | Qt::Tool);
         resize(pixmap().size());
+#endif
 #endif
     }
     // Create buttons

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -1494,14 +1494,12 @@ void CaptureWidget::pushToolToStack()
 void CaptureWidget::drawToolsData(bool updateLayersPanel, bool drawSelection)
 {
     QPixmap pixmapItem = m_context.origScreenshot.copy();
-    QPainter painter(&pixmapItem);
-    painter.setRenderHint(QPainter::Antialiasing);
     int circleCount = 1;
     for (auto toolItem : m_captureToolObjects.captureToolObjects()) {
         if (toolItem->nameID() == ToolType::CIRCLECOUNT) {
             toolItem->setCount(circleCount++);
         }
-        toolItem->process(painter, pixmapItem);
+        processPixmapWithTool(&pixmapItem, toolItem);
     }
 
     m_context.screenshot = pixmapItem.copy();
@@ -1533,6 +1531,13 @@ void CaptureWidget::drawObjectSelection()
             uncheckActiveTool();
         }
     }
+}
+
+void CaptureWidget::processPixmapWithTool(QPixmap* pixmap, CaptureTool* tool)
+{
+    QPainter painter(pixmap);
+    painter.setRenderHint(QPainter::Antialiasing);
+    tool->process(painter, *pixmap);
 }
 
 QPointer<CaptureTool> CaptureWidget::activeToolObject()
@@ -1567,9 +1572,7 @@ void CaptureWidget::copyScreenshot()
 {
     m_captureDone = true;
     if (m_activeTool != nullptr) {
-        QPainter painter(&m_context.screenshot);
-        painter.setRenderHint(QPainter::Antialiasing);
-        m_activeTool->process(painter, m_context.screenshot);
+        processPixmapWithTool(&m_context.screenshot, m_activeTool);
     }
 
     ScreenshotSaver().saveToClipboard(pixmap());
@@ -1583,9 +1586,7 @@ void CaptureWidget::saveScreenshot()
 #endif
     m_captureDone = true;
     if (m_activeTool != nullptr) {
-        QPainter painter(&m_context.screenshot);
-        painter.setRenderHint(QPainter::Antialiasing);
-        m_activeTool->process(painter, m_context.screenshot);
+        processPixmapWithTool(&m_context.screenshot, m_activeTool);
     }
     hide();
     if (m_context.savePath.isEmpty()) {

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -747,7 +747,7 @@ void CaptureWidget::mouseReleaseEvent(QMouseEvent* e)
             newGeometry.setBottom(top);
         }
         m_selection->setGeometry(newGeometry);
-        m_context.selection = extendedRect(&newGeometry);
+        m_context.selection = extendedRect(newGeometry);
         updateSizeIndicator();
         m_buttonHandler->updatePosition(newGeometry);
         m_buttonHandler->show();
@@ -1280,7 +1280,7 @@ void CaptureWidget::repositionSelection(QRect r)
     if (m_selection->isVisible()) {
         m_selection->setGeometry(r);
         QRect newGeometry = m_selection->geometry().intersected(rect());
-        m_context.selection = extendedRect(&newGeometry);
+        m_context.selection = extendedRect(newGeometry);
         m_buttonHandler->updatePosition(m_selection->geometry());
         updateSizeIndicator();
         update();
@@ -1319,7 +1319,7 @@ void CaptureWidget::selectAll()
 {
     QRect newGeometry = rect();
     m_selection->setGeometry(newGeometry);
-    m_context.selection = extendedRect(&newGeometry);
+    m_context.selection = extendedRect(newGeometry);
     m_selection->setVisible(true);
     m_showInitialMsg = false;
     m_buttonHandler->updatePosition(m_selection->geometry());
@@ -1646,16 +1646,16 @@ QRect CaptureWidget::extendedSelection() const
         return QRect();
     }
     QRect r = m_selection->geometry();
-    return extendedRect(&r);
+    return extendedRect(r);
 }
 
-QRect CaptureWidget::extendedRect(QRect* r) const
+QRect CaptureWidget::extendedRect(const QRect& r) const
 {
     auto devicePixelRatio = m_context.screenshot.devicePixelRatio();
-    return QRect(r->left() * devicePixelRatio,
-                 r->top() * devicePixelRatio,
-                 r->width() * devicePixelRatio,
-                 r->height() * devicePixelRatio);
+    return QRect(r.left() * devicePixelRatio,
+                 r.top() * devicePixelRatio,
+                 r.width() * devicePixelRatio,
+                 r.height() * devicePixelRatio);
 }
 
 void CaptureWidget::drawInitialMessage(QPainter* painter)

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -84,6 +84,8 @@ CaptureWidget::CaptureWidget(uint id,
     setAttribute(Qt::WA_DeleteOnClose);
     m_showInitialMsg = m_config.showHelpValue();
     m_opacity = m_config.contrastOpacityValue();
+    m_uiColor = m_config.uiMainColorValue();
+    m_contrastUiColor = m_config.uiContrastColorValue();
     setMouseTracking(true);
     initContext(savePath, fullScreen);
     initShortcuts();
@@ -204,9 +206,6 @@ CaptureWidget::~CaptureWidget()
 // selection in the capture
 void CaptureWidget::updateButtons()
 {
-    m_uiColor = m_config.uiMainColorValue();
-    m_contrastUiColor = m_config.uiContrastColorValue();
-
     auto allButtonTypes = CaptureToolButton::getIterableButtonTypes();
     auto visibleButtonTypes = m_config.getButtons();
     QVector<CaptureToolButton*> vectorButtons;

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -131,11 +131,9 @@ CaptureWidget::CaptureWidget(uint id,
         move(currentScreen->geometry().x(), currentScreen->geometry().y());
         resize(currentScreen->size());
 #else
-
-#if (defined(QT_NO_DEBUG) && defined(Q_OS_LINUX))
+        // Comment For CaptureWidget Debugging under Linux
         setWindowFlags(Qt::BypassWindowManagerHint | Qt::WindowStaysOnTopHint |
                        Qt::FramelessWindowHint | Qt::Tool);
-#endif
         resize(pixmap().size());
 #endif
     }

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -961,8 +961,8 @@ void CaptureWidget::initPanel()
             &SidePanelWidget::togglePanel,
             m_panel,
             &UtilityPanel::toggle);
-    m_sidePanel->colorChanged(m_context.color);
-    m_sidePanel->thicknessChanged(m_context.thickness);
+    emit m_sidePanel->colorChanged(m_context.color);
+    emit m_sidePanel->thicknessChanged(m_context.thickness);
     m_panel->pushWidget(m_sidePanel);
 
     // Fill undo/redo/history list widget
@@ -1069,7 +1069,7 @@ void CaptureWidget::loadDrawThickness()
     } else {
         m_context.thickness = m_config.drawThicknessValue();
     }
-    m_sidePanel->thicknessChanged(m_context.thickness);
+    emit m_sidePanel->thicknessChanged(m_context.thickness);
 }
 
 void CaptureWidget::handleToolSignal(CaptureTool::Request r)
@@ -1181,7 +1181,7 @@ void CaptureWidget::setDrawColor(const QColor& c)
         auto toolItem = activeToolObject();
         if (toolItem) {
             // Change color
-            emit toolItem->colorChanged(c);
+            toolItem->colorChanged(c);
             drawToolsData(false, true);
         }
     }
@@ -1252,7 +1252,7 @@ void CaptureWidget::setDrawThickness(const int& t)
     auto toolItem = activeToolObject();
     if (toolItem) {
         // Change thickness
-        emit toolItem->thicknessChanged(t);
+        toolItem->thicknessChanged(t);
         drawToolsData(false, true);
     } else {
         emit thicknessChanged(m_context.thickness);
@@ -1381,7 +1381,7 @@ void CaptureWidget::initShortcuts()
 void CaptureWidget::deleteCurrentTool()
 {
     int thickness_old = m_context.thickness;
-    emit m_panel->slotButtonDelete(true);
+    m_panel->slotButtonDelete(true);
     drawObjectSelection();
     if (thickness_old != m_context.thickness) {
         emit thicknessChanged(m_context.thickness);

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -246,7 +246,7 @@ void CaptureWidget::initButtons()
         connect(b->tool(),
                 &CaptureTool::requestAction,
                 this,
-                &CaptureWidget::handleButtonSignal);
+                &CaptureWidget::handleToolSignal);
 
         if (visibleButtonTypes.contains(t)) {
             connect(b,
@@ -414,7 +414,7 @@ bool CaptureWidget::startDrawObjectTool(const QPoint& pos)
         connect(m_activeTool,
                 &CaptureTool::requestAction,
                 this,
-                &CaptureWidget::handleButtonSignal);
+                &CaptureWidget::handleToolSignal);
         m_context.mousePos = pos;
         m_activeTool->drawStart(m_context);
         if (m_activeTool->nameID() == ToolType::CIRCLECOUNT) {
@@ -541,7 +541,7 @@ void CaptureWidget::mouseDoubleClickEvent(QMouseEvent* event)
             m_activeTool->setEditMode(true);
             drawToolsData(true, false);
             m_mouseIsClicked = false;
-            handleButtonSignal(CaptureTool::REQ_ADD_CHILD_WIDGET);
+            handleToolSignal(CaptureTool::REQ_ADD_CHILD_WIDGET);
             m_panel->setToolWidget(m_activeTool->configurationWidget());
         }
     }
@@ -1085,7 +1085,7 @@ void CaptureWidget::processTool(CaptureTool* t)
     m_activeTool = backup;
 }
 
-void CaptureWidget::handleButtonSignal(CaptureTool::Request r)
+void CaptureWidget::handleToolSignal(CaptureTool::Request r)
 {
     switch (r) {
         case CaptureTool::REQ_CLEAR_MODIFICATIONS:

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -141,7 +141,7 @@ CaptureWidget::CaptureWidget(uint id,
     }
     // Create buttons
     m_buttonHandler = new ButtonHandler(this);
-    updateButtons();
+    initButtons();
     QVector<QRect> areas;
     if (m_context.fullscreen) {
         QPoint topLeftOffset = QPoint(0, 0);
@@ -202,9 +202,7 @@ CaptureWidget::~CaptureWidget()
     }
 }
 
-// redefineButtons retrieves the buttons configured to be shown with the
-// selection in the capture
-void CaptureWidget::updateButtons()
+void CaptureWidget::initButtons()
 {
     auto allButtonTypes = CaptureToolButton::getIterableButtonTypes();
     auto visibleButtonTypes = m_config.getButtons();

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -263,15 +263,6 @@ void CaptureWidget::initButtons()
 
 QPixmap CaptureWidget::pixmap()
 {
-    QPixmap p;
-    if (m_toolWidget && m_activeTool) {
-        p = m_context.selectedScreenshotArea().copy();
-        QPainter painter(&p);
-        painter.setRenderHint(QPainter::Antialiasing);
-        m_activeTool->process(painter, p);
-    } else {
-        p = m_context.selectedScreenshotArea();
-    }
     return m_context.selectedScreenshotArea();
 }
 

--- a/src/widgets/capture/capturewidget.h
+++ b/src/widgets/capture/capturewidget.h
@@ -45,7 +45,6 @@ public:
                            QWidget* parent = nullptr);
     ~CaptureWidget();
 
-    void updateButtons();
     QPixmap pixmap();
     void showAppUpdateNotification(const QString& appLatestVersion,
                                    const QString& appLatestUrl);
@@ -120,6 +119,7 @@ private:
     void initPanel();
     void initSelection();
     void initShortcuts();
+    void initButtons();
     void updateSizeIndicator();
     void updateCursor();
     void pushToolToStack();

--- a/src/widgets/capture/capturewidget.h
+++ b/src/widgets/capture/capturewidget.h
@@ -130,7 +130,7 @@ private:
     void moveSelection(QPoint p);
 
     QRect extendedSelection() const;
-    QRect extendedRect(QRect* r) const;
+    QRect extendedRect(const QRect& r) const;
     void drawInitialMessage(QPainter* painter);
     void drawInactiveRegion(QPainter* painter);
     void drawToolsData(bool updateLayersPanel = true,

--- a/src/widgets/capture/capturewidget.h
+++ b/src/widgets/capture/capturewidget.h
@@ -85,7 +85,6 @@ private slots:
     void deleteCurrentTool();
 
     void setState(CaptureToolButton* b);
-    void processTool(CaptureTool* t);
     void handleToolSignal(CaptureTool::Request r);
     void setDrawColor(const QColor& c);
     void setDrawThickness(const int& t);

--- a/src/widgets/capture/capturewidget.h
+++ b/src/widgets/capture/capturewidget.h
@@ -86,7 +86,7 @@ private slots:
 
     void setState(CaptureToolButton* b);
     void processTool(CaptureTool* t);
-    void handleButtonSignal(CaptureTool::Request r);
+    void handleToolSignal(CaptureTool::Request r);
     void setDrawColor(const QColor& c);
     void setDrawThickness(const int& t);
     void updateActiveLayer(const int& layer);

--- a/src/widgets/capture/capturewidget.h
+++ b/src/widgets/capture/capturewidget.h
@@ -136,6 +136,8 @@ private:
                        bool drawSelection = false);
     void drawObjectSelection();
 
+    void processPixmapWithTool(QPixmap* pixmap, CaptureTool* tool);
+
     ////////////////////////////////////////
     // Class members
 


### PR DESCRIPTION
Some notes:
- I think we should gradually move towards decoupling `CaptureTool` from
  `CaptureToolButton`. The code will be more readable that way and it will add
  more room for features that allow tools to be activated by means other than
  by buttons (or shortcuts).
- The `pixmap()` method contained a block of code that modified a local object
  without returning it, hence being useless. This could either be redundant
  code, or a bug. From what I could gather this was meant to apply the changes
  to the output image if the text tool was active when you triggered
  save/copy/etc. But I have verified that the image gets saved regardless, so I
  don't think it is a bug.
- I smuggled in a commit that refactors the config part a bit. I was supposed
  to add it in a previous pull request, but I accidentally put it in the
  wrong branch so here it is :)
- In the latest commit I added a small comment among all things, please verify that it is
  correct
- Just throwing this idea in: I think signals and slots should to be renamed so
  that you can identify which is which from the name. I haven't done this here.
- This is just a thought of mine, haven't really thought it through: Maybe it
  would be more elegant to do away with a fair bit of sigslots. Maybe store a
  reference or pointer to `CaptureWidget` in the tools/buttons. And let them
  access various functions directly. One major beneficiary of this would be
  the `requestAction` mechanism, which doesn't seem very elegant to me.
- It seems to me that there are a lot of instances where something is
  implemented in an abstract class that only a few derived classes use. This
  point is related to the previous one.

Perhaps these observations have been made already. But I can't risk any idea going
to waste!

