### PR TITLE
Remove extra timer shots when moving selection with keyboard

### DIFF
--- a/src/widgets/capture/selectionwidget.cpp
+++ b/src/widgets/capture/selectionwidget.cpp
@@ -443,11 +443,10 @@ void SelectionWidget::setGeometryByKeyboard(const QRect& r)
         rect.setHeight(1);
     }
     setGeometry(rect);
-    connect(
-      &timer,
-      &QTimer::timeout,
-      this,
-      [this]() { emit geometrySettled(); },
-      Qt::UniqueConnection);
+    connect(&timer,
+            &QTimer::timeout,
+            this,
+            &SelectionWidget::geometrySettled,
+            Qt::UniqueConnection);
     timer.start(400);
 }


### PR DESCRIPTION
Closes #2512.
