### PR TITLE
Make KDE use Freedesktop portal

### DIFF
--- a/src/utils/screengrabber.cpp
+++ b/src/utils/screengrabber.cpp
@@ -100,25 +100,8 @@ QPixmap ScreenGrabber::grabEntireDesktop(bool& ok)
         QPixmap res;
         // handle screenshot based on DE
         switch (m_info.windowManager()) {
-            case DesktopInfo::GNOME: {
-                freeDesktopPortal(ok, res);
-                break;
-            }
-            case DesktopInfo::KDE: {
-                // https://github.com/KDE/spectacle/blob/517a7baf46a4ca0a45f32fd3f2b1b7210b180134/src/PlatformBackends/KWinWaylandImageGrabber.cpp#L145
-                QDBusInterface kwinInterface(
-                  QStringLiteral("org.kde.KWin"),
-                  QStringLiteral("/Screenshot"),
-                  QStringLiteral("org.kde.kwin.Screenshot"));
-                QDBusReply<QString> reply =
-                  kwinInterface.call(QStringLiteral("screenshotFullscreen"));
-                res = QPixmap(reply.value());
-                if (!res.isNull()) {
-                    QFile dbusResult(reply.value());
-                    dbusResult.remove();
-                }
-                break;
-            }
+            case DesktopInfo::GNOME:
+            case DesktopInfo::KDE:
             case DesktopInfo::SWAY: {
                 freeDesktopPortal(ok, res);
                 break;


### PR DESCRIPTION
This fixes #2436

It looks like in the newest KDE, using the Fredesktop portal is the only way that works (at least that seems to be the case with Fedora 35, where I have tested this change).

Having said so... it **could be** that this ticket breaks compatibility with older versions of KDE (after all, the special KDE code this PR is replacing was originally put in there for a reason!).

So... there are two options here: either merge this PR and forget about backwards compatibility or create a more sofisticated logic which (for the KDE case) tries with different approaches until one succeeds (KDE Screenshot / KDE Screenshot2 / Freedesktop / ...).

I'm not personally a fan of looking backwards... but you decide :)

After this change, all 3 supported desktops (GNOME, KDE and Sway) use the Freedesktop portal... and I *suppose* we could even go as far as dropping the Desktop check from this function and always try to use the Freedesktop portal as this will probably also work with others.
