### PR TITLE
Minor fix and modification on selectable tests in dialogs

### DIFF
--- a/src/tools/imgur/imguruploader.cpp
+++ b/src/tools/imgur/imguruploader.cpp
@@ -52,6 +52,7 @@ ImgurUploader::ImgurUploader(const QPixmap& capture, QWidget* parent)
 
     m_infoLabel = new QLabel(tr("Uploading Image"));
     m_infoLabel->setTextInteractionFlags(Qt::TextSelectableByMouse);
+    m_infoLabel->setCursor(QCursor(Qt::IBeamCursor));
 
     m_vLayout = new QVBoxLayout();
     setLayout(m_vLayout);

--- a/src/widgets/infowindow.cpp
+++ b/src/widgets/infowindow.cpp
@@ -69,12 +69,14 @@ void InfoWindow::initLabels()
     auto* versionLabel = new QLabel(GlobalValues::versionInfo(), this);
     versionLabel->setAlignment(Qt::AlignHCenter);
     versionLabel->setTextInteractionFlags(Qt::TextSelectableByMouse);
+    versionLabel->setCursor(QCursor(Qt::IBeamCursor));
     m_layout->addWidget(versionLabel);
 
     QString kernelInfo = generateKernelString();
     auto* kernelLabel = new QLabel(kernelInfo, this);
     kernelLabel->setAlignment(Qt::AlignHCenter);
     kernelLabel->setTextInteractionFlags(Qt::TextSelectableByMouse);
+    kernelLabel->setCursor(QCursor(Qt::IBeamCursor));
     m_layout->addWidget(kernelLabel);
 
     auto* copyVersion = new QPushButton("Copy Info", this);


### PR DESCRIPTION
The issue is that when imgur upload fails and generates error, the text was not selectable to be copied by user.

See the commit messages for more granular info.

P.s: I'm not sure about the coding quality as I'm not a C++ dev nor a QT dev. So feel free to fix it (and I'll learn) 😅 