### PR TITLE
QFileDialog misbehaves when choosing images format

### DIFF
--- a/src/utils/screenshotsaver.cpp
+++ b/src/utils/screenshotsaver.cpp
@@ -120,6 +120,7 @@ QString ScreenshotSaver::ShowSaveFileDialog(QWidget* parent,
         dialog.setWindowModality(Qt::WindowModal);
     }
 
+    dialog.setOptions(QFileDialog::Option::DontUseNativeDialog);
     dialog.setAcceptMode(QFileDialog::AcceptSave);
 
     // Build string list of supported image formats

--- a/src/utils/screenshotsaver.cpp
+++ b/src/utils/screenshotsaver.cpp
@@ -119,8 +119,9 @@ QString ScreenshotSaver::ShowSaveFileDialog(QWidget* parent,
     if (parent) {
         dialog.setWindowModality(Qt::WindowModal);
     }
-
+#if defined(Q_OS_MACOS)
     dialog.setOptions(QFileDialog::Option::DontUseNativeDialog);
+#endif
     dialog.setAcceptMode(QFileDialog::AcceptSave);
 
     // Build string list of supported image formats
@@ -138,7 +139,8 @@ QString ScreenshotSaver::ShowSaveFileDialog(QWidget* parent,
     dialog.selectMimeTypeFilter(defaultMimeType);
     dialog.setDefaultSuffix(suffix);
     if (dialog.exec() == QDialog::Accepted) {
-        return dialog.selectedFiles().first();
+        const QStringList selectedFiles = dialog.selectedFiles();
+        return selectedFiles.first();
     } else {
         return QString();
     }


### PR DESCRIPTION
It looks like the behaviour described in #2270 is a Qt BUG. I can see it in `Qt v5.15.2`. 
Using non-natives dialog seems the only way of fixing this at the moment.

Also fixed the following warning:
```
.../src/utils/screenshotsaver.cpp:142:16: Don't call QList::first() on temporary [clazy-detaching-temporary]
```