### PR TITLE
Some tweaks to the capture GUI

### DIFF
--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -49,7 +49,7 @@ CaptureWidget::CaptureWidget(uint id,
                              QWidget* parent)
   : QWidget(parent)
   , m_mouseIsClicked(false)
-  , m_newSelection(false)
+  , m_newSelection(true)
   , m_grabbing(false)
   , m_captureDone(false)
   , m_previewEnabled(true)
@@ -493,7 +493,6 @@ void CaptureWidget::mousePressEvent(QMouseEvent* e)
                 m_selection->setGeometry(
                   QRect(m_mousePressedPos, m_mousePressedPos));
                 m_selection->setVisible(false);
-                m_newSelection = true;
                 m_buttonHandler->hide();
                 update();
             } else {
@@ -740,8 +739,10 @@ void CaptureWidget::mouseReleaseEvent(QMouseEvent* e)
     }
     m_mouseIsClicked = false;
     m_activeToolIsMoved = false;
-    m_newSelection = false;
     m_grabbing = false;
+    if (m_selection->isVisible()) {
+        m_newSelection = false;
+    }
 
     updateCursor();
 }

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -215,6 +215,7 @@ void CaptureWidget::initButtons()
             m_sizeIndButton = b;
         }
         b->setColor(m_uiColor);
+        b->hide();
         makeChild(b);
 
         switch (t) {
@@ -253,8 +254,6 @@ void CaptureWidget::initButtons()
                     this,
                     &CaptureWidget::setState);
             vectorButtons << b;
-        } else {
-            b->hide();
         }
     }
     m_buttonHandler->setButtons(vectorButtons);
@@ -663,7 +662,7 @@ void CaptureWidget::mouseMoveEvent(QMouseEvent* e)
               m_buttonHandler->contains(m_context.mousePos);
             if (containsMouse) {
                 m_buttonHandler->hide();
-            } else {
+            } else if (m_selection->isVisible()) {
                 m_buttonHandler->show();
             }
         }

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -188,6 +188,10 @@ CaptureWidget::CaptureWidget(uint id,
     // Init notification widget
     m_notifierBox = new NotifierBox(this);
     m_notifierBox->hide();
+    connect(m_notifierBox, &NotifierBox::hidden, this, [this]() {
+        // Show cursor if it was hidden while adjusting tool thickness
+        updateCursor();
+    });
 
     initPanel();
 }
@@ -765,6 +769,7 @@ void CaptureWidget::updateThickness(int thicknessOffset)
 
     if (m_activeButton && m_activeButton->tool() &&
         m_activeButton->tool()->showMousePreview()) {
+        setCursor(Qt::BlankCursor);
         update();
     }
 

--- a/src/widgets/capture/capturewidget.h
+++ b/src/widgets/capture/capturewidget.h
@@ -127,6 +127,7 @@ private:
     void repositionSelection(QRect r);
     void adjustSelection(QMargins m);
     void moveSelection(QPoint p);
+    void updateThickness(int thicknessOffset);
 
     QRect extendedSelection() const;
     QRect extendedRect(const QRect& r) const;

--- a/src/widgets/capture/notifierbox.cpp
+++ b/src/widgets/capture/notifierbox.cpp
@@ -57,3 +57,8 @@ void NotifierBox::showColor(const QColor& color)
     Q_UNUSED(color)
     m_message = QLatin1String("");
 }
+
+void NotifierBox::hideEvent(QHideEvent* event)
+{
+    emit hidden();
+}

--- a/src/widgets/capture/notifierbox.h
+++ b/src/widgets/capture/notifierbox.h
@@ -17,6 +17,9 @@ protected:
     virtual void enterEvent(QEvent*);
     virtual void paintEvent(QPaintEvent*);
 
+signals:
+    void hidden();
+
 public slots:
     void showMessage(const QString& msg);
     void showColor(const QColor& color);
@@ -26,4 +29,6 @@ private:
     QString m_message;
     QColor m_bgColor;
     QColor m_foregroundColor;
+
+    void hideEvent(QHideEvent* event) override;
 };


### PR DESCRIPTION
- There was a small bug: when you select a tool with the keyboard and draw before making a selection, the capture buttons would show in the top left corner
- After you have done the above and selected the move tool afterwards, the move tool wouldn't create a new selection. Instead it would create a 0-sized selection in the top left corner regardless of where you clicked
- The last two commits are self-explanatory

Actually, with the last commit I smuggled in a mini feature. Hope you don't mind :)

Here's a showcase of the second and last commit:
![recording](https://user-images.githubusercontent.com/29044423/130534554-ce094e75-18f0-4158-b6d1-bb7bdbc6cdb3.gif)
