### PR TITLE
Set circle count on "Ctrl+Scroll Wheel"

### DIFF
--- a/src/tools/capturecontext.h
+++ b/src/tools/capturecontext.h
@@ -27,6 +27,8 @@ struct CaptureContext
     QPoint mousePos;
     // Size of the active tool
     int toolSize;
+    // Current circle count
+    int circleCount;
     // Mode of the capture widget
     bool fullscreen;
     CaptureRequest request = CaptureRequest::GRAPHICAL_MODE;

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -800,6 +800,20 @@ void CaptureWidget::setToolSize(int size)
     }
 }
 
+/**
+ * Show notifier box displaying the selected circle count
+ */
+void CaptureWidget::setCircleCount(int count)
+{
+    m_context.circleCount = count;
+
+    QPoint topLeft =
+      QGuiAppCurrentScreen().currentScreen()->geometry().topLeft();
+    int offset = m_notifierBox->width() / 4;
+    m_notifierBox->move(mapFromGlobal(topLeft) + QPoint(offset, offset));
+    m_notifierBox->showMessage(QString::number(m_context.circleCount));
+}
+
 void CaptureWidget::keyPressEvent(QKeyEvent* e)
 {
     // If the key is a digit, change the tool size

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -860,21 +860,21 @@ void CaptureWidget::wheelEvent(QWheelEvent* e)
      * impossible to scroll. It's easier to calculate number of requests and do
      * not accept events faster that one in 200ms.
      * */
-    int toolSizeOffset = 0;
+    int offset = 0;
     if (e->angleDelta().y() >= 60) {
         // mouse scroll (wheel) increment
-        toolSizeOffset = 1;
+        offset = 1;
     } else if (e->angleDelta().y() <= -60) {
         // mouse scroll (wheel) decrement
-        toolSizeOffset = -1;
+        offset = -1;
     } else {
         // touchpad scroll
         qint64 current = QDateTime::currentMSecsSinceEpoch();
         if ((current - m_lastMouseWheel) > 200) {
             if (e->angleDelta().y() > 0) {
-                toolSizeOffset = 1;
+                offset = 1;
             } else if (e->angleDelta().y() < 0) {
-                toolSizeOffset = -1;
+                offset = -1;
             }
             m_lastMouseWheel = current;
         } else {
@@ -882,7 +882,13 @@ void CaptureWidget::wheelEvent(QWheelEvent* e)
         }
     }
 
-    setToolSize(m_context.toolSize + toolSizeOffset);
+    bool counterMod = qApp->keyboardModifiers() & Qt::ControlModifier;
+
+    if (counterMod) {
+        setCircleCount(m_context.circleCount + offset);
+    } else {
+        setToolSize(m_context.toolSize + offset);
+    }
 }
 
 void CaptureWidget::resizeEvent(QResizeEvent* e)

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -176,6 +176,8 @@ CaptureWidget::CaptureWidget(const CaptureRequest& req,
     m_buttonHandler->updateScreenRegions(areas);
     m_buttonHandler->hide();
 
+    m_context.circleCount = 1;
+
     initButtons();
     initSelection(); // button handler must be initialized before
     initShortcuts(); // must be called after initSelection
@@ -554,6 +556,7 @@ bool CaptureWidget::startDrawObjectTool(const QPoint& pos)
             // While it is based on AbstractTwoPointTool it has the only one
             // point and shouldn't wait for second point and move event
             m_activeTool->drawEnd(m_context.mousePos);
+            m_activeTool->setCount(m_context.circleCount++);
 
             m_captureToolObjectsBackup = m_captureToolObjects;
             m_captureToolObjects.append(m_activeTool);
@@ -1475,11 +1478,7 @@ void CaptureWidget::drawToolsData()
     // TODO refactor this for performance. The objects should not all be updated
     // at once every time
     QPixmap pixmapItem = m_context.origScreenshot;
-    int circleCount = 1;
     for (auto toolItem : m_captureToolObjects.captureToolObjects()) {
-        if (toolItem->type() == CaptureTool::TYPE_CIRCLECOUNT) {
-            toolItem->setCount(circleCount++);
-        }
         processPixmapWithTool(&pixmapItem, toolItem);
         update(paddedUpdateRect(toolItem->boundingRect()));
     }

--- a/src/widgets/capture/capturewidget.h
+++ b/src/widgets/capture/capturewidget.h
@@ -121,6 +121,7 @@ private:
                                   const char* slot);
 
     void setToolSize(int size);
+    void setCircleCount(int count);
 
     QRect extendedSelection() const;
     QRect extendedRect(const QRect& r) const;


### PR DESCRIPTION
Related to: #1214

This PR implements this idea: https://github.com/flameshot-org/flameshot/issues/1214#issuecomment-803057997

I had to have some kind of global variable to keep track of the current circle number, so I added a `m_context.circleCount` context variable.

Maybe there is a better way, I know that something which is tool-related maybe shouldn't be in the general context.

I moved the "incrementation of the series" logic elsewhere: now the increment is done when adding a new circle.

You are not forced to [click outside of the capture area](https://github.com/flameshot\-org/flameshot/issues/1214\#issuecomment\-753593207) to continue the number series anymore.

And you can go back to:

- Previous numbers
- Reset to 1
- Reset to 0
- Negative numbers
  - I kept this because maybe there would be a use-case for this
  - If we were to actually bound the value to a minimum, this minimum should be 0. I had this need this morning because I wanted to display IDs, which were starting from 0.