### PR TITLE
Config error fix

### DIFF
--- a/src/config/generalconf.cpp
+++ b/src/config/generalconf.cpp
@@ -468,7 +468,6 @@ void GeneralConf::initSaveAfterCopy()
     extensionLayout->addWidget(
       new QLabel(tr("Preferred save file extension:")));
     m_setSaveAsFileExtension = new QComboBox(this);
-    m_setSaveAsFileExtension->addItem("");
 
     QStringList imageFormatList;
     foreach (auto mimeType, QImageWriter::supportedImageFormats())


### PR DESCRIPTION
Fixes #2359.

Getting rid of the empty string option "" in the drop selection for the preferred file extension prevents the user from setting `saveAsFileExtension` to an empty string, which results in the error message.

This fix has been tested on Ubuntu 20.04.4 x86.