### PR TITLE
Fixed Gnome File Extensions

### DIFF
--- a/src/utils/screenshotsaver.cpp
+++ b/src/utils/screenshotsaver.cpp
@@ -179,8 +179,6 @@ bool ScreenshotSaver::saveToFilesystemGUI(const QPixmap& capture)
         return ok;
     }
 
-    // TODO: Add check to see if suffix was chopped off
-
     QFile file{ savePath };
     file.open(QIODevice::WriteOnly);
 

--- a/src/utils/screenshotsaver.cpp
+++ b/src/utils/screenshotsaver.cpp
@@ -133,10 +133,13 @@ QString ScreenshotSaver::ShowSaveFileDialog(QWidget* parent,
     dialog.setMimeTypeFilters(mimeTypeList);
 
     QString suffix = ConfigHandler().setSaveAsFileExtension();
+    if (suffix.isEmpty()) {
+        suffix = "png";
+    }
     QString defaultMimeType =
       QMimeDatabase().mimeTypeForFile("image." + suffix).name();
     dialog.selectMimeTypeFilter(defaultMimeType);
-
+    dialog.setDefaultSuffix(suffix);
     if (dialog.exec() == QDialog::Accepted) {
         return dialog.selectedFiles().first();
     } else {
@@ -175,6 +178,8 @@ bool ScreenshotSaver::saveToFilesystemGUI(const QPixmap& capture)
     if (savePath == "") {
         return ok;
     }
+
+    // TODO: Add check to see if suffix was chopped off
 
     QFile file{ savePath };
     file.open(QIODevice::WriteOnly);


### PR DESCRIPTION
This resolves an issue that was only present when using the GTK native file save dialog.

If a user deleted the file suffix in the "name box", even if they had a suffix selected from the dropdown, the file would fail to save.