### PR TITLE
Fix some compile warnings in macOS build

### DIFF
--- a/cmake/modules/MacOSXBundleInfo.plist.in
+++ b/cmake/modules/MacOSXBundleInfo.plist.in
@@ -11,7 +11,7 @@
 	<key>CFBundleIconFile</key>
 	<string>flameshot</string>
 	<key>CFBundleIdentifier</key>
-	<string>https://flameshot.org/</string>
+	<string>org.flameshot</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/cmake/modules/MacOSXBundleInfo.plist.in
+++ b/cmake/modules/MacOSXBundleInfo.plist.in
@@ -11,7 +11,7 @@
 	<key>CFBundleIconFile</key>
 	<string>flameshot</string>
 	<key>CFBundleIdentifier</key>
-	<string>org.flameshot</string>
+	<string>@MACOSX_BUNDLE_IDENTIFIER@</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
@@ -23,9 +23,9 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>0.10.1</string>
+	<string>@PROJECT_VERSION@</string>
 	<key>CFBundleLongVersionString</key>
-	<string>0.10.1</string>
+	<string>@PROJECT_VERSION@</string>
 	<key>CSResourcesFileMapped</key>
 	<true/>
 	<key>NSHumanReadableCopyright</key>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -183,6 +183,12 @@ target_link_libraries(
 )
 
 if (APPLE)
+    set(MACOSX_BUNDLE_IDENTIFIER "org.flameshot")
+    set_target_properties(
+            flameshot
+            PROPERTIES
+            XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER ${MACOSX_BUNDLE_IDENTIFIER}
+    )
     target_link_libraries(
             flameshot
             qhotkey

--- a/src/tools/text/textconfig.cpp
+++ b/src/tools/text/textconfig.cpp
@@ -152,24 +152,22 @@ void TextConfig::weightButtonPressed(const bool w)
 
 void TextConfig::setTextAlignment(Qt::AlignmentFlag alignment)
 {
-
     switch (alignment) {
-        case (Qt::AlignLeft):
-            m_leftAlignButton->setChecked(true);
-            m_centerAlignButton->setChecked(false);
-            m_rightAlignButton->setChecked(false);
-            break;
-
         case (Qt::AlignCenter):
             m_leftAlignButton->setChecked(false);
             m_centerAlignButton->setChecked(true);
             m_rightAlignButton->setChecked(false);
             break;
-
         case (Qt::AlignRight):
             m_leftAlignButton->setChecked(false);
             m_centerAlignButton->setChecked(false);
             m_rightAlignButton->setChecked(true);
+            break;
+        case (Qt::AlignLeft):
+        default:
+            m_leftAlignButton->setChecked(true);
+            m_centerAlignButton->setChecked(false);
+            m_rightAlignButton->setChecked(false);
             break;
     }
     emit alignmentChanged(alignment);

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -1,4 +1,4 @@
-﻿// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 // SPDX-FileCopyrightText: 2017-2019 Alejandro Sirgo Rica & Contributors
 
 // Based on Lightscreen areadialog.cpp, Copyright 2017  Christian Kaiser
@@ -506,7 +506,7 @@ void CaptureWidget::showColorPicker(const QPoint& pos)
 {
     // Try to select new object if current pos out of active object
     auto toolItem = activeToolObject();
-    if (!toolItem || toolItem && !toolItem->boundingRect().contains(pos)) {
+    if (!toolItem || (toolItem && !toolItem->boundingRect().contains(pos))) {
         selectToolItemAtPos(pos);
     }
 

--- a/src/widgets/capture/colorpicker.h
+++ b/src/widgets/capture/colorpicker.h
@@ -17,7 +17,7 @@ signals:
 protected:
     void paintEvent(QPaintEvent* event) override;
     void repaint(int i, QPainter& painter);
-    void mouseMoveEvent(QMouseEvent*);
+    void mouseMoveEvent(QMouseEvent*) override;
     void showEvent(QShowEvent* event) override;
     void hideEvent(QHideEvent* event) override;
 

--- a/src/widgets/capture/notifierbox.h
+++ b/src/widgets/capture/notifierbox.h
@@ -14,8 +14,8 @@ public:
     explicit NotifierBox(QWidget* parent = nullptr);
 
 protected:
-    virtual void enterEvent(QEvent*);
-    virtual void paintEvent(QPaintEvent*);
+    virtual void enterEvent(QEvent*) override;
+    virtual void paintEvent(QPaintEvent*) override;
 
 signals:
     void hidden();

--- a/src/widgets/capture/selectionwidget.h
+++ b/src/widgets/capture/selectionwidget.h
@@ -46,9 +46,9 @@ protected:
     void parentMouseReleaseEvent(QMouseEvent* e);
     void parentMouseMoveEvent(QMouseEvent* e);
 
-    void paintEvent(QPaintEvent*);
-    void resizeEvent(QResizeEvent*);
-    void moveEvent(QMoveEvent*);
+    void paintEvent(QPaintEvent*) override;
+    void resizeEvent(QResizeEvent*) override;
+    void moveEvent(QMoveEvent*) override;
 
     void showEvent(QShowEvent*) override;
     void hideEvent(QHideEvent*) override;

--- a/src/widgets/panel/colorgrabwidget.h
+++ b/src/widgets/panel/colorgrabwidget.h
@@ -23,7 +23,7 @@ signals:
 
 private:
     bool eventFilter(QObject* obj, QEvent* event) override;
-    void paintEvent(QPaintEvent* e);
+    void paintEvent(QPaintEvent* e) override;
     void showEvent(QShowEvent* event) override;
 
     QPoint cursorPos() const;


### PR DESCRIPTION
Fix the following warnings:

* `<methodName>` overrides a member function but is not marked 'override'
* flameshot/src/tools/text/textconfig.cpp:156:13: 9 enumeration values not handled in switch: 'AlignHCenter', 'AlignJustify', 'AlignAbsolute'...
* 'fromList' is deprecated: Use QSet<T>(list.begin(), list.end()) instead
* invalid character in Bundle Identifier. This string must be a uniform type identifier (UTI) that contains only alphanumeric (A-Z,a-z,0-9), hyphen (-), and period (.) characters.