### PR TITLE
Recommend installation of package grim in deb packages

### DIFF
--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -23,6 +23,7 @@ Depends:
  ${misc:Depends},
 Recommends:
  xdg-desktop-portal-gtk | xdg-desktop-portal-gnome | xdg-desktop-portal-kde | xdg-desktop-portal-wlr,
+ grim,
 Suggests:
  ca-certificates,
  openssl,


### PR DESCRIPTION
Package grim is needed when using flameshot in Sway.

See also: #2109