### PR TITLE
fix the --print-geometry for zsh

### DIFF
--- a/data/shell-completion/flameshot.zsh
+++ b/data/shell-completion/flameshot.zsh
@@ -22,7 +22,7 @@ _flameshot_gui_opts=(
     {-d,--delay}'[Delay time in milliseconds]'
     "--region[Screenshot region to select <WxH+X+Y or string>]"
     {-r,--raw}'[Print raw PNG capture]'
-    {-g,--geometry}'[Print geometry of the selection in the format W H X Y. Does nothing if raw is specified]'
+    {-g,--print-geometry}'[Print geometry of the selection in the format W H X Y. Does nothing if raw is specified]'
     {-u,--upload}'[Upload screenshot]'
     "--pin[Pin the capture to the screen]"
     {-s,--accept-on-select}'[Accept capture as soon as a selection is made]'


### PR DESCRIPTION
by mistake I had `--geometry` in the zsh completion which is now changed to `--print-geometry`