### PR TITLE
add invert selection feature for pixelatetool

### DIFF
--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -1,5 +1,8 @@
 target_sources(flameshot PRIVATE arrow/arrowtool.h arrow/arrowtool.cpp)
-target_sources(flameshot PRIVATE pixelate/pixelatetool.h pixelate/pixelatetool.cpp)
+target_sources(flameshot PRIVATE pixelate/pixelatetool.h
+                                 pixelate/pixelatetool.cpp
+                                 pixelate/pixelateconfig.h
+                                 pixelate/pixelateconfig.cpp)
 target_sources(flameshot PRIVATE circle/circletool.h circle/circletool.cpp)
 target_sources(flameshot PRIVATE circlecount/circlecounttool.h circlecount/circlecounttool.cpp)
 target_sources(flameshot PRIVATE copy/copytool.h copy/copytool.cpp)

--- a/src/tools/pixelate/pixelateconfig.cpp
+++ b/src/tools/pixelate/pixelateconfig.cpp
@@ -1,0 +1,18 @@
+#include "pixelateconfig.h"
+
+PixelateConfig::PixelateConfig(QWidget* parent)
+  : QWidget(parent)
+{
+    m_layout = new QVBoxLayout(this);
+    m_invertSelectionCheckBox = new QCheckBox(tr("invert selection"), this);
+    m_layout->addWidget(m_invertSelectionCheckBox);
+    connect(m_invertSelectionCheckBox,
+            &QCheckBox::toggled,
+            this,
+            &PixelateConfig::toggleInvertSelection);
+}
+
+void PixelateConfig::setInvertSelection(bool invert)
+{
+    m_invertSelectionCheckBox->setTristate(invert);
+}

--- a/src/tools/pixelate/pixelateconfig.h
+++ b/src/tools/pixelate/pixelateconfig.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <QCheckBox>
+#include <QVBoxLayout>
+#include <QWidget>
+
+class PixelateConfig : public QWidget
+{
+    Q_OBJECT
+public:
+    explicit PixelateConfig(QWidget* parent = nullptr);
+    void setInvertSelection(bool invert);
+
+signals:
+    void toggleInvertSelection(bool invert);
+
+private:
+    QVBoxLayout* m_layout;
+    QCheckBox* m_invertSelectionCheckBox;
+};

--- a/src/tools/pixelate/pixelatetool.h
+++ b/src/tools/pixelate/pixelatetool.h
@@ -1,9 +1,8 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
-// SPDX-FileCopyrightText: 2017-2019 Alejandro Sirgo Rica & Contributors
-
 #pragma once
 
+#include "pixelateconfig.h"
 #include "src/tools/abstracttwopointtool.h"
+#include <QPointer>
 
 class PixelateTool : public AbstractTwoPointTool
 {
@@ -21,10 +20,17 @@ public:
     void drawSearchArea(QPainter& painter, const QPixmap& pixmap) override;
     void paintMousePreview(QPainter& painter,
                            const CaptureContext& context) override;
+    QWidget* configurationWidget() override;
+    bool isInverSelection();
 
 protected:
     CaptureTool::Type type() const override;
 
 public slots:
     void pressed(CaptureContext& context) override;
+    void setInvertSelection(bool invert);
+
+private:
+    QPointer<PixelateConfig> m_confW;
+    bool m_invertSelection;
 };

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -490,6 +490,7 @@ void CaptureWidget::paintEvent(QPaintEvent* paintEvent)
     if (m_activeTool && m_mouseIsClicked) {
         painter.save();
         m_activeTool->process(painter, m_context.screenshot);
+        update();
         painter.restore();
     } else if (m_previewEnabled && activeButtonTool() &&
                m_activeButton->tool()->showMousePreview()) {
@@ -1570,6 +1571,7 @@ void CaptureWidget::processPixmapWithTool(QPixmap* pixmap, CaptureTool* tool)
     QPainter painter(pixmap);
     painter.setRenderHint(QPainter::Antialiasing);
     tool->process(painter, *pixmap);
+    update();
 }
 
 CaptureTool* CaptureWidget::activeButtonTool() const


### PR DESCRIPTION
close https://github.com/flameshot-org/flameshot/issues/165.
add a checkoutbox in toolpanel to toggle invert selection for pixelatetool.
![2022-04-06_11-49](https://user-images.githubusercontent.com/49367127/161892105-13e832bd-e46b-41be-b856-af1ffc2db108.png)

