### PR TITLE
Introduce a config resolver

### DIFF
--- a/src/config/CMakeLists.txt
+++ b/src/config/CMakeLists.txt
@@ -3,6 +3,8 @@ target_sources(
   PRIVATE buttonlistview.cpp
           clickablelabel.cpp
           configwindow.cpp
+          configresolver.cpp
+          configerrordetails.cpp
           extendedslider.cpp
           filenameeditor.cpp
           generalconf.cpp

--- a/src/config/configerrordetails.cpp
+++ b/src/config/configerrordetails.cpp
@@ -17,7 +17,7 @@ ConfigErrorDetails::ConfigErrorDetails(QWidget* parent)
     ConfigHandler().checkForErrors(&stream);
 
     // Set up dialog
-    setWindowTitle(QStringLiteral("Configuration errors"));
+    setWindowTitle(tr("Configuration errors"));
     setLayout(new QVBoxLayout(this));
 
     // Add text display

--- a/src/config/configerrordetails.cpp
+++ b/src/config/configerrordetails.cpp
@@ -1,0 +1,42 @@
+#include "src/config/configerrordetails.h"
+
+#include "src/utils/abstractlogger.h"
+#include "src/utils/confighandler.h"
+
+#include <QApplication>
+#include <QDialogButtonBox>
+#include <QTextEdit>
+#include <QVBoxLayout>
+
+ConfigErrorDetails::ConfigErrorDetails(QWidget* parent)
+  : QDialog(parent)
+{
+    // Generate error log message
+    QString str;
+    AbstractLogger stream(str, AbstractLogger::Error);
+    ConfigHandler().checkForErrors(&stream);
+
+    // Set up dialog
+    setWindowTitle(QStringLiteral("Configuration errors"));
+    setLayout(new QVBoxLayout(this));
+
+    // Add text display
+    QTextEdit* textDisplay = new QTextEdit(this);
+    textDisplay->setPlainText(str);
+    textDisplay->setReadOnly(true);
+    layout()->addWidget(textDisplay);
+
+    // Add Ok button
+    using BBox = QDialogButtonBox;
+    BBox* buttons = new BBox(BBox::Ok);
+    layout()->addWidget(buttons);
+    connect(buttons, &BBox::clicked, this, [this]() { close(); });
+
+    show();
+
+    qApp->processEvents();
+    QPoint center = geometry().center();
+    QRect dialogRect(0, 0, 600, 400);
+    dialogRect.moveCenter(center);
+    setGeometry(dialogRect);
+}

--- a/src/config/configerrordetails.h
+++ b/src/config/configerrordetails.h
@@ -1,0 +1,9 @@
+#include <QDialog>
+
+#pragma once
+
+class ConfigErrorDetails : public QDialog
+{
+public:
+    ConfigErrorDetails(QWidget* parent = nullptr);
+};

--- a/src/config/configresolver.cpp
+++ b/src/config/configresolver.cpp
@@ -1,0 +1,117 @@
+#include "src/config/configresolver.h"
+#include "src/config/configerrordetails.h"
+#include "src/utils/confighandler.h"
+
+#include "src/utils/valuehandler.h"
+#include <QDialogButtonBox>
+#include <QLabel>
+#include <QVBoxLayout>
+
+ConfigResolver::ConfigResolver(QWidget* parent)
+  : QDialog(parent)
+{
+    setWindowTitle("Resolve configuration errors");
+    setMinimumSize({ 250, 200 });
+    setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Maximum);
+    populate();
+    connect(ConfigHandler::getInstance(),
+            &ConfigHandler::fileChanged,
+            this,
+            [this]() { populate(); });
+}
+
+QGridLayout* ConfigResolver::layout()
+{
+    return dynamic_cast<QGridLayout*>(QDialog::layout());
+}
+
+void ConfigResolver::populate()
+{
+    ConfigHandler config;
+    QList<QString> unrecognized;
+    QList<QString> semanticallyWrong;
+
+    config.checkUnrecognizedSettings(nullptr, &unrecognized);
+    config.checkSemantics(nullptr, &semanticallyWrong);
+
+    // Remove previous layout and children, if any
+    resetLayout();
+
+    bool anyErrors = !semanticallyWrong.isEmpty() || !unrecognized.isEmpty();
+
+    // No errors detected
+    if (!anyErrors) {
+        layout()->addWidget(
+          new QLabel("<b>No errors detected.</b>"), 0, 0, Qt::AlignCenter);
+        accept();
+    }
+
+    layout()->addWidget(
+      new QLabel("<b>You must resolve all errors before continuing:</b>"),
+      0,
+      0,
+      1,
+      2,
+      Qt::AlignCenter);
+
+    int i = 1;
+    // List semantically incorrect settings with a "Reset" button
+    for (const auto& key : semanticallyWrong) {
+        auto* label = new QLabel(key);
+        auto* reset = new QPushButton("Reset");
+        reset->setToolTip("Reset to the default value.");
+        layout()->addWidget(label, i, 0, Qt::AlignRight);
+        layout()->addWidget(reset, i, 1);
+        reset->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+
+        connect(reset, &QPushButton::clicked, this, [key]() {
+            ConfigHandler().resetValue(key);
+        });
+
+        ++i;
+    }
+    // List unrecognized settings with a "Remove" button
+    for (const auto& key : unrecognized) {
+        auto* label = new QLabel(key);
+        auto* remove = new QPushButton("Remove");
+        remove->setToolTip("Remove this setting.");
+        layout()->addWidget(label, i, 0, Qt::AlignRight);
+        layout()->addWidget(remove, i, 1);
+        connect(remove, &QPushButton::clicked, this, [key]() {
+            ConfigHandler().remove(key);
+        });
+        ++i;
+    }
+
+    using BBox = QDialogButtonBox;
+
+    // Add button box at the bottom
+    auto* buttons = new BBox(this);
+    layout()->addWidget(buttons, i, 0, 1, 2, Qt::AlignCenter);
+    QPushButton *resolveAll = new QPushButton("Resolve all"),
+                *details = new QPushButton("Details");
+    resolveAll->setToolTip("Resolve all listed errors.");
+    buttons->addButton(resolveAll, BBox::ResetRole);
+    buttons->addButton(details, BBox::HelpRole);
+
+    connect(resolveAll, &QPushButton::clicked, this, [=]() {
+        for (const auto& key : semanticallyWrong)
+            ConfigHandler().resetValue(key);
+        for (const auto& key : unrecognized)
+            ConfigHandler().remove(key);
+    });
+    connect(details, &QPushButton::clicked, this, [this]() {
+        (new ConfigErrorDetails(this))->exec();
+    });
+    buttons->addButton(BBox::Cancel);
+    connect(buttons, &BBox::rejected, this, [this]() { reject(); });
+}
+
+void ConfigResolver::resetLayout()
+{
+    for (auto* child : children()) {
+        child->deleteLater();
+    }
+    delete layout();
+    setLayout(new QGridLayout());
+}

