### PR TITLE
first pass at region in launcher

### DIFF
--- a/src/widgets/capturelauncher.cpp
+++ b/src/widgets/capturelauncher.cpp
@@ -8,8 +8,10 @@
 #include "src/utils/screengrabber.h"
 #include "src/utils/screenshotsaver.h"
 #include "src/widgets/imagelabel.h"
+#include <QDir>
+#include <QFile>
 #include <QMimeData>
-
+#include <QStandardPaths>
 // https://github.com/KDE/spectacle/blob/941c1a517be82bed25d1254ebd735c29b0d2951c/src/Gui/KSWidget.cpp
 // https://github.com/KDE/spectacle/blob/941c1a517be82bed25d1254ebd735c29b0d2951c/src/Gui/KSMainWindow.cpp
 
@@ -57,13 +59,72 @@ CaptureLauncher::CaptureLauncher(QDialog* parent)
             this,
             &CaptureLauncher::startCapture);
 
+    connect(ui->captureType,
+            QOverload<int>::of(&QComboBox::currentIndexChanged),
+            this,
+            [this]() {
+                auto mode = static_cast<CaptureRequest::CaptureMode>(
+                  ui->captureType->currentData().toInt());
+                if (mode == CaptureRequest::CaptureMode::GRAPHICAL_MODE) {
+                    ui->sizeLabel->show();
+                    ui->screenshotX->show();
+                    ui->screenshotY->show();
+                    ui->screenshotWidth->show();
+                    ui->screenshotHeight->show();
+                } else {
+                    ui->sizeLabel->hide();
+                    ui->screenshotX->hide();
+                    ui->screenshotY->hide();
+                    ui->screenshotWidth->hide();
+                    ui->screenshotHeight->hide();
+                }
+            });
+
+    auto last_region = getLastRegion();
+    ui->screenshotX->setText(QString::number(last_region.x()));
+    ui->screenshotY->setText(QString::number(last_region.y()));
+    ui->screenshotWidth->setText(QString::number(last_region.width()));
+    ui->screenshotHeight->setText(QString::number(last_region.height()));
     show();
 }
 
+void CaptureLauncher::setLastRegion()
+{
+    auto cachePath = getCachePath() + "/region.txt";
+
+    QFile file(cachePath);
+    if (file.open(QIODevice::WriteOnly)) {
+        auto newRegion = QRect(ui->screenshotX->text().toInt(),
+                               ui->screenshotY->text().toInt(),
+                               ui->screenshotWidth->text().toInt(),
+                               ui->screenshotHeight->text().toInt());
+        QDataStream out(&file);
+        out << newRegion;
+        file.close();
+    }
+}
+
+QRect CaptureLauncher::getLastRegion()
+{
+    auto cachePath = getCachePath() + "/region.txt";
+    QFile file(cachePath);
+
+    QRect lastRegion;
+    if (file.open(QIODevice::ReadOnly)) {
+        QDataStream in(&file);
+        in >> lastRegion;
+        file.close();
+    } else {
+        lastRegion = QRect(0, 0, 0, 0);
+    }
+
+    return lastRegion;
+}
 // HACK:
 // https://github.com/KDE/spectacle/blob/fa1e780b8bf3df3ac36c410b9ece4ace041f401b/src/Gui/KSMainWindow.cpp#L70
 void CaptureLauncher::startCapture()
 {
+    setLastRegion();
     ui->launchButton->setEnabled(false);
     hide();
 
@@ -74,6 +135,14 @@ void CaptureLauncher::startCapture()
     CaptureRequest req(mode,
                        additionalDelayToHideUI +
                          ui->delayTime->value() * secondsToMilliseconds);
+
+    if (mode == CaptureRequest::CaptureMode::GRAPHICAL_MODE) {
+        req.setInitialSelection(QRect(ui->screenshotX->text().toInt(),
+                                      ui->screenshotY->text().toInt(),
+                                      ui->screenshotWidth->text().toInt(),
+                                      ui->screenshotHeight->text().toInt()));
+    }
+
     connectCaptureSlots();
     Flameshot::instance()->requestCapture(req);
 }
@@ -107,7 +176,7 @@ void CaptureLauncher::disconnectCaptureSlots() const
                &CaptureLauncher::onCaptureFailed);
 }
 
-void CaptureLauncher::onCaptureTaken(QPixmap screenshot)
+void CaptureLauncher::onCaptureTaken(QPixmap const& screenshot)
 {
     // MacOS specific, more details in the function disconnectCaptureSlots()
     disconnectCaptureSlots();
@@ -135,4 +204,14 @@ void CaptureLauncher::onCaptureFailed()
 CaptureLauncher::~CaptureLauncher()
 {
     delete ui;
+}
+
+QString getCachePath()
+{
+    auto cachePath =
+      QStandardPaths::writableLocation(QStandardPaths::CacheLocation);
+    if (!QDir(cachePath).exists()) {
+        QDir().mkpath(cachePath);
+    }
+    return cachePath;
 }

--- a/src/widgets/capturelauncher.h
+++ b/src/widgets/capturelauncher.h
@@ -23,9 +23,13 @@ private:
     Ui::CaptureLauncher* ui;
     void connectCaptureSlots() const;
     void disconnectCaptureSlots() const;
+    void setLastRegion();
+    QRect getLastRegion();
 
 private slots:
     void startCapture();
-    void onCaptureTaken(QPixmap p);
+    void onCaptureTaken(QPixmap const& p);
     void onCaptureFailed();
 };
+
+QString getCachePath();

--- a/src/widgets/capturelauncher.ui
+++ b/src/widgets/capturelauncher.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>619</width>
-    <height>148</height>
+    <width>807</width>
+    <height>213</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -18,6 +18,18 @@
     <layout class="QHBoxLayout" name="horizontalLayout_3">
      <item>
       <widget class="ImageLabel" name="imagePreview">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>420</width>
+         <height>0</height>
+        </size>
+       </property>
        <property name="text">
         <string>TextLabel</string>
        </property>
@@ -55,6 +67,13 @@
          </property>
         </widget>
        </item>
+       <item row="1" column="1">
+        <widget class="QComboBox" name="captureType">
+         <property name="currentText">
+          <string/>
+         </property>
+        </widget>
+       </item>
        <item row="3" column="0">
         <widget class="QLabel" name="delayLabel">
          <property name="text">
@@ -62,10 +81,16 @@
          </property>
         </widget>
        </item>
-       <item row="1" column="1">
-        <widget class="QComboBox" name="captureType">
-         <property name="currentText">
-          <string/>
+       <item row="4" column="0">
+        <widget class="QLabel" name="sizeLabel">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>WxH+x+y</string>
          </property>
         </widget>
        </item>
@@ -82,12 +107,56 @@
          </property>
         </widget>
        </item>
+       <item row="4" column="1">
+        <layout class="QHBoxLayout" name="horizontalLayout">
+         <item>
+          <widget class="QLineEdit" name="screenshotWidth">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLineEdit" name="screenshotHeight">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLineEdit" name="screenshotX">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLineEdit" name="screenshotY">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
       </layout>
      </item>
      <item alignment="Qt::AlignHCenter">
       <widget class="QPushButton" name="launchButton">
        <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>


### PR DESCRIPTION
## Todo

- [x] Size combo boxes more appropriately 
- [x] Hide region settings when in full screen mode
- [x] If there was no "last region", rather than setting 0x0+0+0, set the full resolution
- [x] Decide where to store the last shot

## Demo
![Peek 2021-12-30 20-06](https://user-images.githubusercontent.com/46930769/147798948-b5598ce7-7e86-4163-9868-1f72e06558bc.gif)

