### PR TITLE
fix issue about externalWidget launchapp

### DIFF
--- a/src/core/flameshot.cpp
+++ b/src/core/flameshot.cpp
@@ -37,6 +37,7 @@
 
 Flameshot::Flameshot()
   : m_captureWindow(nullptr)
+  , m_haveExternalWidget(false)
 #if defined(Q_OS_MACOS)
   , m_HotkeyScreenshotCapture(nullptr)
   , m_HotkeyScreenshotHistory(nullptr)
@@ -411,12 +412,15 @@ void Flameshot::exportCapture(QPixmap capture,
     if (!(tasks & CR::UPLOAD)) {
         emit captureTaken(capture);
     }
-    // hacks: close a window to trigger qt's quitOnLastWindowClose
-    // if not create tmp_window and close, the `flameshot gui` won't exit after
-    // click copy button
-    QWidget* tmp = new QWidget();
-    tmp->show();
-    tmp->close();
+}
+
+void Flameshot::setExternalWidget(bool b)
+{
+    m_haveExternalWidget = b;
+}
+bool Flameshot::haveExternalWidget()
+{
+    return m_haveExternalWidget;
 }
 
 // STATIC ATTRIBUTES

--- a/src/core/flameshot.h
+++ b/src/core/flameshot.h
@@ -47,6 +47,8 @@ public slots:
 public:
     static void setOrigin(Origin origin);
     static Origin origin();
+    void setExternalWidget(bool b);
+    bool haveExternalWidget();
 
 signals:
     void captureTaken(QPixmap p);
@@ -62,6 +64,7 @@ private:
 
     // class members
     static Origin m_origin;
+    bool m_haveExternalWidget;
 
     QPointer<CaptureWidget> m_captureWindow;
     QPointer<InfoWindow> m_infoWindow;

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -1200,6 +1200,7 @@ void CaptureWidget::handleToolSignal(CaptureTool::Request r)
                 w->setAttribute(Qt::WA_DeleteOnClose);
                 w->activateWindow();
                 w->show();
+                Flameshot::instance()->setExternalWidget(true);
             }
             break;
         case CaptureTool::REQ_INCREASE_TOOL_SIZE:


### PR DESCRIPTION
Sorry to introduce other bug when fixed bug #2562 . The first one is the hack that open and close window to trigger exit. It will mess window size in window manager like dwm, so I replace the hack with exit flameshot directly. But I make a mistake so it also close the daemon. This time I add the daemon judge logic, and put it in `captureTaken`'s slot under the MAC_OS code to keep consistent.