### PR TITLE
Show shortcuts in CaptureToolButton tooltips

### DIFF
--- a/src/tools/sizeindicator/sizeindicatortool.cpp
+++ b/src/tools/sizeindicator/sizeindicatortool.cpp
@@ -30,7 +30,7 @@ ToolType SizeIndicatorTool::nameID() const
 
 QString SizeIndicatorTool::description() const
 {
-    return tr("Show the dimensions of the selection (X Y)");
+    return tr("Show X and Y dimensions of the selection");
 }
 
 CaptureTool* SizeIndicatorTool::copy(QObject* parent)

--- a/src/widgets/capture/capturetoolbutton.cpp
+++ b/src/widgets/capture/capturetoolbutton.cpp
@@ -58,7 +58,14 @@ void CaptureToolButton::initButton()
                           GlobalValues::buttonBaseSize() + 2),
                     QRegion::Ellipse));
 
-    setToolTip(m_tool->description());
+    // Set a tooltip showing a shortcut in parentheses (if there is a shortcut)
+    QString tooltip = m_tool->description();
+    QString shortcut =
+      ConfigHandler().shortcut(QVariant::fromValue(m_buttonType).toString());
+    if (!shortcut.isEmpty()) {
+        tooltip += QString(" (%1)").arg(shortcut);
+    }
+    setToolTip(tooltip);
 
     m_emergeAnimation = new QPropertyAnimation(this, "size", this);
     m_emergeAnimation->setEasingCurve(QEasingCurve::InOutQuad);


### PR DESCRIPTION
Sometimes I forget which shortcuts I have on the buttons I use less often, this feature will come in handy. Didn't bother to create an issue since the changes are trivial.