### PR TITLE
Fix debug option for capture mode

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -222,6 +222,11 @@ target_compile_definitions(flameshot PRIVATE APP_VERSION="v${PROJECT_VERSION}")
 target_compile_definitions(flameshot PRIVATE IMGUR_CLIENT_ID="313baf0c7b4d3ff")
 #target_compile_definitions(flameshot PRIVATE QAPPLICATION_CLASS=QApplication)
 target_compile_definitions(flameshot PRIVATE FLAMESHOT_APP_VERSION_URL="${GIT_API_URL}")
+# Enable easier debugging of screenshot capture mode
+if (DEFINED FLAMESHOT_DEBUG_CAPTURE)
+    target_compile_definitions(flameshot PRIVATE
+        FLAMESHOT_DEBUG_CAPTURE="${FLAMESHOT_DEBUG_CAPTURE}")
+endif ()
 
 foreach (FILE ${QM_FILES})
     get_filename_component(F_NAME ${FILE} NAME)

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -132,7 +132,8 @@ CaptureWidget::CaptureWidget(uint id,
         move(currentScreen->geometry().x(), currentScreen->geometry().y());
         resize(currentScreen->size());
 #else
-#if !(defined(QT_DEBUG) && defined(Q_OS_LINUX))
+// Call cmake with -DFLAMESHOT_DEBUG_CAPTURE=true to enable easier debugging
+#if !defined(FLAMESHOT_DEBUG_CAPTURE)
         setWindowFlags(Qt::BypassWindowManagerHint | Qt::WindowStaysOnTopHint |
                        Qt::FramelessWindowHint | Qt::Tool);
         resize(pixmap().size());


### PR DESCRIPTION
Addresses #1883.

Added a cmake option FLAMESHOT_DEBUG_CAPTURE that disables
window-manager-bypassing. The previous method caused confusion.
