### PR TITLE
Zooming in/out happens at different speed

### DIFF
--- a/src/tools/pin/pinwidget.cpp
+++ b/src/tools/pin/pinwidget.cpp
@@ -131,12 +131,17 @@ void PinWidget::mouseMoveEvent(QMouseEvent* e)
          m_dragStart.y() + delta.y() - offsetH);
 }
 
-void PinWidget::setScaledPixmapToLabel(const QSize& newSize, const qreal scale, const bool expanding)
+void PinWidget::setScaledPixmapToLabel(const QSize& newSize,
+                                       const qreal scale,
+                                       const bool expanding)
 {
     ConfigHandler config;
     QPixmap scaledPixmap;
-    const auto aspectRatio = expanding ? Qt::KeepAspectRatioByExpanding : Qt::KeepAspectRatio;
-    const auto transformType = config.antialiasingPinZoom() ? Qt::SmoothTransformation : Qt::FastTransformation;
+    const auto aspectRatio =
+      expanding ? Qt::KeepAspectRatioByExpanding : Qt::KeepAspectRatio;
+    const auto transformType = config.antialiasingPinZoom()
+                                 ? Qt::SmoothTransformation
+                                 : Qt::FastTransformation;
     scaledPixmap = m_pixmap.scaled(newSize * scale, aspectRatio, transformType);
     scaledPixmap.setDevicePixelRatio(scale);
     m_label->setPixmap(scaledPixmap);

--- a/src/tools/pin/pinwidget.cpp
+++ b/src/tools/pin/pinwidget.cpp
@@ -78,13 +78,13 @@ int PinWidget::margin() const
 
 void PinWidget::wheelEvent(QWheelEvent* event)
 {
-    // Getting the mouse wheel rotation in degree
+    // getting the mouse wheel rotation in degree
     const QPoint degrees = event->angleDelta() / 8;
 
-    // is enlarging or shrinking ?
+    // is the user zooming in or out ?
     const int direction = degrees.y() > 0 ? 1 : -1;
 
-    // step taken in pixels
+    // step taken in pixels (including direction)
     const int step = degrees.manhattanLength() * direction;
     const int newWidth = qBound(50, m_label->width() + step, maximumWidth());
     const int newHeight = qBound(50, m_label->height() + step, maximumHeight());

--- a/src/tools/pin/pinwidget.cpp
+++ b/src/tools/pin/pinwidget.cpp
@@ -76,17 +76,27 @@ int PinWidget::margin() const
     return 7;
 }
 
-void PinWidget::wheelEvent(QWheelEvent* e)
+void PinWidget::wheelEvent(QWheelEvent* event)
 {
-    int val = e->angleDelta().y() > 0 ? 15 : -15;
-    int newWidth = qBound(50, m_label->width() + val, maximumWidth());
-    int newHeight = qBound(50, m_label->height() + val, maximumHeight());
+    const QPoint numPixels = event->pixelDelta();
+    const QPoint numDegrees = event->angleDelta() / 8;
 
-    QSize size(newWidth, newHeight);
+    QPoint num;
+    if (!numPixels.isNull()) {
+        num = numPixels;
+    } else if (!numDegrees.isNull()) {
+        num = numDegrees / 15;
+    }
+
+    const int mult = num.y() > 0 ? 1 : -1;
+    const int val = num.manhattanLength() * mult;
+    const int newWidth = qBound(50, (m_label->width() + val), maximumWidth());
+    const int newHeight = qBound(50, (m_label->height() + val), maximumHeight());
+
+    const QSize size(newWidth, newHeight);
     setScaledPixmap(size);
     adjustSize();
-
-    e->accept();
+    event->accept();
 }
 
 void PinWidget::enterEvent(QEvent*)

--- a/src/tools/pin/pinwidget.h
+++ b/src/tools/pin/pinwidget.h
@@ -28,7 +28,7 @@ protected:
     void leaveEvent(QEvent*);
 
 private:
-    void setScaledPixmap(const QSize& size);
+    void setScaledPixmapToLabel(const QSize& newSize, const qreal scale, const bool expanding);
 
     QPixmap m_pixmap;
     QVBoxLayout* m_layout;

--- a/src/tools/pin/pinwidget.h
+++ b/src/tools/pin/pinwidget.h
@@ -28,7 +28,9 @@ protected:
     void leaveEvent(QEvent*);
 
 private:
-    void setScaledPixmapToLabel(const QSize& newSize, const qreal scale, const bool expanding);
+    void setScaledPixmapToLabel(const QSize& newSize,
+                                const qreal scale,
+                                const bool expanding);
 
     QPixmap m_pixmap;
     QVBoxLayout* m_layout;


### PR DESCRIPTION
What I have done: 
- Removed magic number `ex. +15/-15` 
- Calculating the necessary steps (in pixels) from the `QWheelEvent`.
- Using same aspect ratio during zooming in/out
- Refactoring

I have tested it on `Ubuntu 18.04` and `Mac OS Monterey`, but if someone could kindly test this on other devices that would be great.
