### PR TITLE
Pinch gesture on pinned screenshot

### DIFF
--- a/src/tools/pin/pinwidget.cpp
+++ b/src/tools/pin/pinwidget.cpp
@@ -49,7 +49,6 @@ PinWidget::PinWidget(const QPixmap& pixmap,
     m_label = new QLabel();
     m_label->setPixmap(m_pixmap);
     m_layout->addWidget(m_label);
-    this->setStyleSheet("border: 5px solid red");
 
     new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_Q), this, SLOT(close()));
     new QShortcut(Qt::Key_Escape, this, SLOT(close()));

--- a/src/tools/pin/pinwidget.cpp
+++ b/src/tools/pin/pinwidget.cpp
@@ -83,7 +83,12 @@ PinWidget::PinWidget(const QPixmap& pixmap,
 bool PinWidget::scrollEvent(QWheelEvent* event)
 {
     const auto phase = event->phase();
-    if (phase == Qt::ScrollPhase::ScrollUpdate) {
+    if (phase == Qt::ScrollPhase::ScrollUpdate
+#if defined(Q_OS_LINUX)
+        // Linux is getting only NoScrollPhase events.
+        or phase == Qt::ScrollPhase::NoScrollPhase
+#endif
+            ) {
         const auto angle = event->angleDelta();
         if (angle.y() == 0) {
             return true;
@@ -93,7 +98,12 @@ bool PinWidget::scrollEvent(QWheelEvent* event)
                                      : m_currentStepScaleFactor - STEP;
         m_expanding = m_currentStepScaleFactor >= 1.0;
     }
+#if defined(Q_OS_MACOS)
+    // ScrollEnd is currently supported only on Mac OSX
     if (phase == Qt::ScrollPhase::ScrollEnd) {
+#else
+    else{
+#endif
         m_scaleFactor *= m_currentStepScaleFactor;
         m_currentStepScaleFactor = 1.0;
         m_expanding = false;

--- a/src/tools/pin/pinwidget.cpp
+++ b/src/tools/pin/pinwidget.cpp
@@ -88,7 +88,7 @@ bool PinWidget::scrollEvent(QWheelEvent* event)
         // Linux is getting only NoScrollPhase events.
         or phase == Qt::ScrollPhase::NoScrollPhase
 #endif
-            ) {
+    ) {
         const auto angle = event->angleDelta();
         if (angle.y() == 0) {
             return true;
@@ -102,7 +102,7 @@ bool PinWidget::scrollEvent(QWheelEvent* event)
     // ScrollEnd is currently supported only on Mac OSX
     if (phase == Qt::ScrollPhase::ScrollEnd) {
 #else
-    else{
+    else {
 #endif
         m_scaleFactor *= m_currentStepScaleFactor;
         m_currentStepScaleFactor = 1.0;

--- a/src/tools/pin/pinwidget.cpp
+++ b/src/tools/pin/pinwidget.cpp
@@ -172,13 +172,13 @@ void PinWidget::paintEvent(QPaintEvent* event)
                                  : Qt::FastTransformation;
     const qreal iw = m_pixmap.width();
     const qreal ih = m_pixmap.height();
-    const qreal nw = qBound(MIN_SIZE, iw * m_currentStepScaleFactor * m_scaleFactor, static_cast<qreal>(maximumWidth()));
-    const qreal nh = qBound(MIN_SIZE, ih * m_currentStepScaleFactor * m_scaleFactor, static_cast<qreal>(maximumHeight()));
-    const QPixmap pix =
-      m_pixmap.scaled(nw,
-                      nh,
-                      aspectRatio,
-                      transformType);
+    const qreal nw = qBound(MIN_SIZE,
+                            iw * m_currentStepScaleFactor * m_scaleFactor,
+                            static_cast<qreal>(maximumWidth()));
+    const qreal nh = qBound(MIN_SIZE,
+                            ih * m_currentStepScaleFactor * m_scaleFactor,
+                            static_cast<qreal>(maximumHeight()));
+    const QPixmap pix = m_pixmap.scaled(nw, nh, aspectRatio, transformType);
     m_label->setPixmap(pix);
     adjustSize();
 }

--- a/src/tools/pin/pinwidget.cpp
+++ b/src/tools/pin/pinwidget.cpp
@@ -15,11 +15,10 @@
 #include <QVBoxLayout>
 #include <QWheelEvent>
 
-namespace
-{
-    static constexpr int MARGIN = 7;
-    static constexpr int BLUR_RADIUS =  2 * MARGIN;
-    static constexpr qreal STEP = 0.03;
+namespace {
+static constexpr int MARGIN = 7;
+static constexpr int BLUR_RADIUS = 2 * MARGIN;
+static constexpr qreal STEP = 0.03;
 }
 
 PinWidget::PinWidget(const QPixmap& pixmap,
@@ -86,11 +85,12 @@ bool PinWidget::scrollEvent(QWheelEvent* event)
     const auto phase = event->phase();
     if (phase == Qt::ScrollPhase::ScrollUpdate) {
         const auto angle = event->angleDelta();
-        if(angle.y() == 0)
-        {
+        if (angle.y() == 0) {
             return true;
         }
-        m_currentStepScaleFactor = angle.y() > 0 ? m_currentStepScaleFactor + STEP : m_currentStepScaleFactor - STEP;
+        m_currentStepScaleFactor = angle.y() > 0
+                                     ? m_currentStepScaleFactor + STEP
+                                     : m_currentStepScaleFactor - STEP;
         m_expanding = m_currentStepScaleFactor >= 1.0;
     }
     if (phase == Qt::ScrollPhase::ScrollEnd) {
@@ -134,29 +134,25 @@ void PinWidget::mouseMoveEvent(QMouseEvent* e)
          m_dragStart.y() + delta.y() - offsetH);
 }
 
-bool PinWidget::gestureEvent(QGestureEvent *event)
+bool PinWidget::gestureEvent(QGestureEvent* event)
 {
-    if (QGesture *pinch = event->gesture(Qt::PinchGesture))
-    {
-        pinchTriggered(static_cast<QPinchGesture *>(pinch));
+    if (QGesture* pinch = event->gesture(Qt::PinchGesture)) {
+        pinchTriggered(static_cast<QPinchGesture*>(pinch));
     }
     return true;
 }
 
-bool PinWidget::event(QEvent *event)
+bool PinWidget::event(QEvent* event)
 {
-    if (event->type() == QEvent::Gesture)
-    {
+    if (event->type() == QEvent::Gesture) {
         return gestureEvent(static_cast<QGestureEvent*>(event));
-    }
-    else if(event->type() == QEvent::Wheel)
-    {
+    } else if (event->type() == QEvent::Wheel) {
         return scrollEvent(static_cast<QWheelEvent*>(event));
     }
     return QWidget::event(event);
 }
 
-void PinWidget::paintEvent(QPaintEvent * event)
+void PinWidget::paintEvent(QPaintEvent* event)
 {
     const auto aspectRatio =
       m_expanding ? Qt::KeepAspectRatioByExpanding : Qt::KeepAspectRatio;
@@ -165,15 +161,16 @@ void PinWidget::paintEvent(QPaintEvent * event)
                                  : Qt::FastTransformation;
     const qreal iw = m_pixmap.width();
     const qreal ih = m_pixmap.height();
-    const QPixmap pix = m_pixmap.scaled(iw * m_currentStepScaleFactor * m_scaleFactor,
-                    ih * m_currentStepScaleFactor * m_scaleFactor,
-                    aspectRatio,
-                    transformType);
+    const QPixmap pix =
+      m_pixmap.scaled(iw * m_currentStepScaleFactor * m_scaleFactor,
+                      ih * m_currentStepScaleFactor * m_scaleFactor,
+                      aspectRatio,
+                      transformType);
     m_label->setPixmap(pix);
     adjustSize();
 }
 
-void PinWidget::pinchTriggered(QPinchGesture *gesture)
+void PinWidget::pinchTriggered(QPinchGesture* gesture)
 {
     const QPinchGesture::ChangeFlags changeFlags = gesture->changeFlags();
     if (changeFlags & QPinchGesture::ScaleFactorChanged) {

--- a/src/tools/pin/pinwidget.cpp
+++ b/src/tools/pin/pinwidget.cpp
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // SPDX-FileCopyrightText: 2017-2019 Alejandro Sirgo Rica & Contributors
+#include <QGraphicsDropShadowEffect>
 
 #include "pinwidget.h"
 #include "qguiappcurrentscreen.h"
@@ -11,6 +12,12 @@
 #include <QShortcut>
 #include <QVBoxLayout>
 #include <QWheelEvent>
+
+namespace
+{
+    static constexpr int MARGIN = 7;
+    static constexpr int BLUR_RADIUS =  2 * MARGIN;
+}
 
 PinWidget::PinWidget(const QPixmap& pixmap,
                      const QRect& geometry,
@@ -29,12 +36,11 @@ PinWidget::PinWidget(const QPixmap& pixmap,
     m_hoverColor = conf.contrastUiColor();
 
     m_layout = new QVBoxLayout(this);
-    const int margin = this->margin();
-    m_layout->setContentsMargins(margin, margin, margin, margin);
+    m_layout->setContentsMargins(MARGIN, MARGIN, MARGIN, MARGIN);
 
     m_shadowEffect = new QGraphicsDropShadowEffect(this);
     m_shadowEffect->setColor(m_baseColor);
-    m_shadowEffect->setBlurRadius(2 * margin);
+    m_shadowEffect->setBlurRadius(BLUR_RADIUS);
     m_shadowEffect->setOffset(0, 0);
     setGraphicsEffect(m_shadowEffect);
 
@@ -52,7 +58,7 @@ PinWidget::PinWidget(const QPixmap& pixmap,
         devicePixelRatio = currentScreen->devicePixelRatio();
     }
 #endif
-    const int m = margin * devicePixelRatio;
+    const int m = MARGIN * devicePixelRatio;
     QRect adjusted_pos = geometry + QMargins(m, m, m, m);
     setGeometry(adjusted_pos);
 #if defined(Q_OS_MACOS)
@@ -69,11 +75,6 @@ PinWidget::PinWidget(const QPixmap& pixmap,
         move(adjusted_pos.x(), adjusted_pos.y());
     }
 #endif
-}
-
-int PinWidget::margin() const
-{
-    return 7;
 }
 
 void PinWidget::wheelEvent(QWheelEvent* event)
@@ -135,14 +136,12 @@ void PinWidget::setScaledPixmapToLabel(const QSize& newSize,
                                        const qreal scale,
                                        const bool expanding)
 {
-    ConfigHandler config;
-    QPixmap scaledPixmap;
     const auto aspectRatio =
       expanding ? Qt::KeepAspectRatioByExpanding : Qt::KeepAspectRatio;
-    const auto transformType = config.antialiasingPinZoom()
+    const auto transformType = ConfigHandler().antialiasingPinZoom()
                                  ? Qt::SmoothTransformation
                                  : Qt::FastTransformation;
-    scaledPixmap = m_pixmap.scaled(newSize * scale, aspectRatio, transformType);
+    QPixmap scaledPixmap = m_pixmap.scaled(newSize * scale, aspectRatio, transformType);
     scaledPixmap.setDevicePixelRatio(scale);
     m_label->setPixmap(scaledPixmap);
 }

--- a/src/tools/pin/pinwidget.cpp
+++ b/src/tools/pin/pinwidget.cpp
@@ -19,6 +19,7 @@ namespace {
 static constexpr int MARGIN = 7;
 static constexpr int BLUR_RADIUS = 2 * MARGIN;
 static constexpr qreal STEP = 0.03;
+static constexpr qreal MIN_SIZE = 100.0;
 }
 
 PinWidget::PinWidget(const QPixmap& pixmap,
@@ -171,9 +172,11 @@ void PinWidget::paintEvent(QPaintEvent* event)
                                  : Qt::FastTransformation;
     const qreal iw = m_pixmap.width();
     const qreal ih = m_pixmap.height();
+    const qreal nw = qBound(MIN_SIZE, iw * m_currentStepScaleFactor * m_scaleFactor, static_cast<qreal>(maximumWidth()));
+    const qreal nh = qBound(MIN_SIZE, ih * m_currentStepScaleFactor * m_scaleFactor, static_cast<qreal>(maximumHeight()));
     const QPixmap pix =
-      m_pixmap.scaled(iw * m_currentStepScaleFactor * m_scaleFactor,
-                      ih * m_currentStepScaleFactor * m_scaleFactor,
+      m_pixmap.scaled(nw,
+                      nh,
                       aspectRatio,
                       transformType);
     m_label->setPixmap(pix);

--- a/src/tools/pin/pinwidget.h
+++ b/src/tools/pin/pinwidget.h
@@ -43,6 +43,6 @@ private:
     QColor m_baseColor, m_hoverColor;
 
     bool m_expanding{false};
-    qreal scaleFactor{1};
-    qreal currentStepScaleFactor{1};
+    qreal m_scaleFactor{1};
+    qreal m_currentStepScaleFactor{1};
 };

--- a/src/tools/pin/pinwidget.h
+++ b/src/tools/pin/pinwidget.h
@@ -26,11 +26,11 @@ protected:
     void enterEvent(QEvent*) override;
     void leaveEvent(QEvent*) override;
 
-    bool event(QEvent *event) override;
-    void paintEvent(QPaintEvent *event) override;
+    bool event(QEvent* event) override;
+    void paintEvent(QPaintEvent* event) override;
 
 private:
-    bool gestureEvent(QGestureEvent *event);
+    bool gestureEvent(QGestureEvent* event);
     bool scrollEvent(QWheelEvent* e);
     void pinchTriggered(QPinchGesture*);
 
@@ -42,7 +42,7 @@ private:
     QGraphicsDropShadowEffect* m_shadowEffect;
     QColor m_baseColor, m_hoverColor;
 
-    bool m_expanding{false};
-    qreal m_scaleFactor{1};
-    qreal m_currentStepScaleFactor{1};
+    bool m_expanding{ false };
+    qreal m_scaleFactor{ 1 };
+    qreal m_currentStepScaleFactor{ 1 };
 };

--- a/src/tools/pin/pinwidget.h
+++ b/src/tools/pin/pinwidget.h
@@ -3,11 +3,11 @@
 
 #pragma once
 
-#include <QGraphicsDropShadowEffect>
 #include <QWidget>
 
-class QVBoxLayout;
 class QLabel;
+class QVBoxLayout;
+class QGraphicsDropShadowEffect;
 
 class PinWidget : public QWidget
 {
@@ -17,15 +17,13 @@ public:
                        const QRect& geometry,
                        QWidget* parent = nullptr);
 
-    int margin() const;
-
 protected:
-    void wheelEvent(QWheelEvent* e);
-    void mouseDoubleClickEvent(QMouseEvent*);
-    void mousePressEvent(QMouseEvent*);
-    void mouseMoveEvent(QMouseEvent*);
-    void enterEvent(QEvent*);
-    void leaveEvent(QEvent*);
+    void wheelEvent(QWheelEvent* e) override;
+    void mouseDoubleClickEvent(QMouseEvent*) override;
+    void mousePressEvent(QMouseEvent*) override;
+    void mouseMoveEvent(QMouseEvent*) override;
+    void enterEvent(QEvent*) override;
+    void leaveEvent(QEvent*) override;
 
 private:
     void setScaledPixmapToLabel(const QSize& newSize,

--- a/src/tools/pin/pinwidget.h
+++ b/src/tools/pin/pinwidget.h
@@ -7,7 +7,12 @@
 
 class QLabel;
 class QVBoxLayout;
+class QGestureEvent;
+class QPinchGesture;
 class QGraphicsDropShadowEffect;
+
+#include <QLoggingCategory>
+Q_DECLARE_LOGGING_CATEGORY(lcExample)
 
 class PinWidget : public QWidget
 {
@@ -18,14 +23,20 @@ public:
                        QWidget* parent = nullptr);
 
 protected:
-    void wheelEvent(QWheelEvent* e) override;
     void mouseDoubleClickEvent(QMouseEvent*) override;
     void mousePressEvent(QMouseEvent*) override;
     void mouseMoveEvent(QMouseEvent*) override;
     void enterEvent(QEvent*) override;
     void leaveEvent(QEvent*) override;
 
+    bool event(QEvent *event) override;
+    void paintEvent(QPaintEvent *event) override;
+
 private:
+    bool gestureEvent(QGestureEvent *event);
+    bool scrollEvent(QWheelEvent* e);
+    void pinchTriggered(QPinchGesture*);
+
     void setScaledPixmapToLabel(const QSize& newSize,
                                 const qreal scale,
                                 const bool expanding);
@@ -37,4 +48,9 @@ private:
     qreal m_offsetX, m_offsetY;
     QGraphicsDropShadowEffect* m_shadowEffect;
     QColor m_baseColor, m_hoverColor;
+
+    bool m_gestureEvent{false};
+    bool m_expanding{false};
+    qreal scaleFactor{1};
+    qreal currentStepScaleFactor{1};
 };

--- a/src/tools/pin/pinwidget.h
+++ b/src/tools/pin/pinwidget.h
@@ -11,9 +11,6 @@ class QGestureEvent;
 class QPinchGesture;
 class QGraphicsDropShadowEffect;
 
-#include <QLoggingCategory>
-Q_DECLARE_LOGGING_CATEGORY(lcExample)
-
 class PinWidget : public QWidget
 {
     Q_OBJECT
@@ -37,10 +34,6 @@ private:
     bool scrollEvent(QWheelEvent* e);
     void pinchTriggered(QPinchGesture*);
 
-    void setScaledPixmapToLabel(const QSize& newSize,
-                                const qreal scale,
-                                const bool expanding);
-
     QPixmap m_pixmap;
     QVBoxLayout* m_layout;
     QLabel* m_label;
@@ -49,7 +42,6 @@ private:
     QGraphicsDropShadowEffect* m_shadowEffect;
     QColor m_baseColor, m_hoverColor;
 
-    bool m_gestureEvent{false};
     bool m_expanding{false};
     qreal scaleFactor{1};
     qreal currentStepScaleFactor{1};


### PR DESCRIPTION
Pinned image can be zoomed in/out via scrolling the mouse or, if supported, by pinching gesture. Refactored a bit the code.
I couldn't test it on Windows. 
Tested on Mac OS Monterey and Ubuntu linux 18.04.