### PR TITLE
Make text alignment buttons mutually exclusive

### DIFF
--- a/src/tools/text/textconfig.cpp
+++ b/src/tools/text/textconfig.cpp
@@ -77,6 +77,7 @@ TextConfig::TextConfig(QWidget* parent)
     m_leftAlignButton =
       new QPushButton(QIcon(iconPrefix + "leftalign.svg"), QLatin1String(""));
     m_leftAlignButton->setCheckable(true);
+    m_leftAlignButton->setAutoExclusive(true);
     connect(m_leftAlignButton, &QPushButton::clicked, this, [this] {
         alignmentChanged(Qt::AlignLeft);
     });
@@ -85,6 +86,7 @@ TextConfig::TextConfig(QWidget* parent)
     m_centerAlignButton =
       new QPushButton(QIcon(iconPrefix + "centeralign.svg"), QLatin1String(""));
     m_centerAlignButton->setCheckable(true);
+    m_centerAlignButton->setAutoExclusive(true);
     connect(m_centerAlignButton, &QPushButton::clicked, this, [this] {
         alignmentChanged(Qt::AlignCenter);
     });
@@ -93,6 +95,7 @@ TextConfig::TextConfig(QWidget* parent)
     m_rightAlignButton =
       new QPushButton(QIcon(iconPrefix + "rightalign.svg"), QLatin1String(""));
     m_rightAlignButton->setCheckable(true);
+    m_rightAlignButton->setAutoExclusive(true);
     connect(m_rightAlignButton, &QPushButton::clicked, this, [this] {
         alignmentChanged(Qt::AlignRight);
     });


### PR DESCRIPTION
This pull request is intended to close #1978 .

![flameshotfix](https://user-images.githubusercontent.com/15658199/137570042-133c48ad-0960-437c-8a4f-09dab90031e6.gif)

Not very experienced in Qt but this seemed like a straightforward approach: to set the buttons' [`autoExclusive` property](https://doc.qt.io/qt-5/qabstractbutton.html#autoExclusive-prop) to true since they all belong to the same parent (`alignmentLayout`) that is apparently not shared with any of the other controls.

If there's a better way I'll gladly make the necessary adjustments. :)

Cheers!