### PR TITLE
Revert "working on updating to core20"

### DIFF
--- a/.github/workflows/Linux-pack.yml
+++ b/.github/workflows/Linux-pack.yml
@@ -639,7 +639,6 @@ jobs:
         id: snapcraft
       - name: Rename snap name
         shell: bash
-        snapcraft-args: --enable-experimental-extensions
         run: |
           mkdir -p $GITHUB_WORKSPACE/build
           cp ${{ steps.snapcraft.outputs.snap }} $GITHUB_WORKSPACE/build/${PRODUCT}-${VERSION}-${RELEASE}.amd64.snap

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -2,7 +2,7 @@
 
 name: flameshot
 adopt-info: flameshot
-base: core20
+base: core18
 summary: Powerful yet simple to use screenshot software
 description: |
   A powerful open source screenshot and annotation tool for Linux, Flameshot
@@ -18,8 +18,8 @@ architectures:
 
 apps:
   flameshot:
-    command: usr/local/bin/flameshot
-    desktop: usr/local/share/applications/org.flameshot.Flameshot.desktop
+    command: flameshot
+    desktop: usr/share/applications/org.flameshot.Flameshot.desktop
     extensions:
       - kde-neon
     environment:
@@ -34,15 +34,22 @@ apps:
       - network
       - network-bind
       - opengl
-      - x11
+      - pulseaudio
       - wayland
+      - unity7
+      - x11
 
 parts:
   flameshot:
     build-snaps:
-      - kde-frameworks-5-qt-5-15-core20
-    source: https://github.com/flameshot-org/flameshot.git
+      - kde-frameworks-5-core18-sdk
+      - kde-frameworks-5-core18
+      - cmake #core18 does not have new enough cmake so install from snap
     plugin: cmake
+    configflags:
+      - '-DCMAKE_BUILD_TYPE=RelWithDebInfo'
+      - '-DCMAKE_INSTALL_PREFIX=/usr'
+    source: https://github.com/flameshot-org/flameshot.git
     source-type: git
     override-pull: |
       snapcraftctl pull
@@ -53,19 +60,27 @@ parts:
     override-build: |
       snapcraftctl build
       # Correct the Icon path
-      sed -i 's|^Exec=flameshot|Exec=/snap/bin/org.flameshot.Flameshot|' ${SNAPCRAFT_PART_INSTALL}/usr/local/share/applications/org.flameshot.Flameshot.desktop
-      sed -i 's|^Icon=.*|Icon=${SNAP}/usr/local/share/icons/hicolor/scalable/apps/org.flameshot.Flameshot.svg|' ${SNAPCRAFT_PART_INSTALL}/usr/local/share/applications/org.flameshot.Flameshot.desktop
-      sed -i 's/^\(Name\(\[.\+\]\)\?=.*\)$/\1 (Snappy Edition)/g' ${SNAPCRAFT_PART_INSTALL}/usr/local/share/applications/org.flameshot.Flameshot.desktop
+      sed -i 's|^Exec=flameshot|Exec=/snap/bin/org.flameshot.Flameshot|' ${SNAPCRAFT_PART_INSTALL}/usr/share/applications/org.flameshot.Flameshot.desktop
+      sed -i 's|^Icon=.*|Icon=${SNAP}/usr/share/icons/hicolor/scalable/apps/org.flameshot.Flameshot.svg|' ${SNAPCRAFT_PART_INSTALL}/usr/share/applications/org.flameshot.Flameshot.desktop
+      sed -i 's/^\(Name\(\[.\+\]\)\?=.*\)$/\1 (Snappy Edition)/g' ${SNAPCRAFT_PART_INSTALL}/usr/share/applications/org.flameshot.Flameshot.desktop
     build-packages:
       - g++
       - make
       - qt5-default
-      - git
+      - qttools5-dev-tools
+      - libqt5svg5-dev
     stage-packages:
       - dbus-x11
       - libgtk2.0-0
       - openssl
       - ca-certificates
+      - qtwayland5
+      - libqt5dbus5
+      - libqt5network5
+      - libqt5core5a
+      - libqt5widgets5
+      - libqt5gui5
+      - libqt5svg5
       - libxkbcommon0
       - ttf-ubuntu-font-family
       - dmz-cursor-theme
@@ -74,6 +89,12 @@ parts:
       - gnome-themes-standard
       - shared-mime-info
       - libgdk-pixbuf2.0-0
+    prime:
+      # libquazip5-1 pulls in Qt5 from bionic as a dependency. We don't
+      # want it in our snap, however, because we get a newer Qt5 from the
+      # kde-kf5 platform snap.
+      - "-usr/lib/x86_64-linux-gnu/libQt5*"
+      - "-usr/lib/x86_64-linux-gnu/libqt5*"
 slots:
   # Depending on in which environment we're running we either need
   # to use the system or session DBus so we also need to have one


### PR DESCRIPTION
Reverts flameshot-org/flameshot#1944

This needs to be reverted until pipeline is fixed. I didn't notice it broke at first because it failed silently. 