### PR TITLE
Implement abstract logger

### DIFF
--- a/external/Qt-Color-Widgets/src/QtColorWidgets/color_wheel.cpp
+++ b/external/Qt-Color-Widgets/src/QtColorWidgets/color_wheel.cpp
@@ -231,7 +231,11 @@ void ColorWheel::mouseReleaseEvent(QMouseEvent *ev)
 
 void ColorWheel::resizeEvent(QResizeEvent *)
 {
-    p->render_ring();
+    static bool skipFirst = true;
+    // Skip the first time in order to prevent QPainter warning messages
+    if (!skipFirst)
+        p->render_ring();
+    skipFirst = false;
     p->render_inner_selector();
 }
 

--- a/src/config/configwindow.cpp
+++ b/src/config/configwindow.cpp
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: 2017-2019 Alejandro Sirgo Rica & Contributors
 
 #include "configwindow.h"
+#include "abstractlogger.h"
 #include "src/config/filenameeditor.h"
 #include "src/config/generalconf.h"
 #include "src/config/shortcutswidget.h"
@@ -161,7 +162,7 @@ void ConfigWindow::initErrorIndicator(QWidget* tab, QWidget* widget)
     connect(btnShowErrors, &QPushButton::clicked, this, [this]() {
         // Generate error log message
         QString str;
-        QTextStream stream(&str);
+        AbstractLogger stream(str, AbstractLogger::Error);
         ConfigHandler().checkForErrors(&stream);
 
         // Set up dialog

--- a/src/core/controller.cpp
+++ b/src/core/controller.cpp
@@ -8,6 +8,7 @@
 #include "external/QHotkey/QHotkey"
 #endif
 
+#include "abstractlogger.h"
 #include "pinwidget.h"
 #include "screenshotsaver.h"
 #include "src/config/configwindow.h"
@@ -18,14 +19,12 @@
 #include "src/utils/globalvalues.h"
 #include "src/utils/history.h"
 #include "src/utils/screengrabber.h"
-#include "src/utils/systemnotification.h"
 #include "src/widgets/capture/capturetoolbutton.h"
 #include "src/widgets/capture/capturewidget.h"
 #include "src/widgets/capturelauncher.h"
 #include "src/widgets/historywidget.h"
 #include "src/widgets/imguploaddialog.h"
 #include "src/widgets/infowindow.h"
-#include "src/widgets/notificationwidget.h"
 #include <QAction>
 #include <QApplication>
 #include <QBuffer>
@@ -604,8 +603,8 @@ void Controller::exportCapture(QPixmap capture,
     if (tasks & CR::PIN) {
         FlameshotDaemon::createPin(capture, selection);
         if (mode == CR::SCREEN_MODE || mode == CR::FULLSCREEN_MODE) {
-            SystemNotification().sendMessage(
-              QObject::tr("Full screen screenshot pinned to screen"));
+            AbstractLogger::info()
+              << QObject::tr("Full screen screenshot pinned to screen");
         }
     }
 
@@ -626,9 +625,8 @@ void Controller::exportCapture(QPixmap capture,
           widget, &ImgUploaderBase::uploadOk, [=](const QUrl& url) {
               if (ConfigHandler().copyAndCloseAfterUpload()) {
                   if (!(tasks & CR::COPY)) {
-                      SystemNotification().sendMessage(
-                        QObject::tr("URL copied to clipboard."));
-
+                      AbstractLogger::info()
+                        << QObject::tr("URL copied to clipboard.");
                       QApplication::clipboard()->setText(url.toString());
                       widget->close();
                   } else {

--- a/src/core/flameshotdaemon.cpp
+++ b/src/core/flameshotdaemon.cpp
@@ -1,10 +1,10 @@
 #include "flameshotdaemon.h"
 
+#include "abstractlogger.h"
 #include "confighandler.h"
 #include "controller.h"
 #include "pinwidget.h"
 #include "screenshotsaver.h"
-#include "systemnotification.h"
 #include <QApplication>
 #include <QClipboard>
 #include <QDBusConnection>
@@ -228,7 +228,7 @@ void FlameshotDaemon::attachTextToClipboard(QString text, QString notification)
     m_clipboardSignalBlocked = true;
     clipboard->setText(text);
     if (!notification.isEmpty()) {
-        SystemNotification().sendMessage(notification);
+        AbstractLogger::info() << notification;
     }
     clipboard->blockSignals(false);
 }
@@ -246,7 +246,7 @@ QDBusMessage FlameshotDaemon::createMethodCall(QString method)
 void FlameshotDaemon::checkDBusConnection(const QDBusConnection& connection)
 {
     if (!connection.isConnected()) {
-        SystemNotification().sendMessage(tr("Unable to connect via DBus"));
+        AbstractLogger::error() << tr("Unable to connect via DBus");
         qApp->exit(1);
     }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -60,9 +60,7 @@ void requestCaptureAndWait(const CaptureRequest& req)
           }
       });
     QObject::connect(controller, &Controller::captureFailed, []() {
-        // TODO use abstract logger
-        // TODO do we have to do more stuff here?
-        QTextStream(stderr) << "screenshot aborted\n";
+        AbstractLogger::info() << "Screenshot aborted.";
         qApp->exit(1);
     });
     qApp->exec();
@@ -241,14 +239,15 @@ int main(int argc, char* argv[])
                   "You may need to escape the '#' sign as in '\\#FFF'");
 
     const QString delayErr =
-      QObject::tr("Invalid delay, it must be higher than 0");
+      QObject::tr("Invalid delay, it must be a number greater than 0");
     const QString numberErr =
       QObject::tr("Invalid screen number, it must be non negative");
     const QString regionErr = QObject::tr(
       "Invalid region, use 'WxH+X+Y' or 'all' or 'screen0/screen1/...'.");
     auto numericChecker = [](const QString& delayValue) -> bool {
-        int value = delayValue.toInt();
-        return value >= 0;
+        bool ok;
+        int value = delayValue.toInt(&ok);
+        return ok && value >= 0;
     };
     auto regionChecker = [](const QString& region) -> bool {
         Region valueHandler;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -16,7 +16,6 @@
 #include "src/utils/confighandler.h"
 #include "src/utils/filenamehandler.h"
 #include "src/utils/pathinfo.h"
-#include "src/utils/systemnotification.h"
 #include "src/utils/valuehandler.h"
 #include <QApplication>
 #include <QDir>
@@ -139,8 +138,8 @@ int main(int argc, char* argv[])
         new FlameshotDBusAdapter(c);
         QDBusConnection dbus = QDBusConnection::sessionBus();
         if (!dbus.isConnected()) {
-            SystemNotification().sendMessage(
-              QObject::tr("Unable to connect via DBus"));
+            AbstractLogger::error()
+              << QObject::tr("Unable to connect via DBus");
         }
         dbus.registerObject(QStringLiteral("/"), c);
         dbus.registerService(QStringLiteral("org.flameshot.Flameshot"));
@@ -264,8 +263,7 @@ int main(int argc, char* argv[])
         if (fileInfo.isDir() || fileInfo.dir().exists()) {
             return true;
         } else {
-            SystemNotification().sendMessage(
-              QObject::tr(pathErr.toLatin1().data()));
+            AbstractLogger::error() << QObject::tr(pathErr.toLatin1().data());
             return false;
         }
     };
@@ -502,7 +500,7 @@ int main(int argc, char* argv[])
         bool someFlagSet =
           (filename || tray || mainColor || contrastColor || check);
         if (check) {
-            AbstractLogger err(AbstractLogger::Error, AbstractLogger::Stderr);
+            AbstractLogger err = AbstractLogger::error(AbstractLogger::Stderr);
             bool ok = ConfigHandler(true).checkForErrors(&err);
             if (ok) {
                 err << QStringLiteral("No errors detected.\n");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,6 +7,7 @@
 #include "QtSolutions/qtsingleapplication.h"
 #endif
 
+#include "abstractlogger.h"
 #include "src/cli/commandlineparser.h"
 #include "src/config/styleoverride.h"
 #include "src/core/capturerequest.h"
@@ -28,6 +29,7 @@
 #include "spdlog/spdlog.h"
 
 #if defined(Q_OS_LINUX) || defined(Q_OS_UNIX)
+#include "abstractlogger.h"
 #include "src/core/flameshotdbusadapter.h"
 #include <QApplication>
 #include <QDBusConnection>
@@ -500,7 +502,7 @@ int main(int argc, char* argv[])
         bool someFlagSet =
           (filename || tray || mainColor || contrastColor || check);
         if (check) {
-            QTextStream err(stderr);
+            AbstractLogger err(AbstractLogger::Error, AbstractLogger::Stderr);
             bool ok = ConfigHandler(true).checkForErrors(&err);
             if (ok) {
                 err << QStringLiteral("No errors detected.\n");

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -1,7 +1,8 @@
 # Required to generate MOC
 target_sources(
   flameshot
-  PRIVATE filenamehandler.h
+  PRIVATE abstractlogger.h
+          filenamehandler.h
           screengrabber.h
           systemnotification.h
           valuehandler.h
@@ -11,7 +12,8 @@ target_sources(
 
 target_sources(
   flameshot
-  PRIVATE filenamehandler.cpp
+  PRIVATE abstractlogger.cpp
+          filenamehandler.cpp
           screengrabber.cpp
           confighandler.cpp
           systemnotification.cpp

--- a/src/utils/abstractlogger.cpp
+++ b/src/utils/abstractlogger.cpp
@@ -48,7 +48,7 @@ AbstractLogger AbstractLogger::error(int targets)
     return AbstractLogger(Error, targets);
 }
 
-void AbstractLogger::sendMessage(QString msg, Channel channel)
+AbstractLogger& AbstractLogger::sendMessage(QString msg, Channel channel)
 {
     if (m_targets & Notification) {
         SystemNotification().sendMessage(
@@ -113,6 +113,9 @@ AbstractLogger& AbstractLogger::enableMessageHeader(bool enable)
  */
 QString AbstractLogger::messageHeader(Channel channel, Target target)
 {
+    if (!m_enableMessageHeader) {
+        return "";
+    }
     QString messageChannel;
     if (channel == Info) {
         messageChannel = "info";

--- a/src/utils/abstractlogger.cpp
+++ b/src/utils/abstractlogger.cpp
@@ -3,9 +3,6 @@
 
 #include <QFileInfo>
 
-// TODO add null checks and exceptions
-// TODO only send notification when flushed
-
 AbstractLogger::AbstractLogger(Channel channel, int targets)
   : m_defaultChannel(channel)
   , m_targets(targets)
@@ -24,7 +21,6 @@ AbstractLogger::AbstractLogger(QString& str,
                                int additionalChannels)
   : AbstractLogger(channel, additionalChannels)
 {
-    // TODO error if targets excludes String.
     m_textStreams << new QTextStream(&str);
 }
 

--- a/src/utils/abstractlogger.cpp
+++ b/src/utils/abstractlogger.cpp
@@ -1,0 +1,59 @@
+#include "abstractlogger.h"
+#include "systemnotification.h"
+
+#include <QFileInfo>
+
+// TODO add null checks and exceptions
+// TODO only send notification when flushed
+
+AbstractLogger::AbstractLogger(Type type, int channels)
+  : m_channels(channels)
+{
+    if (channels & LogFile) {
+        // TODO
+    }
+}
+
+AbstractLogger::AbstractLogger(QString& str, Type type, int additionalChannels)
+  : AbstractLogger(type, additionalChannels)
+{
+    // TODO error if channels excludes String.
+    m_textStreams << new QTextStream(&str);
+}
+
+AbstractLogger::~AbstractLogger()
+{
+    qDeleteAll(m_textStreams);
+}
+
+AbstractLogger& AbstractLogger::operator<<(const QString& msg)
+{
+    if (m_channels & Notification) {
+        SystemNotification().sendMessage(msg);
+    }
+    if (!m_textStreams.isEmpty()) {
+        foreach (auto* stream, m_textStreams) {
+            *stream << msg;
+        }
+    }
+    if (m_channels & LogFile) {
+        // TODO
+    }
+    if (m_channels & Stdout) {
+        // TODO this doesn't work with dbus. Either remove dbus or change this.
+        // TODO should we ever log to stdout?
+        QTextStream stream(stdout);
+        stream << msg << "\n";
+    }
+    if (m_channels & Stderr) {
+        // TODO this doesn't work with dbus. Either remove dbus or change this.
+        QTextStream stream(stderr);
+        stream << msg << "\n";
+    }
+    return *this;
+}
+
+void AbstractLogger::addOutputString(QString& str)
+{
+    m_textStreams << new QTextStream(&str);
+}

--- a/src/utils/abstractlogger.cpp
+++ b/src/utils/abstractlogger.cpp
@@ -1,5 +1,6 @@
 #include "abstractlogger.h"
 #include "systemnotification.h"
+#include <cassert>
 
 #include <QFileInfo>
 

--- a/src/utils/abstractlogger.cpp
+++ b/src/utils/abstractlogger.cpp
@@ -62,6 +62,7 @@ AbstractLogger& AbstractLogger::sendMessage(QString msg, Channel channel)
         QTextStream stream(stderr);
         stream << messageHeader(channel, Stderr) << msg << "\n";
     }
+    return *this;
 }
 
 /**

--- a/src/utils/abstractlogger.h
+++ b/src/utils/abstractlogger.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <QString>
+#include <QTextStream>
+
+/**
+ * @brief A class that allows you to log events to where they need to go.
+ */
+class AbstractLogger : public QObject
+{
+    Q_OBJECT
+public:
+    enum Channel
+    {
+        Notification = 0x01,
+        LogFile = 0x02,
+        Stderr = 0x04,
+        Stdout = 0x08,
+        String = 0x10,
+        Default = Notification | LogFile | Stderr,
+    };
+
+    enum Type
+    {
+        Info,
+        Warning,
+        Error
+    };
+
+    AbstractLogger(Type type = Info, int channels = Stdout);
+    AbstractLogger(QString& str, Type type, int additionalChannels = String);
+    ~AbstractLogger();
+
+    AbstractLogger& operator<<(const QString& msg);
+    void addOutputString(QString& str);
+
+private:
+    int m_channels;
+    QList<QTextStream*> m_textStreams;
+};

--- a/src/utils/abstractlogger.h
+++ b/src/utils/abstractlogger.h
@@ -10,31 +10,45 @@ class AbstractLogger : public QObject
 {
     Q_OBJECT
 public:
-    enum Channel
+    enum Target
     {
         Notification = 0x01,
-        LogFile = 0x02,
-        Stderr = 0x04,
-        Stdout = 0x08,
+        Stderr = 0x02,
+        LogFile = 0x08,
         String = 0x10,
         Default = Notification | LogFile | Stderr,
     };
 
-    enum Type
+    enum Channel
     {
         Info,
         Warning,
         Error
     };
 
-    AbstractLogger(Type type = Info, int channels = Stdout);
-    AbstractLogger(QString& str, Type type, int additionalChannels = String);
+    AbstractLogger(Channel channel = Info, int targets = Default);
+    AbstractLogger(QString& str,
+                   Channel channel,
+                   int additionalTargets = String);
     ~AbstractLogger();
 
-    AbstractLogger& operator<<(const QString& msg);
-    void addOutputString(QString& str);
+    // Convenience functions
+    static AbstractLogger info(int targets = Default);
+    static AbstractLogger warning(int targets = Default);
+    static AbstractLogger error(int targets = Default);
+
+    void sendMessage(QString msg, Channel channel);
+    AbstractLogger& operator<<(QString msg);
+    AbstractLogger& addOutputString(QString& str);
+    AbstractLogger& attachNotificationPath(QString path);
+    AbstractLogger& enableMessageHeader(bool enable);
 
 private:
-    int m_channels;
+    QString messageHeader(Channel type, Target channel);
+
+    int m_targets;
+    Channel m_defaultChannel;
     QList<QTextStream*> m_textStreams;
+    QString m_notificationPath;
+    bool m_enableMessageHeader;
 };

--- a/src/utils/abstractlogger.h
+++ b/src/utils/abstractlogger.h
@@ -6,9 +6,8 @@
 /**
  * @brief A class that allows you to log events to where they need to go.
  */
-class AbstractLogger : public QObject
+class AbstractLogger
 {
-    Q_OBJECT
 public:
     enum Target
     {
@@ -37,7 +36,7 @@ public:
     static AbstractLogger warning(int targets = Default);
     static AbstractLogger error(int targets = Default);
 
-    void sendMessage(QString msg, Channel channel);
+    AbstractLogger& sendMessage(QString msg, Channel channel);
     AbstractLogger& operator<<(QString msg);
     AbstractLogger& addOutputString(QString& str);
     AbstractLogger& attachNotificationPath(QString path);
@@ -50,5 +49,5 @@ private:
     Channel m_defaultChannel;
     QList<QTextStream*> m_textStreams;
     QString m_notificationPath;
-    bool m_enableMessageHeader;
+    bool m_enableMessageHeader = true;
 };

--- a/src/utils/confighandler.cpp
+++ b/src/utils/confighandler.cpp
@@ -4,7 +4,6 @@
 #include "confighandler.h"
 #include "abstractlogger.h"
 #include "src/tools/capturetool.h"
-#include "systemnotification.h"
 #include "valuehandler.h"
 #include <QCoreApplication>
 #include <QDebug>
@@ -659,12 +658,12 @@ void ConfigHandler::setErrorState(bool error) const
     // Notify user every time m_hasError changes
     if (!hadError && m_hasError) {
         QString msg = errorMessage();
-        SystemNotification().sendMessage(msg);
+        AbstractLogger::error() << msg;
         emit getInstance()->error();
     } else if (hadError && !m_hasError) {
         auto msg =
           tr("You have successfully resolved the configuration error.");
-        SystemNotification().sendMessage(msg);
+        AbstractLogger::info() << msg;
         emit getInstance()->errorResolved();
     }
 }

--- a/src/utils/confighandler.cpp
+++ b/src/utils/confighandler.cpp
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: 2017-2019 Alejandro Sirgo Rica & Contributors
 
 #include "confighandler.h"
+#include "abstractlogger.h"
 #include "src/tools/capturetool.h"
 #include "systemnotification.h"
 #include "valuehandler.h"
@@ -14,7 +15,6 @@
 #include <QMap>
 #include <QSharedPointer>
 #include <QStandardPaths>
-#include <QTextStream>
 #include <QVector>
 #include <algorithm>
 #include <stdexcept>
@@ -508,7 +508,7 @@ QSet<QString> ConfigHandler::keysFromGroup(const QString& group) const
 
 // ERROR HANDLING
 
-bool ConfigHandler::checkForErrors(QTextStream* log) const
+bool ConfigHandler::checkForErrors(AbstractLogger* log) const
 {
     return checkUnrecognizedSettings(log) & checkShortcutConflicts(log) &
            checkSemantics(log);
@@ -522,7 +522,7 @@ bool ConfigHandler::checkForErrors(QTextStream* log) const
  * `recognizedGeneralOptions` or `recognizedShortcutNames` depending on the
  * group the option belongs to.
  */
-bool ConfigHandler::checkUnrecognizedSettings(QTextStream* log) const
+bool ConfigHandler::checkUnrecognizedSettings(AbstractLogger* log) const
 {
     // sort the config keys by group
     QSet<QString> generalKeys = keysFromGroup("General"),
@@ -556,7 +556,7 @@ bool ConfigHandler::checkUnrecognizedSettings(QTextStream* log) const
  * is the flameshot default (not because the user explicitly configured it), and
  * action B uses the same shortcut.
  */
-bool ConfigHandler::checkShortcutConflicts(QTextStream* log) const
+bool ConfigHandler::checkShortcutConflicts(AbstractLogger* log) const
 {
     bool ok = true;
     m_settings.beginGroup("Shortcuts");
@@ -598,7 +598,7 @@ bool ConfigHandler::checkShortcutConflicts(QTextStream* log) const
  * @brief Check each config value semantically.
  * @return Whether the config passes this check.
  */
-bool ConfigHandler::checkSemantics(QTextStream* log) const
+bool ConfigHandler::checkSemantics(AbstractLogger* log) const
 {
     QStringList allKeys = m_settings.allKeys();
     bool ok = true;

--- a/src/utils/confighandler.h
+++ b/src/utils/confighandler.h
@@ -14,6 +14,7 @@ class ValueHandler;
 template<class T>
 class QSharedPointer;
 class QTextStream;
+class AbstractLogger;
 
 /**
  * Declare and implement a getter for a config option. `KEY` is the option key
@@ -135,10 +136,10 @@ public:
     QSet<QString> keysFromGroup(const QString& group) const;
 
     // ERROR HANDLING
-    bool checkForErrors(QTextStream* log = nullptr) const;
-    bool checkUnrecognizedSettings(QTextStream* log = nullptr) const;
-    bool checkShortcutConflicts(QTextStream* log = nullptr) const;
-    bool checkSemantics(QTextStream* log = nullptr) const;
+    bool checkForErrors(AbstractLogger* log = nullptr) const;
+    bool checkUnrecognizedSettings(AbstractLogger* log = nullptr) const;
+    bool checkShortcutConflicts(AbstractLogger* log = nullptr) const;
+    bool checkSemantics(AbstractLogger* log = nullptr) const;
     void checkAndHandleError() const;
     void setErrorState(bool error) const;
     bool hasError() const;

--- a/src/utils/screengrabber.cpp
+++ b/src/utils/screengrabber.cpp
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: 2017-2019 Alejandro Sirgo Rica & Contributors
 
 #include "screengrabber.h"
+#include "abstractlogger.h"
 #include "src/core/qguiappcurrentscreen.h"
 #include "src/utils/filenamehandler.h"
 #include "src/utils/systemnotification.h"
@@ -124,7 +125,7 @@ QPixmap ScreenGrabber::grabEntireDesktop(bool& ok)
                 break;
         }
         if (!ok) {
-            SystemNotification().sendMessage(tr("Unable to capture screen"));
+            AbstractLogger::error() << tr("Unable to capture screen");
         }
         return res;
     }

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -10,6 +10,7 @@
 // <http://www.gnu.org/licenses/old-licenses/library.txt>
 
 #include "capturewidget.h"
+#include "abstractlogger.h"
 #include "copytool.h"
 #include "src/core/controller.h"
 #include "src/core/qguiappcurrentscreen.h"
@@ -100,7 +101,7 @@ CaptureWidget::CaptureWidget(const CaptureRequest& req,
         bool ok = true;
         m_context.screenshot = ScreenGrabber().grabEntireDesktop(ok);
         if (!ok) {
-            SystemNotification().sendMessage(tr("Unable to capture screen"));
+            AbstractLogger::error() << tr("Unable to capture screen");
             this->close();
         }
         m_context.origScreenshot = m_context.screenshot;


### PR DESCRIPTION
As briefly advertised some time ago, I implemented an AbstractLogger thatserves
as a common interface for all messages/notifications/logs. I replaced all
notifications with calls to AbstractLogger. Those calls initiate notifications
just like before, but now also print those same messages to the CLI using a
standard format:

```
flameshot: info/warning/error: ...
```

And I replaced some of the `QTextStream(stderr)` calls with AbstractLogger.

**Some problems:**

- Since copy to clipboard is handled by the daemon, the CLI notification
  is also printed by the daemon. The fix for this is unrelated to the
  AbstractLogger implementation, and I'll implement it another time
- Logging to a file is not implemented. We have to discuss the dynamics of
  that first, in an issue. I'll get around to opening that discussion, or if
  someone else feels more emotionally attached to that feature they can do it.

Let me know what you think. And please test this out - I might have missed some
spots, i.e. forgot to rewrite some old messages/logging using the new interface.

Additionally, I managed to fix the annoying QPainter warnings (which were
printed at the subcommand since the DBUS PR, and not at the daemon). The fix is
inside the QtColorWidgets library. I'm going to try to push that fix upstream
as well.
