### PR TITLE
improve print geometry final action

### DIFF
--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -272,11 +272,10 @@ void CaptureWidget::initButtons()
 {
     auto allButtonTypes = CaptureToolButton::getIterableButtonTypes();
     auto visibleButtonTypes = m_config.buttons();
-    if ((m_context.request.tasks() == CaptureRequest::NO_TASK) ||
-        (m_context.request.tasks() == CaptureRequest::PRINT_GEOMETRY)) {
+    if (m_context.request.tasks() == CaptureRequest::NO_TASK) {
         allButtonTypes.removeOne(CaptureTool::TYPE_ACCEPT);
         visibleButtonTypes.removeOne(CaptureTool::TYPE_ACCEPT);
-    } else {
+    } else if (m_context.request.tasks() != CaptureRequest::PRINT_GEOMETRY){
         // Remove irrelevant buttons from both lists
         for (auto* buttonList : { &allButtonTypes, &visibleButtonTypes }) {
             buttonList->removeOne(CaptureTool::TYPE_SAVE);


### PR DESCRIPTION
#2444 remove the accept button when `flameshot gui --print-geometry`, which is confusing(compared to other final action). I think keep the accept button and other final action button maybe better. @borgmanJeremy 