### PR TITLE
Explain why saving a screenshot might fail

### DIFF
--- a/src/utils/screenshotsaver.cpp
+++ b/src/utils/screenshotsaver.cpp
@@ -90,7 +90,9 @@ bool ScreenshotSaver::saveToFilesystem(const QPixmap& capture,
 {
     QString completePath = FileNameHandler().properScreenshotPath(
       path, ConfigHandler().setSaveAsFileExtension());
-    bool ok = capture.save(completePath);
+    QFile file{ completePath };
+    file.open(QIODevice::WriteOnly);
+    bool ok = capture.save(&file);
     QString saveMessage = messagePrefix;
     QString notificationPath = completePath;
     if (!saveMessage.isEmpty()) {
@@ -103,6 +105,9 @@ bool ScreenshotSaver::saveToFilesystem(const QPixmap& capture,
           m_id, QFileInfo(completePath).canonicalFilePath());
     } else {
         saveMessage += QObject::tr("Error trying to save as ") + completePath;
+        if (file.error() != QFile::NoError) {
+            saveMessage += ": " + file.errorString();
+        }
         notificationPath = "";
     }
 
@@ -171,7 +176,10 @@ bool ScreenshotSaver::saveToFilesystemGUI(const QPixmap& capture)
         return ok;
     }
 
-    ok = capture.save(savePath);
+    QFile file{ savePath };
+    file.open(QIODevice::WriteOnly);
+
+    ok = capture.save(&file);
 
     if (ok) {
         QString pathNoFile =
@@ -198,6 +206,11 @@ bool ScreenshotSaver::saveToFilesystemGUI(const QPixmap& capture)
 
     } else {
         QString msg = QObject::tr("Error trying to save as ") + savePath;
+
+        if (file.error() != QFile::NoError) {
+            msg += ": " + file.errorString();
+        }
+
         QMessageBox saveErrBox(
           QMessageBox::Warning, QObject::tr("Save Error"), msg);
         saveErrBox.setWindowIcon(QIcon(":img/app/flameshot.svg"));


### PR DESCRIPTION
My `~/Pictures` folder is located in a separate partition, and for whatever reason it was mounted in readonly mode. When I tried to save a screenshot, flameshot was just saying, *"Error trying to save as /home/michael/Pictures/2021-10-27_12-56.png"*, without giving any real explanation for what went wrong. 

I ended up scratching my head for a good 5-10 minutes trying to figure out why saving was failing when the folder exists and it has all the right permission. I only figured out what the issue was when I tried to create a file and `touch` gave me a more useful error message - *"touch: cannot touch '/home/michael/Pictures/asdf': Read-only file system"*.

This PR modifies the way we save screenshots to write to a `QFile` and append `file.errorString()` to the error message if the save error was file-related.