### PR TITLE
Add --clipboard to gui subcommand

### DIFF
--- a/data/dbus/org.flameshot.Flameshot.xml
+++ b/data/dbus/org.flameshot.Flameshot.xml
@@ -5,6 +5,7 @@
       <!--
         graphicCapture:
         @path: the path where the screenshot will be saved. When the argument is empty the program will ask for a path graphically.
+        @toClipboard: Whether to copy the screenshot to clipboard or not.
         @delay: delay time in milliseconds.
         @id: identificator of the call.
 
@@ -13,6 +14,7 @@
     -->
     <method name="graphicCapture">
       <arg name="path" type="s" direction="in"/>
+      <arg name="toClipboard" type="b" direction="in"/>
       <arg name="delay" type="i" direction="in"/>
       <arg name="id" type="u" direction="in"/>
     </method>

--- a/src/core/controller.cpp
+++ b/src/core/controller.cpp
@@ -140,6 +140,11 @@ void Controller::setCheckForUpdatesEnabled(const bool enabled)
     }
 }
 
+QMap<uint, CaptureRequest>& Controller::requests()
+{
+    return m_requestMap;
+}
+
 void Controller::getLatestAvailableVersion()
 {
     // This features is required for MacOS and Windows user and for Linux users

--- a/src/core/controller.h
+++ b/src/core/controller.h
@@ -42,6 +42,8 @@ public:
 
     void setCheckForUpdatesEnabled(const bool enabled);
 
+    QMap<uint, CaptureRequest>& requests();
+
 signals:
     void captureTaken(uint id, QPixmap p, QRect selection);
     void captureFailed(uint id);

--- a/src/core/flameshotdbusadapter.cpp
+++ b/src/core/flameshotdbusadapter.cpp
@@ -28,12 +28,15 @@ FlameshotDBusAdapter::FlameshotDBusAdapter(QObject* parent)
 
 FlameshotDBusAdapter::~FlameshotDBusAdapter() {}
 
-void FlameshotDBusAdapter::graphicCapture(QString path, int delay, uint id)
+void FlameshotDBusAdapter::graphicCapture(QString path,
+                                          bool toClipboard,
+                                          int delay,
+                                          uint id)
 {
     CaptureRequest req(CaptureRequest::GRAPHICAL_MODE, delay, path);
-    //    if (toClipboard) {
-    //        req.addTask(CaptureRequest::CLIPBOARD_SAVE_TASK);
-    //    }
+    if (toClipboard) {
+        req.addTask(CaptureRequest::CLIPBOARD_SAVE_TASK);
+    }
     req.setStaticID(id);
     Controller::getInstance()->requestCapture(req);
 }

--- a/src/core/flameshotdbusadapter.h
+++ b/src/core/flameshotdbusadapter.h
@@ -21,7 +21,10 @@ signals:
     void captureSaved(uint id, QString savePath);
 
 public slots:
-    Q_NOREPLY void graphicCapture(QString path, int delay, uint id);
+    Q_NOREPLY void graphicCapture(QString path,
+                                  bool toClipboard,
+                                  int delay,
+                                  uint id);
     Q_NOREPLY void fullScreen(QString path,
                               bool toClipboard,
                               int delay,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -247,9 +247,12 @@ int main(int argc, char* argv[])
     parser.AddArgument(configArgument);
     auto helpOption = parser.addHelpOption();
     auto versionOption = parser.addVersionOption();
-    parser.AddOptions(
-      { pathOption, delayOption, rawImageOption, selectionOption },
-      guiArgument);
+    parser.AddOptions({ pathOption,
+                        clipboardOption,
+                        delayOption,
+                        rawImageOption,
+                        selectionOption },
+                      guiArgument);
     parser.AddOptions({ screenNumberOption,
                         clipboardOption,
                         pathOption,
@@ -289,10 +292,14 @@ int main(int argc, char* argv[])
     } else if (parser.isSet(guiArgument)) { // GUI
         QString pathValue = parser.value(pathOption);
         int delay = parser.value(delayOption).toInt();
+        bool toClipboard = parser.isSet(clipboardOption);
         bool isRaw = parser.isSet(rawImageOption);
         bool isSelection = parser.isSet(selectionOption);
         DBusUtils dbusUtils;
         CaptureRequest req(CaptureRequest::GRAPHICAL_MODE, delay, pathValue);
+        if (toClipboard) {
+            req.addTask(CaptureRequest::CLIPBOARD_SAVE_TASK);
+        }
         uint id = req.id();
 
         // Send message
@@ -301,7 +308,7 @@ int main(int argc, char* argv[])
           QStringLiteral("/"),
           QLatin1String(""),
           QStringLiteral("graphicCapture"));
-        m << pathValue << delay << id;
+        m << pathValue << toClipboard << delay << id;
         QDBusConnection sessionBus = QDBusConnection::sessionBus();
         dbusUtils.checkDBusConnection(sessionBus);
         sessionBus.call(m);

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -1574,7 +1574,9 @@ void CaptureWidget::copyScreenshot()
         processPixmapWithTool(&m_context.screenshot, m_activeTool);
     }
 
-    ScreenshotSaver().saveToClipboard(pixmap());
+    auto req = Controller::getInstance()->requests().find(m_id);
+    req->addTask(CaptureRequest::CLIPBOARD_SAVE_TASK);
+
     close();
 }
 


### PR DESCRIPTION
Tracks issue #1559.

When you run `flameshot gui --clipboard`, any action that closes the GUI (except for pressing Escape) will copy the screenshot to the clipboard.

This patch currently has a minor problem. If you click copy to clipboard in the GUI, you will get the notification "Capture saved to clipboard" twice - once from the button and once from the `--clipboard` option. Need to figure out a good way to suppress this.