### PR TITLE
Flameshot crashes with GB locale

### DIFF
--- a/src/utils/filenamehandler.cpp
+++ b/src/utils/filenamehandler.cpp
@@ -15,7 +15,7 @@ FileNameHandler::FileNameHandler(QObject* parent)
 {
     auto err = AbstractLogger::error(AbstractLogger::Stderr);
     try {
-        std::locale::global(std::locale(""));
+        std::locale::global(std::locale());
     } catch (std::exception& e) {
         err << "Locales on your system are not properly configured. Falling "
                "back to defaults";


### PR DESCRIPTION
Couldn't start flameshot on ArchLinux with GB locale.
This PR fixes the issue.