### PR TITLE
Unify the badge style in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,19 +20,19 @@
       <img src="https://img.shields.io/github/workflow/status/flameshot-org/flameshot/Packaging(MacOS)?label=macos" alt="MacOS Build Status" />
     </a>
     <a href="https://github.com/flameshot-org/flameshot/releases">
-      <img src="https://img.shields.io/github/release/flameshot-org/flameshot.svg?style=flat-square" alt="Latest Stable Release" />
+      <img src="https://img.shields.io/github/release/flameshot-org/flameshot.svg" alt="Latest Stable Release" />
     </a>
     <a href="https://github.com/flameshot-org/flameshot/releases">
-      <img src="https://img.shields.io/github/downloads/flameshot-org/flameshot/total.svg?style=flat-square" alt="Total Downloads" />
+      <img src="https://img.shields.io/github/downloads/flameshot-org/flameshot/total.svg" alt="Total Downloads" />
     </a>
     <a href="https://github.com/flameshot-org/flameshot/blob/master/LICENSE">
-      <img src="https://img.shields.io/github/license/flameshot-org/flameshot.svg?style=flat-square" alt="License" />
+      <img src="https://img.shields.io/github/license/flameshot-org/flameshot.svg" alt="License" />
     </a>
   <a href="https://hosted.weblate.org/engage/flameshot/">
     <img src="https://hosted.weblate.org/widgets/flameshot/-/flameshot/svg-badge.svg" alt="Translation status" />
   </a>
   <a href="https://flameshot.org">
-      <img src="https://img.shields.io/github/release/flameshot-org/flameshot.svg?style=flat-square&label=docs" alt="Docs" />
+      <img src="https://img.shields.io/github/release/flameshot-org/flameshot.svg?label=docs" alt="Docs" />
     </a>
     <br>
     <a href="https://snapcraft.io/flameshot">


### PR DESCRIPTION
There are two styles of badges in the README.md, which is inconsistent.

I found that the style change made in #339, which is a README clean up pull request, seemed to be an accident, as the clean up works should not change the style things.

If the "flat-square" style is preferred, I can also see all the badges can use it, but the default one is simple and easy, and I didn't see a PR/commit indented to change the style since the beginning, so I think the default would be better.