### PR TITLE
Minor improvements to app launcher

### DIFF
--- a/src/tools/launcher/applauncherwidget.cpp
+++ b/src/tools/launcher/applauncherwidget.cpp
@@ -18,6 +18,7 @@
 #include <QPixmap>
 #include <QProcess>
 #include <QTabWidget>
+#include <QKeyEvent>
 
 namespace {
 
@@ -245,5 +246,14 @@ void AppLauncherWidget::addAppsToListWidget(
         buttonItem->setIcon(app.icon);
         buttonItem->setText(app.name);
         buttonItem->setToolTip(app.description);
+    }
+}
+
+void AppLauncherWidget::keyPressEvent(QKeyEvent *keyEvent)
+{
+    if (keyEvent->key() == Qt::Key_Escape) {
+        close();
+    } else {
+        QWidget::keyPressEvent(keyEvent);
     }
 }

--- a/src/tools/launcher/applauncherwidget.cpp
+++ b/src/tools/launcher/applauncherwidget.cpp
@@ -10,6 +10,7 @@
 #include <QCheckBox>
 #include <QDir>
 #include <QHBoxLayout>
+#include <QKeyEvent>
 #include <QLineEdit>
 #include <QList>
 #include <QListView>
@@ -18,7 +19,6 @@
 #include <QPixmap>
 #include <QProcess>
 #include <QTabWidget>
-#include <QKeyEvent>
 
 namespace {
 
@@ -249,7 +249,7 @@ void AppLauncherWidget::addAppsToListWidget(
     }
 }
 
-void AppLauncherWidget::keyPressEvent(QKeyEvent *keyEvent)
+void AppLauncherWidget::keyPressEvent(QKeyEvent* keyEvent)
 {
     if (keyEvent->key() == Qt::Key_Escape) {
         close();

--- a/src/tools/launcher/applauncherwidget.h
+++ b/src/tools/launcher/applauncherwidget.h
@@ -30,6 +30,7 @@ private:
     void configureListView(QListWidget* widget);
     void addAppsToListWidget(QListWidget* widget,
                              const QVector<DesktopAppData>& appList);
+    void keyPressEvent(QKeyEvent *keyEvent) override;
 
     DesktopFileParser m_parser;
     QPixmap m_pixmap;

--- a/src/tools/launcher/applauncherwidget.h
+++ b/src/tools/launcher/applauncherwidget.h
@@ -30,7 +30,7 @@ private:
     void configureListView(QListWidget* widget);
     void addAppsToListWidget(QListWidget* widget,
                              const QVector<DesktopAppData>& appList);
-    void keyPressEvent(QKeyEvent *keyEvent) override;
+    void keyPressEvent(QKeyEvent* keyEvent) override;
 
     DesktopFileParser m_parser;
     QPixmap m_pixmap;

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -1158,6 +1158,7 @@ void CaptureWidget::handleButtonSignal(CaptureTool::Request r)
             } else {
                 QWidget* w = m_activeTool->widget();
                 w->setAttribute(Qt::WA_DeleteOnClose);
+                w->activateWindow();
                 w->show();
             }
             break;


### PR DESCRIPTION
The "Activate external widget" commit was added because the app launcher didn't get focused automatically in i3wm, at least on my machine. Didn't observe that effect in Ubuntu 20.04, with a stock DE.