### PR TITLE
Fix QLayout warning in 'flameshot config'

### DIFF
--- a/src/config/configwindow.cpp
+++ b/src/config/configwindow.cpp
@@ -119,7 +119,7 @@ void ConfigWindow::initErrorIndicator(QWidget* tab, QWidget* widget)
 {
     QLabel* label = new QLabel(tab);
     QPushButton* btnShowErrors = new QPushButton("Show errors", tab);
-    QHBoxLayout* btnLayout = new QHBoxLayout(tab);
+    QHBoxLayout* btnLayout = new QHBoxLayout();
 
     // Set up label
     label->setText(tr(


### PR DESCRIPTION
Removes the following warning messages from `flameshot config`:
```
QLayout: Attempting to add QLayout "" to QWidget "", which already has a layout
```
