### PR TITLE
Always use native Wayland backend on KDE Plasma

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -50,8 +50,7 @@ void wayland_hacks()
 {
     // Workaround to https://github.com/ksnip/ksnip/issues/416
     DesktopInfo info;
-    if ((info.windowManager() == DesktopInfo::GNOME) ||
-        (info.windowManager() == DesktopInfo::KDE)) {
+    if (info.windowManager() == DesktopInfo::GNOME) {
         qputenv("QT_QPA_PLATFORM", "xcb");
     }
 }


### PR DESCRIPTION
This will fix issues with broken hotkeys on KDE Plasma on Wayland.

Partially reverts 5d66405ed0e0fb871c174b8c1dfffb4a4d48034e commit.

Closes #2077.