### PR TITLE
Fix errors when generating flameshot.icons

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,18 +21,18 @@ if (APPLE)
             COMMAND bash "-c" "mkdir -p flameshot.iconset"
     )
     execute_process(
-            COMMAND bash "-c" "sips -z 16 16     ../data/img/app/flameshot.png --out flameshot.iconset/icon_16x16.png"
-            COMMAND bash "-c" "sips -z 32 32     ../data/img/app/flameshot.png --out flameshot.iconset/icon_16x16@2x.png"
-            COMMAND bash "-c" "sips -z 32 32     ../data/img/app/flameshot.png --out flameshot.iconset/icon_32x32.png"
-            COMMAND bash "-c" "sips -z 64 64     ../data/img/app/flameshot.png --out flameshot.iconset/icon_32x32@2x.png"
-            COMMAND bash "-c" "sips -z 64 64     ../data/img/app/flameshot.png --out flameshot.iconset/icon_64x64x.png"
-            COMMAND bash "-c" "sips -z 128 128   ../data/img/app/flameshot.png --out flameshot.iconset/icon_64x64@2.png"
-            COMMAND bash "-c" "sips -z 128 128   ../data/img/app/flameshot.png --out flameshot.iconset/icon_128x128.png"
-            COMMAND bash "-c" "sips -z 256 256   ../data/img/app/org.flameshot.Flameshot-1024.png --out flameshot.iconset/icon_128x128@2x.png"
-            COMMAND bash "-c" "sips -z 256 256   ../data/img/app/org.flameshot.Flameshot-1024.png --out flameshot.iconset/icon_256x256.png"
-            COMMAND bash "-c" "sips -z 512 512   ../data/img/app/org.flameshot.Flameshot-1024.png --out flameshot.iconset/icon_256x256@2x.png"
-            COMMAND bash "-c" "sips -z 512 512   ../data/img/app/org.flameshot.Flameshot-1024.png --out flameshot.iconset/icon_512x512.png"
-            COMMAND bash "-c" "sips -z 1024 1024 ../data/img/app/org.flameshot.Flameshot-1024.png --out flameshot.iconset/icon_512x512@2x.png"
+            COMMAND bash "-c" "sips -z 16 16     \"${CMAKE_SOURCE_DIR}\"/data/img/app/flameshot.png --out flameshot.iconset/icon_16x16.png"
+            COMMAND bash "-c" "sips -z 32 32     \"${CMAKE_SOURCE_DIR}\"/data/img/app/flameshot.png --out flameshot.iconset/icon_16x16@2x.png"
+            COMMAND bash "-c" "sips -z 32 32     \"${CMAKE_SOURCE_DIR}\"/data/img/app/flameshot.png --out flameshot.iconset/icon_32x32.png"
+            COMMAND bash "-c" "sips -z 64 64     \"${CMAKE_SOURCE_DIR}\"/data/img/app/flameshot.png --out flameshot.iconset/icon_32x32@2x.png"
+            COMMAND bash "-c" "sips -z 64 64     \"${CMAKE_SOURCE_DIR}\"/data/img/app/flameshot.png --out flameshot.iconset/icon_64x64x.png"
+            COMMAND bash "-c" "sips -z 128 128   \"${CMAKE_SOURCE_DIR}\"/data/img/app/flameshot.png --out flameshot.iconset/icon_64x64@2.png"
+            COMMAND bash "-c" "sips -z 128 128   \"${CMAKE_SOURCE_DIR}\"/data/img/app/flameshot.png --out flameshot.iconset/icon_128x128.png"
+            COMMAND bash "-c" "sips -z 256 256   \"${CMAKE_SOURCE_DIR}\"/data/img/app/org.flameshot.Flameshot-1024.png --out flameshot.iconset/icon_128x128@2x.png"
+            COMMAND bash "-c" "sips -z 256 256   \"${CMAKE_SOURCE_DIR}\"/data/img/app/org.flameshot.Flameshot-1024.png --out flameshot.iconset/icon_256x256.png"
+            COMMAND bash "-c" "sips -z 512 512   \"${CMAKE_SOURCE_DIR}\"/data/img/app/org.flameshot.Flameshot-1024.png --out flameshot.iconset/icon_256x256@2x.png"
+            COMMAND bash "-c" "sips -z 512 512   \"${CMAKE_SOURCE_DIR}\"/data/img/app/org.flameshot.Flameshot-1024.png --out flameshot.iconset/icon_512x512.png"
+            COMMAND bash "-c" "sips -z 1024 1024 \"${CMAKE_SOURCE_DIR}\"/data/img/app/org.flameshot.Flameshot-1024.png --out flameshot.iconset/icon_512x512@2x.png"
             COMMAND bash "-c" "iconutil -c icns flameshot.iconset"
     )
 
@@ -42,7 +42,7 @@ if (APPLE)
 
     execute_process(
             # copy icon from cache generated on the localhost if generation on CI failed
-            COMMAND bash "-c" "[[ -r 'flameshot.icns' ]] || cp ../packaging/macos/flameshot.icns ./"
+            COMMAND bash "-c" "[[ -r 'flameshot.icns' ]] || cp \"${CMAKE_SOURCE_DIR}\"/packaging/macos/flameshot.icns ./"
     )
 
     # Set application icon


### PR DESCRIPTION
On macOS when you configure Flameshot with CMake it produces errors during generation of the iconset file:

```sh
mkdir build/xcode
cd build/xcode
cmake ../../ -G Xcode
```

```
Warning: ../data/img/app/flameshot.png not a valid file - skipping
Warning: ../data/img/app/flameshot.png not a valid file - skipping
Warning: ../data/img/app/flameshot.png not a valid file - skipping
Warning: ../data/img/app/flameshot.png not a valid file - skipping
Warning: ../data/img/app/flameshot.png not a valid file - skipping
Warning: ../data/img/app/flameshot.png not a valid file - skipping
Warning: ../data/img/app/flameshot.png not a valid file - skipping
Warning: ../data/img/app/org.flameshot.Flameshot-1024.png not a valid file - skipping
Warning: ../data/img/app/org.flameshot.Flameshot-1024.png not a valid file - skipping
Warning: ../data/img/app/org.flameshot.Flameshot-1024.png not a valid file - skipping
Warning: ../data/img/app/org.flameshot.Flameshot-1024.png not a valid file - skipping
Warning: ../data/img/app/org.flameshot.Flameshot-1024.png not a valid file - skipping
flameshot.iconset:Failed to generate ICNS.
cp: ../packaging/macos/flameshot.icns: No such file or directory
-- Found Git: /usr/bin/git (found version "2.30.1 (Apple Git-130)")
git found: /usr/bin/git in version     2.30.1 (Apple Git-130)
FLAMESHOT_GIT_HASH: a1e6a2f
-- Configuring done
CMake Error at src/CMakeLists.txt:55 (add_executable):
  Cannot find source file:

    /Users/szx/Sources/flameshot/build/xcode/flameshot.icns

  Tried extensions .c .C .c++ .cc .cpp .cxx .cu .mpp .m .M .mm .ixx .cppm .h
  .hh .h++ .hm .hpp .hxx .in .txx .f .F .for .f77 .f90 .f95 .f03 .hip .ispc
```

Solution: instead of a relative path `../data/` use `${CMAKE_SOURCE_DIR}/data/`