--- a/src/config/configresolver.cpp
+++ b/src/config/configresolver.cpp
@@ -10,7 +10,7 @@
 ConfigResolver::ConfigResolver(QWidget* parent)
   : QDialog(parent)
 {
-    setWindowTitle("Resolve configuration errors");
+    setWindowTitle(tr("Resolve configuration errors"));
     setMinimumSize({ 250, 200 });
     setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Maximum);
     populate();
@@ -45,7 +45,8 @@ void ConfigResolver::populate()
         accept();
     } else {
         layout()->addWidget(
-          new QLabel("<b>You must resolve all errors before continuing:</b>"),
+          new QLabel(
+            tr("<b>You must resolve all errors before continuing:</b>")),
           0,
           0,
           1,
@@ -57,8 +58,8 @@ void ConfigResolver::populate()
     // List semantically incorrect settings with a "Reset" button
     for (const auto& key : semanticallyWrong) {
         auto* label = new QLabel(key);
-        auto* reset = new QPushButton("Reset");
-        reset->setToolTip("Reset to the default value.");
+        auto* reset = new QPushButton(tr("Reset"));
+        reset->setToolTip(tr("Reset to the default value."));
         layout()->addWidget(label, i, 0, Qt::AlignRight);
         layout()->addWidget(reset, i, 1);
         reset->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
@@ -72,8 +73,8 @@ void ConfigResolver::populate()
     // List unrecognized settings with a "Remove" button
     for (const auto& key : unrecognized) {
         auto* label = new QLabel(key);
-        auto* remove = new QPushButton("Remove");
-        remove->setToolTip("Remove this setting.");
+        auto* remove = new QPushButton(tr("Remove"));
+        remove->setToolTip(tr("Remove this setting."));
         layout()->addWidget(label, i, 0, Qt::AlignRight);
         layout()->addWidget(remove, i, 1);
         connect(remove, &QPushButton::clicked, this, [key]() {
@@ -83,10 +84,10 @@ void ConfigResolver::populate()
     }
 
     if (!config.checkShortcutConflicts()) {
-        auto* conflicts =
-          new QLabel("Some keyboard shortcuts have conflicts.\n"
-                     "This will NOT prevent flameshot from starting.\n"
-                     "Please solve them manually in the configuration file.");
+        auto* conflicts = new QLabel(
+          tr("Some keyboard shortcuts have conflicts.\n"
+             "This will NOT prevent flameshot from starting.\n"
+             "Please solve them manually in the configuration file."));
         conflicts->setWordWrap(true);
         conflicts->setMaximumWidth(geometry().width());
         conflicts->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Maximum);
@@ -100,8 +101,8 @@ void ConfigResolver::populate()
     auto* buttons = new BBox(this);
     layout()->addWidget(buttons, i, 0, 1, 2, Qt::AlignCenter);
     if (anyErrors) {
-        QPushButton* resolveAll = new QPushButton("Resolve all");
-        resolveAll->setToolTip("Resolve all listed errors.");
+        QPushButton* resolveAll = new QPushButton(tr("Resolve all"));
+        resolveAll->setToolTip(tr("Resolve all listed errors."));
         buttons->addButton(resolveAll, BBox::ResetRole);
         connect(resolveAll, &QPushButton::clicked, this, [=]() {
             for (const auto& key : semanticallyWrong)
@@ -111,7 +112,7 @@ void ConfigResolver::populate()
         });
     }
 
-    QPushButton* details = new QPushButton("Details");
+    QPushButton* details = new QPushButton(tr("Details"));
     buttons->addButton(details, BBox::HelpRole);
     connect(details, &QPushButton::clicked, this, [this]() {
         (new ConfigErrorDetails(this))->exec();

--- a/src/config/configresolver.cpp
+++ b/src/config/configresolver.cpp
@@ -5,6 +5,7 @@
 #include "src/utils/valuehandler.h"
 #include <QDialogButtonBox>
 #include <QLabel>
+#include <QSplitter>
 #include <QVBoxLayout>
 
 ConfigResolver::ConfigResolver(QWidget* parent)
@@ -50,8 +51,7 @@ void ConfigResolver::populate()
           0,
           0,
           1,
-          2,
-          Qt::AlignCenter);
+          2);
         ++row;
     }
 
@@ -60,7 +60,7 @@ void ConfigResolver::populate()
         auto* label = new QLabel(key);
         auto* reset = new QPushButton(tr("Reset"));
         reset->setToolTip(tr("Reset to the default value."));
-        layout()->addWidget(label, row, 0, Qt::AlignRight);
+        layout()->addWidget(label, row, 0);
         layout()->addWidget(reset, row, 1);
         reset->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
 
@@ -75,7 +75,7 @@ void ConfigResolver::populate()
         auto* label = new QLabel(key);
         auto* remove = new QPushButton(tr("Remove"));
         remove->setToolTip(tr("Remove this setting."));
-        layout()->addWidget(label, row, 0, Qt::AlignRight);
+        layout()->addWidget(label, row, 0);
         layout()->addWidget(remove, row, 1);
         connect(remove, &QPushButton::clicked, this, [key]() {
             ConfigHandler().remove(key);
@@ -94,6 +94,12 @@ void ConfigResolver::populate()
         layout()->addWidget(conflicts, row, 0, 1, 2, Qt::AlignCenter);
         ++row;
     }
+
+    QFrame* separator = new QFrame(this);
+    separator->setFrameShape(QFrame::HLine);
+    separator->setFrameShadow(QFrame::Sunken);
+    layout()->addWidget(separator, row, 0, 1, 2);
+    ++row;
 
     using BBox = QDialogButtonBox;
 

--- a/src/config/configresolver.cpp
+++ b/src/config/configresolver.cpp
@@ -38,7 +38,7 @@ void ConfigResolver::populate()
     resetLayout();
 
     bool anyErrors = !semanticallyWrong.isEmpty() || !unrecognized.isEmpty();
-    int i = 0;
+    int row = 0;
 
     // No errors detected
     if (!anyErrors) {
@@ -52,7 +52,7 @@ void ConfigResolver::populate()
           1,
           2,
           Qt::AlignCenter);
-        ++i;
+        ++row;
     }
 
     // List semantically incorrect settings with a "Reset" button
@@ -60,27 +60,27 @@ void ConfigResolver::populate()
         auto* label = new QLabel(key);
         auto* reset = new QPushButton(tr("Reset"));
         reset->setToolTip(tr("Reset to the default value."));
-        layout()->addWidget(label, i, 0, Qt::AlignRight);
-        layout()->addWidget(reset, i, 1);
+        layout()->addWidget(label, row, 0, Qt::AlignRight);
+        layout()->addWidget(reset, row, 1);
         reset->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
 
         connect(reset, &QPushButton::clicked, this, [key]() {
             ConfigHandler().resetValue(key);
         });
 
-        ++i;
+        ++row;
     }
     // List unrecognized settings with a "Remove" button
     for (const auto& key : unrecognized) {
         auto* label = new QLabel(key);
         auto* remove = new QPushButton(tr("Remove"));
         remove->setToolTip(tr("Remove this setting."));
-        layout()->addWidget(label, i, 0, Qt::AlignRight);
-        layout()->addWidget(remove, i, 1);
+        layout()->addWidget(label, row, 0, Qt::AlignRight);
+        layout()->addWidget(remove, row, 1);
         connect(remove, &QPushButton::clicked, this, [key]() {
             ConfigHandler().remove(key);
         });
-        ++i;
+        ++row;
     }
 
     if (!config.checkShortcutConflicts()) {
@@ -91,15 +91,15 @@ void ConfigResolver::populate()
         conflicts->setWordWrap(true);
         conflicts->setMaximumWidth(geometry().width());
         conflicts->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Maximum);
-        layout()->addWidget(conflicts, i, 0, 1, 2, Qt::AlignCenter);
-        ++i;
+        layout()->addWidget(conflicts, row, 0, 1, 2, Qt::AlignCenter);
+        ++row;
     }
 
     using BBox = QDialogButtonBox;
 
     // Add button box at the bottom
     auto* buttons = new BBox(this);
-    layout()->addWidget(buttons, i, 0, 1, 2, Qt::AlignCenter);
+    layout()->addWidget(buttons, row, 0, 1, 2, Qt::AlignCenter);
     if (anyErrors) {
         QPushButton* resolveAll = new QPushButton(tr("Resolve all"));
         resolveAll->setToolTip(tr("Resolve all listed errors."));

--- a/src/config/configresolver.cpp
+++ b/src/config/configresolver.cpp
@@ -59,6 +59,7 @@ void ConfigResolver::populate()
     for (const auto& key : semanticallyWrong) {
         auto* label = new QLabel(key);
         auto* reset = new QPushButton(tr("Reset"));
+        label->setToolTip("This setting has a bad value.");
         reset->setToolTip(tr("Reset to the default value."));
         layout()->addWidget(label, row, 0);
         layout()->addWidget(reset, row, 1);
@@ -74,6 +75,7 @@ void ConfigResolver::populate()
     for (const auto& key : unrecognized) {
         auto* label = new QLabel(key);
         auto* remove = new QPushButton(tr("Remove"));
+        label->setToolTip("This setting is unrecognized.");
         remove->setToolTip(tr("Remove this setting."));
         layout()->addWidget(label, row, 0);
         layout()->addWidget(remove, row, 1);

--- a/src/config/configresolver.cpp
+++ b/src/config/configresolver.cpp
@@ -40,11 +40,8 @@ void ConfigResolver::populate()
     bool anyErrors = !semanticallyWrong.isEmpty() || !unrecognized.isEmpty();
 
     // No errors detected
-    if (!anyErrors) {
-        layout()->addWidget(
-          new QLabel("<b>No errors detected.</b>"), 0, 0, Qt::AlignCenter);
+    if (!anyErrors)
         accept();
-    }
 
     layout()->addWidget(
       new QLabel("<b>You must resolve all errors before continuing:</b>"),

--- a/src/config/configresolver.h
+++ b/src/config/configresolver.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <QDialog>
+
+class QGridLayout;
+
+class ConfigResolver : public QDialog
+{
+public:
+    ConfigResolver(QWidget* parent = nullptr);
+
+    QGridLayout* layout();
+
+private:
+    void populate();
+    void resetLayout();
+};

--- a/src/config/configwindow.cpp
+++ b/src/config/configwindow.cpp
@@ -119,7 +119,7 @@ void ConfigWindow::keyPressEvent(QKeyEvent* e)
 void ConfigWindow::initErrorIndicator(QWidget* tab, QWidget* widget)
 {
     QLabel* label = new QLabel(tab);
-    QPushButton* btnResolve = new QPushButton("Resolve", tab);
+    QPushButton* btnResolve = new QPushButton(tr("Resolve"), tab);
     QHBoxLayout* btnLayout = new QHBoxLayout();
 
     // Set up label

--- a/src/config/configwindow.cpp
+++ b/src/config/configwindow.cpp
@@ -3,6 +3,7 @@
 
 #include "configwindow.h"
 #include "abstractlogger.h"
+#include "src/config/configresolver.h"
 #include "src/config/filenameeditor.h"
 #include "src/config/generalconf.h"
 #include "src/config/shortcutswidget.h"
@@ -118,7 +119,7 @@ void ConfigWindow::keyPressEvent(QKeyEvent* e)
 void ConfigWindow::initErrorIndicator(QWidget* tab, QWidget* widget)
 {
     QLabel* label = new QLabel(tab);
-    QPushButton* btnShowErrors = new QPushButton("Show errors", tab);
+    QPushButton* btnResolve = new QPushButton("Resolve", tab);
     QHBoxLayout* btnLayout = new QHBoxLayout();
 
     // Set up label
@@ -129,9 +130,9 @@ void ConfigWindow::initErrorIndicator(QWidget* tab, QWidget* widget)
     label->setVisible(ConfigHandler().hasError());
 
     // Set up "Show errors" button
-    btnShowErrors->setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Fixed);
-    btnLayout->addWidget(btnShowErrors);
-    btnShowErrors->setVisible(ConfigHandler().hasError());
+    btnResolve->setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Fixed);
+    btnLayout->addWidget(btnResolve);
+    btnResolve->setVisible(ConfigHandler().hasError());
 
     widget->setEnabled(!ConfigHandler().hasError());
 
@@ -142,14 +143,14 @@ void ConfigWindow::initErrorIndicator(QWidget* tab, QWidget* widget)
         layout->insertLayout(1, btnLayout);
     } else {
         widget->layout()->addWidget(label);
-        widget->layout()->addWidget(btnShowErrors);
+        widget->layout()->addWidget(btnResolve);
     }
 
     // Sigslots
     connect(ConfigHandler::getInstance(), &ConfigHandler::error, widget, [=]() {
         widget->setEnabled(false);
         label->show();
-        btnShowErrors->show();
+        btnResolve->show();
     });
     connect(ConfigHandler::getInstance(),
             &ConfigHandler::errorResolved,
@@ -157,41 +158,9 @@ void ConfigWindow::initErrorIndicator(QWidget* tab, QWidget* widget)
             [=]() {
                 widget->setEnabled(true);
                 label->hide();
-                btnShowErrors->hide();
+                btnResolve->hide();
             });
-    connect(btnShowErrors, &QPushButton::clicked, this, [this]() {
-        // Generate error log message
-        QString str;
-        AbstractLogger stream(str, AbstractLogger::Error);
-        ConfigHandler().checkForErrors(&stream);
-
-        // Set up dialog
-        QDialog dialog;
-        dialog.setWindowTitle(QStringLiteral("Configuration errors"));
-        dialog.setLayout(new QVBoxLayout(&dialog));
-
-        // Add text display
-        QTextEdit* textDisplay = new QTextEdit(&dialog);
-        textDisplay->setPlainText(str);
-        textDisplay->setReadOnly(true);
-        dialog.layout()->addWidget(textDisplay);
-
-        // Add Ok button
-        using BBox = QDialogButtonBox;
-        BBox* buttons = new BBox(BBox::Ok);
-        dialog.layout()->addWidget(buttons);
-        connect(buttons, &QDialogButtonBox::clicked, this, [&dialog]() {
-            dialog.close();
-        });
-
-        dialog.show();
-
-        qApp->processEvents();
-        QPoint center = dialog.geometry().center();
-        QRect dialogRect(0, 0, 600, 400);
-        dialogRect.moveCenter(center);
-        dialog.setGeometry(dialogRect);
-
-        dialog.exec();
+    connect(btnResolve, &QPushButton::clicked, this, [this]() {
+        ConfigResolver().exec();
     });
 }

--- a/src/core/controller.cpp
+++ b/src/core/controller.cpp
@@ -139,14 +139,9 @@ void Controller::setOrigin(Origin origin)
     m_origin = origin;
 }
 
-Controller::Origin Controller::origin() const
+Controller::Origin Controller::origin()
 {
     return m_origin;
-}
-
-void Controller::cancel()
-{
-    m_canceled = true;
 }
 
 void Controller::getLatestAvailableVersion()
@@ -169,20 +164,35 @@ void Controller::getLatestAvailableVersion()
     });
 }
 
-void Controller::showConfigResolver()
+/**
+ * @brief Prompt the user to resolve config errors if necessary.
+ * @return Whether errors were resolved.
+ */
+bool Controller::resolveAnyConfigErrors()
 {
-    ConfigResolver* resolver = new ConfigResolver();
-    QObject::connect(resolver, &ConfigResolver::rejected, [resolver]() {
-        resolver->deleteLater();
-        exit(1);
-    });
-    QObject::connect(resolver, &ConfigResolver::accepted, [resolver]() {
-        resolver->close();
-        resolver->deleteLater();
-        // Ensure that the dialog is closed before starting capture
+    bool resolved = true;
+    if (ConfigHandler().hasError()) {
+        ConfigResolver* resolver = new ConfigResolver();
+        QObject::connect(
+          resolver, &ConfigResolver::rejected, [this, resolver, &resolved]() {
+              resolved = false;
+              resolver->deleteLater();
+              if (origin() == CLI) {
+                  exit(1);
+              }
+          });
+        QObject::connect(
+          resolver, &ConfigResolver::accepted, [resolver, &resolved]() {
+              resolved = true;
+              resolver->close();
+              resolver->deleteLater();
+              // Ensure that the dialog is closed before starting capture
+              qApp->processEvents();
+          });
+        resolver->exec();
         qApp->processEvents();
-    });
-    resolver->exec();
+    }
+    return resolved;
 }
 
 void Controller::handleReplyCheckUpdates(QNetworkReply* reply)
@@ -239,9 +249,7 @@ void Controller::appUpdates()
 
 void Controller::requestCapture(const CaptureRequest& request)
 {
-    if (ConfigHandler().hasError())
-        showConfigResolver();
-    if (m_canceled)
+    if (!resolveAnyConfigErrors())
         return;
 
     switch (request.captureMode()) {
@@ -272,6 +280,9 @@ void Controller::requestCapture(const CaptureRequest& request)
 // creation of a new capture in GUI mode
 void Controller::startVisualCapture(const CaptureRequest& req)
 {
+    if (!resolveAnyConfigErrors())
+        return;
+
 #if defined(Q_OS_MACOS)
     // This is required on MacOS because of Mission Control. If you'll switch to
     // another Desktop you cannot take a new screenshot from the tray, you have
@@ -332,6 +343,9 @@ void Controller::startVisualCapture(const CaptureRequest& req)
 
 void Controller::startScreenGrab(CaptureRequest req, const int screenNumber)
 {
+    if (!resolveAnyConfigErrors())
+        return;
+
     bool ok = true;
     QScreen* screen;
 
@@ -371,9 +385,7 @@ void Controller::startScreenGrab(CaptureRequest req, const int screenNumber)
 // creation of the configuration window
 void Controller::openConfigWindow()
 {
-    if (ConfigHandler().hasError())
-        showConfigResolver();
-    if (m_canceled)
+    if (!resolveAnyConfigErrors())
         return;
 
     if (!m_configWindow) {
@@ -400,9 +412,7 @@ void Controller::openInfoWindow()
 
 void Controller::openLauncherWindow()
 {
-    if (ConfigHandler().hasError())
-        showConfigResolver();
-    if (m_canceled)
+    if (!resolveAnyConfigErrors())
         return;
 
     if (!m_launcherWindow) {
@@ -677,6 +687,9 @@ void Controller::exportCapture(QPixmap capture,
 
 void Controller::startFullscreenCapture(const CaptureRequest& req)
 {
+    if (!resolveAnyConfigErrors())
+        return;
+
     bool ok = true;
     QPixmap p(ScreenGrabber().grabEntireDesktop(ok));
     QRect region = req.initialSelection();
@@ -713,3 +726,6 @@ void Controller::doLater(int msec, QObject* receiver, lambda func)
     timer->setInterval(msec);
     timer->start();
 }
+
+// STATIC ATTRIBUTES
+Controller::Origin Controller::m_origin = Controller::DAEMON;

--- a/src/core/controller.cpp
+++ b/src/core/controller.cpp
@@ -171,7 +171,8 @@ void Controller::getLatestAvailableVersion()
 bool Controller::resolveAnyConfigErrors()
 {
     bool resolved = true;
-    if (ConfigHandler().hasError()) {
+    ConfigHandler config;
+    if (!config.checkUnrecognizedSettings() || !config.checkSemantics()) {
         ConfigResolver* resolver = new ConfigResolver();
         QObject::connect(
           resolver, &ConfigResolver::rejected, [this, resolver, &resolved]() {

--- a/src/core/controller.h
+++ b/src/core/controller.h
@@ -30,19 +30,18 @@ class Controller : public QObject
 {
     Q_OBJECT
 
+public:
     enum Origin
     {
         CLI,
         DAEMON
     };
 
-public:
     static Controller* getInstance();
 
     void setCheckForUpdatesEnabled(const bool enabled);
-    void setOrigin(Origin origin);
-    Origin origin() const;
-    void cancel();
+    static void setOrigin(Origin origin);
+    static Origin origin();
 
 signals:
     // TODO remove all parameters from captureTaken and update dependencies
@@ -83,7 +82,7 @@ private:
     Controller();
     ~Controller();
     void getLatestAvailableVersion();
-    void showConfigResolver();
+    bool resolveAnyConfigErrors();
     void sendTrayNotification(
       const QString& text,
       const QString& title = QStringLiteral("Flameshot Info"),
@@ -98,8 +97,7 @@ private:
     QString m_appLatestUrl;
     QString m_appLatestVersion;
     bool m_showCheckAppUpdateStatus;
-    bool m_canceled = false;
-    Origin m_origin = DAEMON;
+    static Origin m_origin;
 
     QPointer<CaptureWidget> m_captureWindow;
     QPointer<InfoWindow> m_infoWindow;

--- a/src/core/controller.h
+++ b/src/core/controller.h
@@ -63,6 +63,10 @@ public slots:
     void showRecentUploads();
 
     void exportCapture(QPixmap p, QRect& selection, const CaptureRequest& req);
+    void sendTrayNotification(
+      const QString& text,
+      const QString& title = QStringLiteral("Flameshot Info"),
+      const int timeout = 5000);
 
 private slots:
     void startFullscreenCapture(const CaptureRequest& req);
@@ -83,10 +87,6 @@ private:
     ~Controller();
     void getLatestAvailableVersion();
     bool resolveAnyConfigErrors();
-    void sendTrayNotification(
-      const QString& text,
-      const QString& title = QStringLiteral("Flameshot Info"),
-      const int timeout = 5000);
 
     // replace QTimer::singleShot introduced in Qt 5.4
     // the actual target Qt version is 5.3

--- a/src/core/controller.h
+++ b/src/core/controller.h
@@ -30,10 +30,19 @@ class Controller : public QObject
 {
     Q_OBJECT
 
+    enum Origin
+    {
+        CLI,
+        DAEMON
+    };
+
 public:
     static Controller* getInstance();
 
     void setCheckForUpdatesEnabled(const bool enabled);
+    void setOrigin(Origin origin);
+    Origin origin() const;
+    void cancel();
 
 signals:
     // TODO remove all parameters from captureTaken and update dependencies
@@ -51,10 +60,6 @@ public slots:
     void initTrayIcon();
     void enableTrayIcon();
     void disableTrayIcon();
-    void sendTrayNotification(
-      const QString& text,
-      const QString& title = QStringLiteral("Flameshot Info"),
-      const int timeout = 5000);
 
     void showRecentUploads();
 
@@ -78,6 +83,11 @@ private:
     Controller();
     ~Controller();
     void getLatestAvailableVersion();
+    void showConfigResolver();
+    void sendTrayNotification(
+      const QString& text,
+      const QString& title = QStringLiteral("Flameshot Info"),
+      const int timeout = 5000);
 
     // replace QTimer::singleShot introduced in Qt 5.4
     // the actual target Qt version is 5.3
@@ -88,6 +98,8 @@ private:
     QString m_appLatestUrl;
     QString m_appLatestVersion;
     bool m_showCheckAppUpdateStatus;
+    bool m_canceled = false;
+    Origin m_origin = DAEMON;
 
     QPointer<CaptureWidget> m_captureWindow;
     QPointer<InfoWindow> m_infoWindow;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,7 +9,6 @@
 
 #include "abstractlogger.h"
 #include "src/cli/commandlineparser.h"
-#include "src/config/configresolver.h"
 #include "src/config/styleoverride.h"
 #include "src/core/capturerequest.h"
 #include "src/core/controller.h"
@@ -78,24 +77,6 @@ QSharedMemory* guiMutexLock()
         return nullptr;
     }
     return shm;
-}
-
-void showConfigResolver()
-{
-    if (ConfigHandler().hasError()) {
-        ConfigResolver* resolver = new ConfigResolver();
-        QObject::connect(resolver, &ConfigResolver::rejected, [resolver]() {
-            resolver->deleteLater();
-            exit(1);
-        });
-        QObject::connect(resolver, &ConfigResolver::accepted, [resolver]() {
-            resolver->close();
-            resolver->deleteLater();
-            // Ensure that the dialog is closed before starting capture
-            qApp->processEvents();
-        });
-        resolver->exec();
-    }
 }
 
 int main(int argc, char* argv[])
@@ -351,8 +332,6 @@ int main(int argc, char* argv[])
     } else if (parser.isSet(launcherArgument)) { // LAUNCHER
         delete qApp;
         new QApplication(argc, argv);
-        if (ConfigHandler().hasError())
-            showConfigResolver();
         Controller* controller = Controller::getInstance();
         controller->openLauncherWindow();
         qApp->exec();
@@ -372,9 +351,6 @@ int main(int argc, char* argv[])
                   delete mutex;
               });
         }
-
-        if (ConfigHandler().hasError())
-            showConfigResolver();
 
         // Option values
         QString path = parser.value(pathOption);
@@ -426,9 +402,6 @@ int main(int argc, char* argv[])
         delete qApp;
         new QApplication(argc, argv);
 
-        if (ConfigHandler().hasError())
-            showConfigResolver();
-
         // Option values
         QString path = parser.value(pathOption);
         if (!path.isEmpty()) {
@@ -466,9 +439,6 @@ int main(int argc, char* argv[])
         // TODO find a way so we don't have to do this
         delete qApp;
         new QApplication(argc, argv);
-
-        if (ConfigHandler().hasError())
-            showConfigResolver();
 
         QString numberStr = parser.value(screenNumberOption);
         // Option values
@@ -537,9 +507,6 @@ int main(int argc, char* argv[])
             }
         }
         ConfigHandler config;
-
-        if (config.hasError())
-            showConfigResolver();
 
         if (autostart) {
             config.setStartupLaunch(parser.value(autostartOption) == "true");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -328,6 +328,7 @@ int main(int argc, char* argv[])
 
     // PROCESS DATA
     //--------------
+    Controller::setOrigin(Controller::CLI);
     if (parser.isSet(helpOption) || parser.isSet(versionOption)) {
     } else if (parser.isSet(launcherArgument)) { // LAUNCHER
         delete qApp;
@@ -498,7 +499,7 @@ int main(int argc, char* argv[])
           (filename || tray || mainColor || contrastColor || check);
         if (check) {
             AbstractLogger err = AbstractLogger::error(AbstractLogger::Stderr);
-            bool ok = ConfigHandler(true).checkForErrors(&err);
+            bool ok = ConfigHandler().checkForErrors(&err);
             if (ok) {
                 err << QStringLiteral("No errors detected.\n");
                 goto finish;
@@ -506,44 +507,45 @@ int main(int argc, char* argv[])
                 return 1;
             }
         }
-        ConfigHandler config;
-
-        if (autostart) {
-            config.setStartupLaunch(parser.value(autostartOption) == "true");
-        }
-        if (filename) {
-            QString newFilename(parser.value(filenameOption));
-            config.setFilenamePattern(newFilename);
-            FileNameHandler fh;
-            QTextStream(stdout)
-              << QStringLiteral("The new pattern is '%1'\n"
-                                "Parsed pattern example: %2\n")
-                   .arg(newFilename)
-                   .arg(fh.parsedPattern());
-        }
-        if (tray) {
-            config.setDisabledTrayIcon(parser.value(trayOption) == "false");
-        }
-        if (mainColor) {
-            // TODO use value handler
-            QString colorCode = parser.value(mainColorOption);
-            QColor parsedColor(colorCode);
-            config.setUiColor(parsedColor);
-        }
-        if (contrastColor) {
-            QString colorCode = parser.value(contrastColorOption);
-            QColor parsedColor(colorCode);
-            config.setContrastUiColor(parsedColor);
-        }
-
-        // Open gui when no options
         if (!someFlagSet) {
+            // Open gui when no options are given
             delete qApp;
             new QApplication(argc, argv);
             QObject::connect(
               qApp, &QApplication::lastWindowClosed, qApp, &QApplication::quit);
             Controller::getInstance()->openConfigWindow();
             qApp->exec();
+        } else {
+            ConfigHandler config;
+
+            if (autostart) {
+                config.setStartupLaunch(parser.value(autostartOption) ==
+                                        "true");
+            }
+            if (filename) {
+                QString newFilename(parser.value(filenameOption));
+                config.setFilenamePattern(newFilename);
+                FileNameHandler fh;
+                QTextStream(stdout)
+                  << QStringLiteral("The new pattern is '%1'\n"
+                                    "Parsed pattern example: %2\n")
+                       .arg(newFilename)
+                       .arg(fh.parsedPattern());
+            }
+            if (tray) {
+                config.setDisabledTrayIcon(parser.value(trayOption) == "false");
+            }
+            if (mainColor) {
+                // TODO use value handler
+                QString colorCode = parser.value(mainColorOption);
+                QColor parsedColor(colorCode);
+                config.setUiColor(parsedColor);
+            }
+            if (contrastColor) {
+                QString colorCode = parser.value(contrastColorOption);
+                QColor parsedColor(colorCode);
+                config.setContrastUiColor(parsedColor);
+            }
         }
     }
 finish:

--- a/src/utils/confighandler.cpp
+++ b/src/utils/confighandler.cpp
@@ -553,7 +553,7 @@ bool ConfigHandler::checkUnrecognizedSettings(AbstractLogger* log,
                 *log << QStringLiteral("Unrecognized shortcut name: '%1'.\n")
                           .arg(key);
             if (offenders)
-                offenders->append(key);
+                offenders->append(CONFIG_GROUP_SHORTCUTS "/" + key);
         }
     }
     return ok;

--- a/src/utils/confighandler.cpp
+++ b/src/utils/confighandler.cpp
@@ -544,14 +544,13 @@ bool ConfigHandler::checkUnrecognizedSettings(AbstractLogger* log,
     if (log != nullptr || offenders != nullptr) {
         for (const QString& key : generalKeys) {
             if (log)
-                *log << QStringLiteral("Unrecognized setting: '%1'\n").arg(key);
+                *log << tr("Unrecognized setting: '%1'\n").arg(key);
             if (offenders)
                 offenders->append(key);
         }
         for (const QString& key : shortcutKeys) {
             if (log)
-                *log << QStringLiteral("Unrecognized shortcut name: '%1'.\n")
-                          .arg(key);
+                *log << tr("Unrecognized shortcut name: '%1'.\n").arg(key);
             if (offenders)
                 offenders->append(CONFIG_GROUP_SHORTCUTS "/" + key);
         }
@@ -592,8 +591,8 @@ bool ConfigHandler::checkShortcutConflicts(AbstractLogger* log) const
                            !reportedInLog.contains(*key2)) { // log entries
                     reportedInLog.append(*key1);
                     reportedInLog.append(*key2);
-                    *log << QStringLiteral("Shortcut conflict: '%1' and '%2' "
-                                           "have the same shortcut: %3\n")
+                    *log << tr("Shortcut conflict: '%1' and '%2' "
+                               "have the same shortcut: %3\n")
                               .arg(*key1)
                               .arg(*key2)
                               .arg(value1);
@@ -631,7 +630,7 @@ bool ConfigHandler::checkSemantics(AbstractLogger* log,
             if (log == nullptr && offenders == nullptr)
                 break;
             if (log != nullptr) {
-                *log << QStringLiteral("Bad value in '%1'. Expected: %2\n")
+                *log << tr("Bad value in '%1'. Expected: %2\n")
                           .arg(key)
                           .arg(valueHandler->expected());
             }

--- a/src/utils/confighandler.cpp
+++ b/src/utils/confighandler.cpp
@@ -173,19 +173,13 @@ static QMap<QString, QSharedPointer<KeySequence>> recognizedShortcuts = {
 
 // CLASS CONFIGHANDLER
 
-ConfigHandler::ConfigHandler(bool skipInitialErrorCheck)
+ConfigHandler::ConfigHandler()
   : m_settings(QSettings::IniFormat,
                QSettings::UserScope,
                qApp->organizationName(),
                qApp->applicationName())
 {
-    static bool wasEverChecked = false;
     static bool firstInitialization = true;
-    if (!skipInitialErrorCheck && !wasEverChecked) {
-        // check for error on initial call
-        checkAndHandleError();
-        wasEverChecked = true;
-    }
     if (firstInitialization) {
         // check for error every time the file changes
         m_configWatcher.reset(new QFileSystemWatcher());
@@ -787,7 +781,7 @@ QString ConfigHandler::baseName(QString key) const
 // STATIC MEMBER DEFINITIONS
 
 bool ConfigHandler::m_hasError = false;
-bool ConfigHandler::m_errorCheckPending = false;
+bool ConfigHandler::m_errorCheckPending = true;
 bool ConfigHandler::m_skipNextErrorCheck = false;
 
 QSharedPointer<QFileSystemWatcher> ConfigHandler::m_configWatcher;

--- a/src/utils/confighandler.cpp
+++ b/src/utils/confighandler.cpp
@@ -449,9 +449,6 @@ void ConfigHandler::setValue(const QString& key, const QVariant& value)
 QVariant ConfigHandler::value(const QString& key) const
 {
     assertKeyRecognized(key);
-    // Perform check on entire config if due. Please make sure that this
-    // function is called in all scenarios - best to keep it on top.
-    hasError();
 
     auto val = m_settings.value(key);
 
@@ -466,6 +463,16 @@ QVariant ConfigHandler::value(const QString& key) const
     }
 
     return handler->value(val);
+}
+
+void ConfigHandler::remove(const QString& key)
+{
+    m_settings.remove(key);
+}
+
+void ConfigHandler::resetValue(const QString& key)
+{
+    m_settings.setValue(key, valueHandler(key)->fallback());
 }
 
 QSet<QString>& ConfigHandler::recognizedGeneralOptions()
@@ -492,8 +499,10 @@ QSet<QString>& ConfigHandler::recognizedShortcutNames()
     return names;
 }
 
-// Return keys from group `group`. Use CONFIG_GROUP_GENERAL (General) for
-// general settings.
+/**
+ * @brief Return keys from group `group`.
+ * Use CONFIG_GROUP_GENERAL (General) for general settings.
+ */
 QSet<QString> ConfigHandler::keysFromGroup(const QString& group) const
 {
     QSet<QString> keys;
@@ -515,20 +524,6 @@ bool ConfigHandler::checkForErrors(AbstractLogger* log) const
            checkSemantics(log);
 }
 
-void ConfigHandler::cleanUnusedKeys(const QString& group,
-                                    const QSet<QString>& keys) const
-{
-    for (const QString& key : keys) {
-        if (group == CONFIG_GROUP_GENERAL && !key.contains('/')) {
-            m_settings.remove(key);
-        } else {
-            m_settings.beginGroup(group);
-            m_settings.remove(key);
-            m_settings.endGroup();
-        }
-    }
-}
-
 /**
  * @brief Parse the config to find settings with unrecognized names.
  * @return Whether the config passes this check.
@@ -537,7 +532,8 @@ void ConfigHandler::cleanUnusedKeys(const QString& group,
  * `recognizedGeneralOptions` or `recognizedShortcutNames` depending on the
  * group the option belongs to.
  */
-bool ConfigHandler::checkUnrecognizedSettings(AbstractLogger* log) const
+bool ConfigHandler::checkUnrecognizedSettings(AbstractLogger* log,
+                                              QList<QString>* offenders) const
 {
     // sort the config keys by group
     QSet<QString> generalKeys = keysFromGroup(CONFIG_GROUP_GENERAL),
@@ -549,38 +545,21 @@ bool ConfigHandler::checkUnrecognizedSettings(AbstractLogger* log) const
     generalKeys.subtract(recognizedGeneralKeys);
     shortcutKeys.subtract(recognizedShortcutKeys);
 
-    // automatically clean up unused keys
-    if (!generalKeys.isEmpty()) {
-        cleanUnusedKeys(CONFIG_GROUP_GENERAL, generalKeys);
-        generalKeys = keysFromGroup(CONFIG_GROUP_GENERAL),
-        generalKeys.subtract(recognizedGeneralKeys);
-    }
-    if (!shortcutKeys.isEmpty()) {
-        cleanUnusedKeys(CONFIG_GROUP_SHORTCUTS, shortcutKeys);
-        shortcutKeys = keysFromGroup(CONFIG_GROUP_SHORTCUTS);
-        shortcutKeys.subtract(recognizedShortcutKeys);
-    }
-
-    // clean up unused groups
-    QStringList settingsGroups = m_settings.childGroups();
-    for (const auto& group : settingsGroups) {
-        if (group != QLatin1String(CONFIG_GROUP_SHORTCUTS) &&
-            group != QLatin1String(CONFIG_GROUP_GENERAL)) {
-            m_settings.beginGroup(group);
-            m_settings.remove("");
-            m_settings.endGroup();
-        }
-    }
-
     // what is left are the unrecognized keys - hopefully empty
     bool ok = generalKeys.isEmpty() && shortcutKeys.isEmpty();
-    if (log != nullptr) {
+    if (log != nullptr || offenders != nullptr) {
         for (const QString& key : generalKeys) {
-            *log << QStringLiteral("Unrecognized setting: '%1'\n").arg(key);
+            if (log)
+                *log << QStringLiteral("Unrecognized setting: '%1'\n").arg(key);
+            if (offenders)
+                offenders->append(key);
         }
         for (const QString& key : shortcutKeys) {
-            *log
-              << QStringLiteral("Unrecognized shortcut name: '%1'.\n").arg(key);
+            if (log)
+                *log << QStringLiteral("Unrecognized shortcut name: '%1'.\n")
+                          .arg(key);
+            if (offenders)
+                offenders->append(key);
         }
     }
     return ok;
@@ -634,9 +613,12 @@ bool ConfigHandler::checkShortcutConflicts(AbstractLogger* log) const
 
 /**
  * @brief Check each config value semantically.
+ * @param log Destination for error log output.
+ * @param offenders Destination for the semantically invalid keys.
  * @return Whether the config passes this check.
  */
-bool ConfigHandler::checkSemantics(AbstractLogger* log) const
+bool ConfigHandler::checkSemantics(AbstractLogger* log,
+                                   QList<QString>* offenders) const
 {
     QStringList allKeys = m_settings.allKeys();
     bool ok = true;
@@ -650,14 +632,17 @@ bool ConfigHandler::checkSemantics(AbstractLogger* log) const
         QVariant val = m_settings.value(key);
         auto valueHandler = this->valueHandler(key);
         if (val.isValid() && !valueHandler->check(val)) {
+            // Key does not pass the check
             ok = false;
-            if (log == nullptr) {
+            if (log == nullptr && offenders == nullptr)
                 break;
-            } else {
-                *log << QStringLiteral("Semantic error in '%1'. Expected: %2\n")
+            if (log != nullptr) {
+                *log << QStringLiteral("Bad value in '%1'. Expected: %2\n")
                           .arg(key)
                           .arg(valueHandler->expected());
             }
+            if (offenders != nullptr)
+                offenders->append(key);
         }
     }
     return ok;
@@ -724,7 +709,8 @@ bool ConfigHandler::hasError() const
 /// Error message that can be used by other classes as well
 QString ConfigHandler::errorMessage() const
 {
-    return tr("The configuration contains an error. Falling back to default.");
+    return tr(
+      "The configuration contains an error. Open configuration to resolve.");
 }
 
 void ConfigHandler::ensureFileWatched() const

--- a/src/utils/confighandler.h
+++ b/src/utils/confighandler.h
@@ -58,7 +58,7 @@ class ConfigHandler : public QObject
     Q_OBJECT
 
 public:
-    explicit ConfigHandler(bool skipInitialErrorCheck = false);
+    explicit ConfigHandler();
 
     static ConfigHandler* getInstance();
 

--- a/src/utils/confighandler.h
+++ b/src/utils/confighandler.h
@@ -133,6 +133,8 @@ public:
     QString shortcut(const QString& actionName);
     void setValue(const QString& key, const QVariant& value);
     QVariant value(const QString& key) const;
+    void remove(const QString& key);
+    void resetValue(const QString& key);
 
     // INFO
     static QSet<QString>& recognizedGeneralOptions();
@@ -141,9 +143,11 @@ public:
 
     // ERROR HANDLING
     bool checkForErrors(AbstractLogger* log = nullptr) const;
-    bool checkUnrecognizedSettings(AbstractLogger* log = nullptr) const;
+    bool checkUnrecognizedSettings(AbstractLogger* log = nullptr,
+                                   QList<QString>* offenders = nullptr) const;
     bool checkShortcutConflicts(AbstractLogger* log = nullptr) const;
-    bool checkSemantics(AbstractLogger* log = nullptr) const;
+    bool checkSemantics(AbstractLogger* log = nullptr,
+                        QList<QString>* offenders = nullptr) const;
     void checkAndHandleError() const;
     void setErrorState(bool error) const;
     bool hasError() const;


### PR DESCRIPTION
Closes #2232.
Test against #2192.

Added a ConfigResolver dialog that appears when a flameshot action is activated
and the configuration contains semantic errors or unrecognized options. The user
has to click some buttons in the widget to resolve the errors, after which the
dialog automatically closes and flameshot proceeds to the requested action. If
the dialog is canceled flameshot aborts the action.

Note that if there is a shortcut conflict, that won't trigger the dialog. But
the dialog that is triggered by the other types of error, informs the user that
there are shortcut conflicts and that they have to be manually resolved via
config file. I think this is acceptable because there is currently no way to
create conflicts using the GUI. If there was in previous versions, I don't think
it's as common as the other error types (as the issues tell us), and I'm not
willing to invest the extra effort which is substantial.

Some notes:
- The config resolver is automatically updated when the config file changes
- The config window will still show a configuration error notice, but the button
    that appeared alongside it now opens the ConfigResolver instead of the old
    details dialog.
- Same behavior when launched via GUI as via CLI.
- Not all flameshot actions will trigger the dialog. For example triggering the
  "About" window or upload history won't, because those actions do not have any
  configurable features.
