### PR TITLE
Fix FLAMESHOT_DEBUG_CAPTURE cmake option

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -223,9 +223,8 @@ target_compile_definitions(flameshot PRIVATE IMGUR_CLIENT_ID="313baf0c7b4d3ff")
 #target_compile_definitions(flameshot PRIVATE QAPPLICATION_CLASS=QApplication)
 target_compile_definitions(flameshot PRIVATE FLAMESHOT_APP_VERSION_URL="${GIT_API_URL}")
 # Enable easier debugging of screenshot capture mode
-if (DEFINED FLAMESHOT_DEBUG_CAPTURE)
-    target_compile_definitions(flameshot PRIVATE
-        FLAMESHOT_DEBUG_CAPTURE="${FLAMESHOT_DEBUG_CAPTURE}")
+if (FLAMESHOT_DEBUG_CAPTURE)
+    target_compile_definitions(flameshot PRIVATE FLAMESHOT_DEBUG_CAPTURE)
 endif ()
 
 foreach (FILE ${QM_FILES})


### PR DESCRIPTION
Closes #1886.

Issue was caused by me and @borgmanJeremy using incompatible approaches to add the
`FLAMESHOT_DEBUG_CAPTURE` option.
