### PR TITLE
Add the 'commit text in text area' hotkey to the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ These shortcuts are available in GUI mode:
 | <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>Z</kbd>                                            | Redo the next modification                    |
 | <kbd>Ctrl</kbd> + <kbd>Q</kbd>                                            | Leave the capture screen                                         |
 | <kbd>Ctrl</kbd> + <kbd>O</kbd>                                            | Choose an app to open the capture                                |
+| <kbd>Ctrl</kbd> + <kbd>Return</kbd>                                            | Commit text in text area|
 | <kbd>Return</kbd>                                             | Upload the selection to Imgur                                      |
 | <kbd>Spacebar</kbd>                                                       | Toggle visibility of sidebar with options of the selected tool, color picker for the drawing color and history menu |
 | Right Click                                                               | Show the color wheel                                              |


### PR DESCRIPTION
We add the hotkey for 'Commit text in text area' (C-Ret) to the documentation.

Pull request info:
The hotkey for 'commit text in text area' is currently tucked away in the configuration. At an initial glance, it might not be apparent to a user that this hotkey exists. I think it would be a good idea to add it to the docs.