### PR TITLE
fix bug on macos with save dialog

### DIFF
--- a/src/core/controller.cpp
+++ b/src/core/controller.cpp
@@ -639,9 +639,9 @@ void Controller::exportCapture(QPixmap capture,
 
     if (tasks & CR::SAVE) {
         if (req.path().isEmpty()) {
-            ScreenshotSaver().saveToFilesystemGUI(capture);
+            saveToFilesystemGUI(capture);
         } else {
-            ScreenshotSaver().saveToFilesystem(capture, path);
+            saveToFilesystem(capture, path);
         }
     }
 

--- a/src/core/flameshotdaemon.cpp
+++ b/src/core/flameshotdaemon.cpp
@@ -203,7 +203,7 @@ void FlameshotDaemon::attachScreenshotToClipboard(QPixmap pixmap)
     // This variable is necessary because the signal doesn't get blocked on
     // windows for some reason
     m_clipboardSignalBlocked = true;
-    ScreenshotSaver().saveToClipboard(pixmap);
+    saveToClipboard(pixmap);
     clipboard->blockSignals(false);
 }
 

--- a/src/tools/imgupload/storages/imguploaderbase.cpp
+++ b/src/tools/imgupload/storages/imguploaderbase.cpp
@@ -186,7 +186,7 @@ void ImgUploaderBase::deleteCurrentImage()
 
 void ImgUploaderBase::saveScreenshotToFilesystem()
 {
-    if (!ScreenshotSaver().saveToFilesystemGUI(m_pixmap)) {
+    if (!saveToFilesystemGUI(m_pixmap)) {
         m_notification->showMessage(
           tr("Unable to save the screenshot to disk."));
         return;

--- a/src/utils/screenshotsaver.cpp
+++ b/src/utils/screenshotsaver.cpp
@@ -178,7 +178,6 @@ bool saveToFilesystemGUI(const QPixmap& capture)
     }
 #endif
     if (!config.savePathFixed()) {
-        // auto imageFormats = QImageWriter::supportedImageFormats();
         savePath = ShowSaveFileDialog(QObject::tr("Save screenshot"), savePath);
     }
     if (savePath == "") {

--- a/src/utils/screenshotsaver.h
+++ b/src/utils/screenshotsaver.h
@@ -11,7 +11,7 @@ class QWidget;
 class ScreenshotSaver
 {
 public:
-    ScreenshotSaver();
+    ScreenshotSaver() = default;
 
     void saveToClipboard(const QPixmap& capture);
     void saveToClipboardMime(const QPixmap& capture, const QString& imageType);

--- a/src/utils/screenshotsaver.h
+++ b/src/utils/screenshotsaver.h
@@ -6,22 +6,11 @@
 #include <QString>
 
 class QPixmap;
-class QWidget;
 
-class ScreenshotSaver
-{
-public:
-    ScreenshotSaver() = default;
-
-    void saveToClipboard(const QPixmap& capture);
-    void saveToClipboardMime(const QPixmap& capture, const QString& imageType);
-    bool saveToFilesystem(const QPixmap& capture,
-                          const QString& path,
-                          const QString& messagePrefix = "");
-    bool saveToFilesystemGUI(const QPixmap& capture);
-
-private:
-    QString ShowSaveFileDialog(QWidget* parent,
-                               const QString& title,
-                               const QString& directory);
-};
+bool saveToFilesystem(const QPixmap& capture,
+                      const QString& path,
+                      const QString& messagePrefix = "");
+QString ShowSaveFileDialog(const QString& title, const QString& directory);
+void saveToClipboardMime(const QPixmap& capture, const QString& imageType);
+void saveToClipboard(const QPixmap& capture);
+bool saveToFilesystemGUI(const QPixmap& capture);

--- a/src/widgets/capturelauncher.cpp
+++ b/src/widgets/capturelauncher.cpp
@@ -119,7 +119,7 @@ void CaptureLauncher::captureTaken(QPixmap screenshot)
       ui->captureType->currentData().toInt());
 
     if (mode == CaptureRequest::FULLSCREEN_MODE) {
-        ScreenshotSaver().saveToFilesystemGUI(screenshot);
+        saveToFilesystemGUI(screenshot);
     }
     ui->launchButton->setEnabled(true);
 }


### PR DESCRIPTION
There is a bug on on MacOs. When the mime types are populated Qt reports HEIC and HEIF as seperate types. Really they are the same thing except HEIF also supports video. 

The MacOs native dialog always shows heif/heic, so it was causing an off by one error. This fix removes HEIF from the list. 