### PR TITLE
Fixed spelling issue in `Jarhhundert`

### DIFF
--- a/data/translations/Internationalization_de_DE.ts
+++ b/data/translations/Internationalization_de_DE.ts
@@ -2174,7 +2174,7 @@ Eventuell muss das &apos;#&apos; Zeichen als &apos;\#FFF&apos; maskiert werden</
     <message>
         <location filename="../../src/config/strftimechooserwidget.cpp" line="37"/>
         <source>Century (00-99)</source>
-        <translation>Jarhhundert (00-99)</translation>
+        <translation>Jahrhundert (00-99)</translation>
     </message>
     <message>
         <location filename="../../src/config/strftimechooserwidget.cpp" line="38"/>


### PR DESCRIPTION
Fixed spelling in `Jarhhundert` by renaming it to `Jahrhundert`.