### PR TITLE
Enable Screenshot & Screenshot history shortcut changing in MACOS

### DIFF
--- a/src/config/setshortcutwidget.cpp
+++ b/src/config/setshortcutwidget.cpp
@@ -34,12 +34,16 @@ SetShortcutDialog::SetShortcutDialog(QDialog* parent, QString shortcutName)
 
     QString msg = "";
 #if defined(Q_OS_MAC)
-    msg = tr("Press Esc to cancel or ⌘+Backspace to disable the keyboard shortcut.");
+    msg = tr(
+      "Press Esc to cancel or ⌘+Backspace to disable the keyboard shortcut.");
 #else
-    msg = tr("Press Esc to cancel or Backspace to disable the keyboard shortcut.");
+    msg =
+      tr("Press Esc to cancel or Backspace to disable the keyboard shortcut.");
 #endif
-    if (shortcutName == "TAKE_SCREENSHOT" || shortcutName == "SCREENSHOT_HISTORY"){
-        msg += "\n" + tr("Require restart flameshot"); 
+    if (shortcutName == "TAKE_SCREENSHOT" ||
+        shortcutName == "SCREENSHOT_HISTORY") {
+        msg +=
+          "\n" + tr("Flameshot must be restarted for changes to take effect.");
     }
     QLabel* infoBottom = new QLabel(msg);
     infoBottom->setMargin(10);

--- a/src/config/setshortcutwidget.cpp
+++ b/src/config/setshortcutwidget.cpp
@@ -9,7 +9,7 @@
 #include <QLayout>
 #include <QPixmap>
 
-SetShortcutDialog::SetShortcutDialog(QDialog* parent)
+SetShortcutDialog::SetShortcutDialog(QDialog* parent, QString shortcutName)
   : QDialog(parent)
 {
     setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
@@ -32,13 +32,16 @@ SetShortcutDialog::SetShortcutDialog(QDialog* parent)
 
     m_layout->addWidget(infoIcon);
 
+    QString msg = "";
 #if defined(Q_OS_MAC)
-    QLabel* infoBottom = new QLabel(tr(
-      "Press Esc to cancel or ⌘+Backspace to disable the keyboard shortcut."));
+    msg = tr("Press Esc to cancel or ⌘+Backspace to disable the keyboard shortcut.");
 #else
-    QLabel* infoBottom = new QLabel(
-      tr("Press Esc to cancel or Backspace to disable the keyboard shortcut."));
+    msg = tr("Press Esc to cancel or Backspace to disable the keyboard shortcut.");
 #endif
+    if (shortcutName == "TAKE_SCREENSHOT" || shortcutName == "SCREENSHOT_HISTORY"){
+        msg += "\n" + tr("Require restart flameshot"); 
+    }
+    QLabel* infoBottom = new QLabel(msg);
     infoBottom->setMargin(10);
     infoBottom->setAlignment(Qt::AlignCenter);
     m_layout->addWidget(infoBottom);

--- a/src/config/setshortcutwidget.h
+++ b/src/config/setshortcutwidget.h
@@ -14,7 +14,7 @@ class SetShortcutDialog : public QDialog
 {
     Q_OBJECT
 public:
-    explicit SetShortcutDialog(QDialog* parent = nullptr);
+    explicit SetShortcutDialog(QDialog* parent = nullptr, QString shortcutName = "");
     const QKeySequence& shortcut();
 
 public:

--- a/src/config/setshortcutwidget.h
+++ b/src/config/setshortcutwidget.h
@@ -14,7 +14,8 @@ class SetShortcutDialog : public QDialog
 {
     Q_OBJECT
 public:
-    explicit SetShortcutDialog(QDialog* parent = nullptr, QString shortcutName = "");
+    explicit SetShortcutDialog(QDialog* parent = nullptr,
+                               QString shortcutName = "");
     const QKeySequence& shortcut();
 
 public:

--- a/src/config/shortcutswidget.cpp
+++ b/src/config/shortcutswidget.cpp
@@ -130,7 +130,8 @@ void ShortcutsWidget::onShortcutCellClicked(int row, int col)
         }
 
         QString shortcutName = m_shortcuts.at(row).at(0);
-        SetShortcutDialog* setShortcutDialog = new SetShortcutDialog(nullptr, shortcutName);
+        SetShortcutDialog* setShortcutDialog =
+          new SetShortcutDialog(nullptr, shortcutName);
         if (0 != setShortcutDialog->exec()) {
             QKeySequence shortcutValue = setShortcutDialog->shortcut();
 

--- a/src/config/shortcutswidget.cpp
+++ b/src/config/shortcutswidget.cpp
@@ -129,9 +129,9 @@ void ShortcutsWidget::onShortcutCellClicked(int row, int col)
             return;
         }
 
-        SetShortcutDialog* setShortcutDialog = new SetShortcutDialog();
+        QString shortcutName = m_shortcuts.at(row).at(0);
+        SetShortcutDialog* setShortcutDialog = new SetShortcutDialog(nullptr, shortcutName);
         if (0 != setShortcutDialog->exec()) {
-            QString shortcutName = m_shortcuts.at(row).at(0);
             QKeySequence shortcutValue = setShortcutDialog->shortcut();
 
             // set no shortcut is Backspace
@@ -189,10 +189,8 @@ void ShortcutsWidget::loadShortcuts()
 
     // Global hotkeys
 #if defined(Q_OS_MACOS)
-    m_shortcuts << (QStringList()
-                    << "" << QObject::tr("Screenshot history") << "⇧⌘⌥H");
-    m_shortcuts << (QStringList()
-                    << "" << QObject::tr("Capture screen") << "⇧⌘⌥4");
+    appendShortcut("TAKE_SCREENSHOT", "Capture screen");
+    appendShortcut("SCREENSHOT_HISTORY", "Screenshot history");
 #elif defined(Q_OS_WIN)
     m_shortcuts << (QStringList() << "" << QObject::tr("Screenshot history")
                                   << "Shift+Print Screen");

--- a/src/core/controller.cpp
+++ b/src/core/controller.cpp
@@ -90,14 +90,14 @@ Controller::Controller()
     currentScreen->grabWindow(QApplication::desktop()->winId(), 0, 0, 1, 1);
 
     // set global shortcuts for MacOS
-    m_HotkeyScreenshotCapture =
-      new QHotkey(QKeySequence(ConfigHandler().shortcut("TAKE_SCREENSHOT")), true, this);
+    m_HotkeyScreenshotCapture = new QHotkey(
+      QKeySequence(ConfigHandler().shortcut("TAKE_SCREENSHOT")), true, this);
     QObject::connect(m_HotkeyScreenshotCapture,
                      &QHotkey::activated,
                      qApp,
                      [&]() { this->startVisualCapture(); });
-    m_HotkeyScreenshotHistory =
-      new QHotkey(QKeySequence(ConfigHandler().shortcut("SCREENSHOT_HISTORY")), true, this);
+    m_HotkeyScreenshotHistory = new QHotkey(
+      QKeySequence(ConfigHandler().shortcut("SCREENSHOT_HISTORY")), true, this);
     QObject::connect(m_HotkeyScreenshotHistory,
                      &QHotkey::activated,
                      qApp,

--- a/src/core/controller.cpp
+++ b/src/core/controller.cpp
@@ -91,19 +91,18 @@ Controller::Controller()
 
     // set global shortcuts for MacOS
     m_HotkeyScreenshotCapture =
-      new QHotkey(QKeySequence("Ctrl+Alt+Shift+4"), true, this);
+      new QHotkey(QKeySequence(ConfigHandler().shortcut("TAKE_SCREENSHOT")), true, this);
     QObject::connect(m_HotkeyScreenshotCapture,
                      &QHotkey::activated,
                      qApp,
                      [&]() { this->startVisualCapture(); });
     m_HotkeyScreenshotHistory =
-      new QHotkey(QKeySequence("Ctrl+Alt+Shift+H"), true, this);
+      new QHotkey(QKeySequence(ConfigHandler().shortcut("SCREENSHOT_HISTORY")), true, this);
     QObject::connect(m_HotkeyScreenshotHistory,
                      &QHotkey::activated,
                      qApp,
                      [&]() { this->showRecentUploads(); });
 #endif
-
     if (ConfigHandler().checkForUpdates()) {
         getLatestAvailableVersion();
     }

--- a/src/utils/confighandler.cpp
+++ b/src/utils/confighandler.cpp
@@ -153,6 +153,8 @@ static QMap<QString, QSharedPointer<KeySequence>> recognizedShortcuts = {
     SHORTCUT("TYPE_COMMIT_CURRENT_TOOL" ,   "Ctrl+Return"           ),
 #if defined(Q_OS_MACOS)
     SHORTCUT("TYPE_DELETE_CURRENT_TOOL" ,   "Backspace"             ),
+    SHORTCUT("TAKE_SCREENSHOT"          ,   "Ctrl+Shift+X"          ),
+    SHORTCUT("SCREENSHOT_HISTORY"       ,   "Alt+Shift+X"           ),
 #else
     SHORTCUT("TYPE_DELETE_CURRENT_TOOL" ,   "Delete"                ),
 #endif


### PR DESCRIPTION
From issue #1259 and my experience, I've enabled and tested this feature in my Hackintosh. So now you can change shortcut to take screenshot and show screenshot history (require restart flameshot).
- Default key to take screenshot is "Cmd + Shift + X", screenshot history is "Option + Shift + X".
- Added new translate text "Require restart flameshot".