### PR TITLE
Workaround for focus problem

### DIFF
--- a/src/widgets/capture/capturetoolbutton.cpp
+++ b/src/widgets/capture/capturetoolbutton.cpp
@@ -97,6 +97,7 @@ QIcon CaptureToolButton::icon() const
 
 void CaptureToolButton::mousePressEvent(QMouseEvent* e)
 {
+    activateWindow();
     if (e->button() == Qt::LeftButton) {
         emit pressedButton(this);
         emit pressed();

--- a/src/widgets/capture/capturewidget.h
+++ b/src/widgets/capture/capturewidget.h
@@ -94,6 +94,7 @@ protected:
     void wheelEvent(QWheelEvent* wheelEvent) override;
     void resizeEvent(QResizeEvent* resizeEvent) override;
     void moveEvent(QMoveEvent* moveEvent) override;
+    void changeEvent(QEvent* changeEvent) override;
 
 private:
     void loadDrawThickness();
@@ -122,7 +123,7 @@ private:
     QRect extendedSelection() const;
     QRect extendedRect(const QRect& r) const;
     QRect paddedUpdateRect(const QRect& r) const;
-    void drawConfigErrorMessage(QPainter* painter);
+    void drawErrorMessage(const QString& msg, QPainter* painter);
     void drawInactiveRegion(QPainter* painter);
     void drawToolsData();
     void drawObjectSelection();


### PR DESCRIPTION
There has been a long standing problem of flameshot losing focus to other programs.

The relevant issues:
- #133
- #1072 
- #1232 
- #1824 
- #1897

This PR provides a workaround to the problem. If flameshot loses focus, a text message will be displayed in the bottom right corner of the capture GUI that says

*Flameshot has lost focus. Keyboard shortcuts won't work until you click somewhere.*

As the message says, clicking anywhere in the GUI will restore focus. I don't know if this works on all platforms. I have tested it on Arch Linux with i3wm.

Note: The actual term is not focus. Instead we are talking about whether the window is active or not. But the user need not be burdened by such technicalities.