### PR TITLE
Remove qt5-devel from Fedora compile dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,7 +396,7 @@ apt install git openssl ca-certificates
 
 ```shell
 # Compile-time
-dnf install gcc-c++ cmake qt5-devel qt5-qtbase-devel qt5-linguist
+dnf install gcc-c++ cmake qt5-qtbase-devel qt5-linguist
 
 # Run-time
 dnf install qt5-qtbase qt5-qtsvg-devel


### PR DESCRIPTION
Package `qt5-devel` is no longer in Fedora repos and is not needed for the build. Just clarifying the README.