### PR TITLE
Added Alt-PrtScn as alternate method for initiating screen capture

### DIFF
--- a/src/core/globalshortcutfilter.cpp
+++ b/src/core/globalshortcutfilter.cpp
@@ -38,7 +38,7 @@ bool GlobalShortcutFilter::nativeEventFilter(const QByteArray& eventType,
         }
 
         // Capture screen
-        if (VK_SNAPSHOT == keycode && 0 == modifiers) {
+        if (VK_SNAPSHOT == keycode && (0 == modifiers || MOD_ALT == modifiers) {
             Controller::getInstance()->requestCapture(
               CaptureRequest(CaptureRequest::GRAPHICAL_MODE));
         }


### PR DESCRIPTION
Simple fix to allow Alt-PrtScr as alternative way of initiating screen capture on windows 10.
This should provide workaround for using keyboard to capture screen in windows when other WINDOWs defaults Bind to the PrtScr Key.