### PR TITLE
Added confirmation for Upload

### DIFF
--- a/flameshot.example.ini
+++ b/flameshot.example.ini
@@ -75,6 +75,9 @@
 ;; Use JPG format instead of PNG (bool)
 ;useJpgForClipboard=false
 ;
+;; Upload to imgur without confirmation (bool)
+;uploadWithoutConfirmation=false
+;
 ;; Shortcut Settings for all tools
 ;[Shortcuts]
 ;TYPE_ARROW=A

--- a/src/config/generalconf.cpp
+++ b/src/config/generalconf.cpp
@@ -44,6 +44,7 @@ GeneralConf::GeneralConf(QWidget* parent)
     initCopyAndCloseAfterUpload();
     initCopyPathAfterSave();
     initAntialiasingPinZoom();
+    initUploadWithoutConfirmation();
     initUseJpgForClipboard();
     initSaveAfterCopy();
     inituploadHistoryMax();
@@ -68,6 +69,7 @@ void GeneralConf::_updateComponents(bool allowEmptySavePath)
     m_copyPathAfterSave->setChecked(config.copyPathAfterSave());
     m_antialiasingPinZoom->setChecked(config.antialiasingPinZoom());
     m_useJpgForClipboard->setChecked(config.useJpgForClipboard());
+    m_uploadWithoutConfirmation->setChecked(config.uploadWithoutConfirmation());
     m_historyConfirmationToDelete->setChecked(
       config.historyConfirmationToDelete());
     m_checkForUpdates->setChecked(config.checkForUpdates());
@@ -528,6 +530,18 @@ void GeneralConf::initAntialiasingPinZoom()
     m_scrollAreaLayout->addWidget(m_antialiasingPinZoom);
     connect(m_antialiasingPinZoom, &QCheckBox::clicked, [](bool checked) {
         ConfigHandler().setAntialiasingPinZoom(checked);
+    });
+}
+
+void GeneralConf::initUploadWithoutConfirmation()
+{
+    m_uploadWithoutConfirmation =
+      new QCheckBox(tr("Upload to Imgur without confirmation"), this);
+    m_uploadWithoutConfirmation->setToolTip(
+      tr("Upload to Imgur without confirmation"));
+    m_scrollAreaLayout->addWidget(m_uploadWithoutConfirmation);
+    connect(m_uploadWithoutConfirmation, &QCheckBox::clicked, [](bool checked) {
+        ConfigHandler().setUploadWithoutConfirmation(checked);
     });
 }
 

--- a/src/config/generalconf.h
+++ b/src/config/generalconf.h
@@ -62,6 +62,7 @@ private:
     void initCopyPathAfterSave();
     void initAntialiasingPinZoom();
     void initUseJpgForClipboard();
+    void initUploadWithoutConfirmation();
 
     void _updateComponents(bool allowEmptySavePath);
 
@@ -79,6 +80,7 @@ private:
     QCheckBox* m_copyAndCloseAfterUpload;
     QCheckBox* m_copyPathAfterSave;
     QCheckBox* m_antialiasingPinZoom;
+    QCheckBox* m_uploadWithoutConfirmation;
     QPushButton* m_importButton;
     QPushButton* m_exportButton;
     QPushButton* m_resetButton;

--- a/src/core/capturerequest.cpp
+++ b/src/core/capturerequest.cpp
@@ -7,6 +7,7 @@
 #include "imguruploader.h"
 #include "pinwidget.h"
 #include "src/utils/screenshotsaver.h"
+#include "src/widgets/imguruploaddialog.h"
 #include "systemnotification.h"
 #include <QApplication>
 #include <QClipboard>
@@ -148,6 +149,12 @@ void CaptureRequest::exportCapture(const QPixmap& capture)
     }
 
     if (m_tasks & UPLOAD) {
+        if (!ConfigHandler().uploadWithoutConfirmation()) {
+            ImgurUploadDialog* dialog = new ImgurUploadDialog();
+            if (dialog->exec() == QDialog::Rejected) {
+                return;
+            }
+        }
         ImgurUploader* widget = new ImgurUploader(capture);
         widget->show();
         widget->activateWindow();

--- a/src/utils/confighandler.cpp
+++ b/src/utils/confighandler.cpp
@@ -93,6 +93,7 @@ static QMap<class QString, QSharedPointer<ValueHandler>>
 #if !defined(Q_OS_MACOS)
         OPTION("useJpgForClipboard"          ,Bool               ( false         )),
 #endif
+        OPTION("uploadWithoutConfirmation"   ,Bool               ( false         )),
         OPTION("saveAfterCopy"               ,Bool               ( false         )),
         OPTION("savePath"                    ,ExistingDir        (               )),
         OPTION("savePathFixed"               ,Bool               ( false         )),

--- a/src/utils/confighandler.h
+++ b/src/utils/confighandler.h
@@ -93,6 +93,9 @@ public:
                          QString)
     CONFIG_GETTER_SETTER(antialiasingPinZoom, setAntialiasingPinZoom, bool)
     CONFIG_GETTER_SETTER(useJpgForClipboard, setUseJpgForClipboard, bool)
+    CONFIG_GETTER_SETTER(uploadWithoutConfirmation,
+                         setUploadWithoutConfirmation,
+                         bool)
     CONFIG_GETTER_SETTER(ignoreUpdateToVersion,
                          setIgnoreUpdateToVersion,
                          QString)

--- a/src/widgets/CMakeLists.txt
+++ b/src/widgets/CMakeLists.txt
@@ -13,6 +13,7 @@ target_sources(
         orientablepushbutton.h
         historywidget.h
         updatenotificationwidget.h
+        imguruploaddialog.h
         capture/capturetoolobjects.h
 )
 
@@ -27,5 +28,6 @@ target_sources(
         orientablepushbutton.cpp
         historywidget.cpp
         updatenotificationwidget.cpp
+        imguruploaddialog.cpp
         capture/capturetoolobjects.cpp
 )

--- a/src/widgets/imguruploaddialog.cpp
+++ b/src/widgets/imguruploaddialog.cpp
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2017-2019 Alejandro Sirgo Rica & Contributors
+
+#include "imguruploaddialog.h"
+#include "src/utils/confighandler.h"
+#include <QCheckBox>
+#include <QDialogButtonBox>
+#include <QLabel>
+#include <QVBoxLayout>
+
+ImgurUploadDialog::ImgurUploadDialog(QDialog* parent)
+  : QDialog(parent)
+{
+    setAttribute(Qt::WA_DeleteOnClose);
+    setMinimumSize(400, 120);
+    setWindowIcon(QIcon(":img/app/flameshot.svg"));
+    setWindowTitle(tr("Upload Confirmation"));
+
+    layout = new QVBoxLayout(this);
+
+    m_uploadLabel =
+      new QLabel(tr("Do you want to upload this capture to Imgur?"), this);
+
+    layout->addWidget(m_uploadLabel);
+
+    buttonBox =
+      new QDialogButtonBox(QDialogButtonBox::Yes | QDialogButtonBox::No);
+
+    connect(buttonBox, &QDialogButtonBox::accepted, this, &QDialog::accept);
+    connect(buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
+
+    layout->addWidget(buttonBox);
+
+    m_uploadWithoutConfirmation =
+      new QCheckBox(tr("Upload to Imgur without confirmation"), this);
+    m_uploadWithoutConfirmation->setToolTip(
+      tr("Upload to Imgur without confirmation"));
+    connect(m_uploadWithoutConfirmation, &QCheckBox::clicked, [](bool checked) {
+        ConfigHandler().setUploadWithoutConfirmation(checked);
+    });
+
+    layout->addWidget(m_uploadWithoutConfirmation);
+}

--- a/src/widgets/imguruploaddialog.h
+++ b/src/widgets/imguruploaddialog.h
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2017-2019 Alejandro Sirgo Rica & Contributors
+
+#pragma once
+
+#include <QDialog>
+
+class QCheckBox;
+class QLabel;
+class QDialogButtonBox;
+class QVBoxLayout;
+
+class ImgurUploadDialog : public QDialog
+{
+    Q_OBJECT
+public:
+    explicit ImgurUploadDialog(QDialog* parent = nullptr);
+
+private:
+    QCheckBox* m_uploadWithoutConfirmation;
+    QLabel* m_uploadLabel;
+    QDialogButtonBox* buttonBox;
+    QVBoxLayout* layout;
+};


### PR DESCRIPTION
Closes #1751

Features:
- Show prompt before upload to Imgur.
- Users can check ```Upload to Imgur without confirmation```  field in general configuration tab if they do not want the prompt.
- This field can also be checked in the prompt itself.
- Behavior is also modifiable in flameshot.ini.