### PR TITLE
rename Imgur API Key to Imgur Application Client ID

### DIFF
--- a/data/translations/Internationalization_bg.ts
+++ b/data/translations/Internationalization_bg.ts
@@ -1154,8 +1154,8 @@ Please solve them manually in the configuration file.</translation>
     </message>
     <message>
         <location filename="../../src/config/generalconf.cpp" line="540"/>
-        <source>Imgur API Key</source>
-        <translation>Imgur API Key</translation>
+        <source>Imgur Application Client ID</source>
+        <translation>Imgur Application Client ID</translation>
     </message>
     <message>
         <location filename="../../src/config/generalconf.cpp" line="571"/>

--- a/data/translations/Internationalization_ca.ts
+++ b/data/translations/Internationalization_ca.ts
@@ -1162,8 +1162,8 @@ Please solve them manually in the configuration file.</translation>
     </message>
     <message>
         <location filename="../../src/config/generalconf.cpp" line="540"/>
-        <source>Imgur API Key</source>
-        <translation>Imgur API Key</translation>
+        <source>Imgur Application Client ID</source>
+        <translation>Imgur Application Client ID</translation>
     </message>
     <message>
         <location filename="../../src/config/generalconf.cpp" line="571"/>

--- a/data/translations/Internationalization_cs.ts
+++ b/data/translations/Internationalization_cs.ts
@@ -1221,8 +1221,8 @@ Vyřešte je, prosím, ručně v souboru s nastavením.</translation>
     </message>
     <message>
         <location filename="../../src/config/generalconf.cpp" line="540"/>
-        <source>Imgur API Key</source>
-        <translation>Imgur API Key</translation>
+        <source>Imgur Application Client ID</source>
+        <translation>Imgur Application Client ID</translation>
     </message>
     <message>
         <location filename="../../src/config/generalconf.cpp" line="571"/>

--- a/data/translations/Internationalization_de_DE.ts
+++ b/data/translations/Internationalization_de_DE.ts
@@ -1174,8 +1174,8 @@ Bitte beseitige sie manuell in der Konfigurationsdatei.</translation>
     </message>
     <message>
         <location filename="../../src/config/generalconf.cpp" line="540"/>
-        <source>Imgur API Key</source>
-        <translation>Imgur API Key</translation>
+        <source>Imgur Application Client ID</source>
+        <translation>Imgur Application Client ID</translation>
     </message>
     <message>
         <location filename="../../src/config/generalconf.cpp" line="571"/>

--- a/data/translations/Internationalization_el.ts
+++ b/data/translations/Internationalization_el.ts
@@ -1166,7 +1166,7 @@ Please solve them manually in the configuration file.</source>
     </message>
     <message>
         <location filename="../../src/config/generalconf.cpp" line="540"/>
-        <source>Imgur API Key</source>
+        <source>Imgur Application Client ID</source>
         <translation>Κλειδί API Imgur</translation>
     </message>
     <message>

--- a/data/translations/Internationalization_es.ts
+++ b/data/translations/Internationalization_es.ts
@@ -1177,8 +1177,8 @@ Por favor, resuélvelos manualmente en el archivo de configuración.</translatio
     </message>
     <message>
         <location filename="../../src/config/generalconf.cpp" line="540"/>
-        <source>Imgur API Key</source>
-        <translation>Imgur API Key</translation>
+        <source>Imgur Application Client ID</source>
+        <translation>Imgur Application Client ID</translation>
     </message>
     <message>
         <location filename="../../src/config/generalconf.cpp" line="571"/>

--- a/data/translations/Internationalization_eu.ts
+++ b/data/translations/Internationalization_eu.ts
@@ -1209,8 +1209,8 @@ Please solve them manually in the configuration file.</translation>
     </message>
     <message>
         <location filename="../../src/config/generalconf.cpp" line="540"/>
-        <source>Imgur API Key</source>
-        <translation>Imgur API Key</translation>
+        <source>Imgur Application Client ID</source>
+        <translation>Imgur Application Client ID</translation>
     </message>
     <message>
         <location filename="../../src/config/generalconf.cpp" line="571"/>

--- a/data/translations/Internationalization_fa.ts
+++ b/data/translations/Internationalization_fa.ts
@@ -1158,8 +1158,8 @@ Please solve them manually in the configuration file.</translation>
     </message>
     <message>
         <location filename="../../src/config/generalconf.cpp" line="540"/>
-        <source>Imgur API Key</source>
-        <translation>Imgur API Key</translation>
+        <source>Imgur Application Client ID</source>
+        <translation>Imgur Application Client ID</translation>
     </message>
     <message>
         <location filename="../../src/config/generalconf.cpp" line="571"/>

--- a/data/translations/Internationalization_fi.ts
+++ b/data/translations/Internationalization_fi.ts
@@ -1162,8 +1162,8 @@ Please solve them manually in the configuration file.</translation>
     </message>
     <message>
         <location filename="../../src/config/generalconf.cpp" line="540"/>
-        <source>Imgur API Key</source>
-        <translation>Imgur API Key</translation>
+        <source>Imgur Application Client ID</source>
+        <translation>Imgur Application Client ID</translation>
     </message>
     <message>
         <location filename="../../src/config/generalconf.cpp" line="571"/>

--- a/data/translations/Internationalization_fr.ts
+++ b/data/translations/Internationalization_fr.ts
@@ -1177,8 +1177,8 @@ Veuillez résoudre ce problème manuellement depuis le fichier de configuration.
     </message>
     <message>
         <location filename="../../src/config/generalconf.cpp" line="540"/>
-        <source>Imgur API Key</source>
-        <translation>Imgur API Key</translation>
+        <source>Imgur Application Client ID</source>
+        <translation>Imgur Application Client ID</translation>
     </message>
     <message>
         <location filename="../../src/config/generalconf.cpp" line="571"/>

--- a/data/translations/Internationalization_gl.ts
+++ b/data/translations/Internationalization_gl.ts
@@ -1154,8 +1154,8 @@ Please solve them manually in the configuration file.</translation>
     </message>
     <message>
         <location filename="../../src/config/generalconf.cpp" line="540"/>
-        <source>Imgur API Key</source>
-        <translation>Imgur API Key</translation>
+        <source>Imgur Application Client ID</source>
+        <translation>Imgur Application Client ID</translation>
     </message>
     <message>
         <location filename="../../src/config/generalconf.cpp" line="571"/>

--- a/data/translations/Internationalization_he.ts
+++ b/data/translations/Internationalization_he.ts
@@ -1170,8 +1170,8 @@ Please solve them manually in the configuration file.</source>
     </message>
     <message>
         <location filename="../../src/config/generalconf.cpp" line="540"/>
-        <source>Imgur API Key</source>
-        <translation>Imgur API Key</translation>
+        <source>Imgur Application Client ID</source>
+        <translation>Imgur Application Client ID</translation>
     </message>
     <message>
         <location filename="../../src/config/generalconf.cpp" line="571"/>

--- a/data/translations/Internationalization_hu.ts
+++ b/data/translations/Internationalization_hu.ts
@@ -1015,8 +1015,8 @@ Please solve them manually in the configuration file.</translation>
         <translation>Enable Copy on Double Click</translation>
     </message>
     <message>
-        <source>Imgur API Key</source>
-        <translation>Imgur API Key</translation>
+        <source>Imgur Application Client ID</source>
+        <translation>Imgur Application Client ID</translation>
     </message>
 </context>
 <context>

--- a/data/translations/Internationalization_id.ts
+++ b/data/translations/Internationalization_id.ts
@@ -1170,8 +1170,8 @@ Mohon atasi mereka secara manual di file konfigurasi.</translation>
     </message>
     <message>
         <location filename="../../src/config/generalconf.cpp" line="540"/>
-        <source>Imgur API Key</source>
-        <translation>Imgur API Key</translation>
+        <source>Imgur Application Client ID</source>
+        <translation>Imgur Application Client ID</translation>
     </message>
     <message>
         <location filename="../../src/config/generalconf.cpp" line="571"/>

--- a/data/translations/Internationalization_it_IT.ts
+++ b/data/translations/Internationalization_it_IT.ts
@@ -1091,7 +1091,7 @@ Si prega di risolverli manualmente nel file di configurazione.</translation>
     </message>
     <message>
         <location filename="../../src/config/generalconf.cpp" line="540"/>
-        <source>Imgur API Key</source>
+        <source>Imgur Application Client ID</source>
         <translation>Chiave API Imgur</translation>
     </message>
     <message>

--- a/data/translations/Internationalization_ja.ts
+++ b/data/translations/Internationalization_ja.ts
@@ -1157,8 +1157,8 @@ Please solve them manually in the configuration file.</translation>
     </message>
     <message>
         <location filename="../../src/config/generalconf.cpp" line="540"/>
-        <source>Imgur API Key</source>
-        <translation>Imgur API Key</translation>
+        <source>Imgur Application Client ID</source>
+        <translation>Imgur Application Client ID</translation>
     </message>
     <message>
         <location filename="../../src/config/generalconf.cpp" line="571"/>

--- a/data/translations/Internationalization_ka.ts
+++ b/data/translations/Internationalization_ka.ts
@@ -1157,8 +1157,8 @@ Please solve them manually in the configuration file.</translation>
     </message>
     <message>
         <location filename="../../src/config/generalconf.cpp" line="540"/>
-        <source>Imgur API Key</source>
-        <translation>Imgur API Key</translation>
+        <source>Imgur Application Client ID</source>
+        <translation>Imgur Application Client ID</translation>
     </message>
     <message>
         <location filename="../../src/config/generalconf.cpp" line="571"/>

--- a/data/translations/Internationalization_ko.ts
+++ b/data/translations/Internationalization_ko.ts
@@ -1178,8 +1178,8 @@ Please solve them manually in the configuration file.</translation>
     </message>
     <message>
         <location filename="../../src/config/generalconf.cpp" line="540"/>
-        <source>Imgur API Key</source>
-        <translation>Imgur API Key</translation>
+        <source>Imgur Application Client ID</source>
+        <translation>Imgur Application Client ID</translation>
     </message>
     <message>
         <location filename="../../src/config/generalconf.cpp" line="571"/>

--- a/data/translations/Internationalization_nb_NO.ts
+++ b/data/translations/Internationalization_nb_NO.ts
@@ -1158,8 +1158,8 @@ Please solve them manually in the configuration file.</translation>
     </message>
     <message>
         <location filename="../../src/config/generalconf.cpp" line="540"/>
-        <source>Imgur API Key</source>
-        <translation>Imgur API Key</translation>
+        <source>Imgur Application Client ID</source>
+        <translation>Imgur Application Client ID</translation>
     </message>
     <message>
         <location filename="../../src/config/generalconf.cpp" line="571"/>

--- a/data/translations/Internationalization_nl.ts
+++ b/data/translations/Internationalization_nl.ts
@@ -1155,7 +1155,7 @@ Please solve them manually in the configuration file.</source>
     </message>
     <message>
         <location filename="../../src/config/generalconf.cpp" line="540"/>
-        <source>Imgur API Key</source>
+        <source>Imgur Application Client ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/data/translations/Internationalization_nl_NL.ts
+++ b/data/translations/Internationalization_nl_NL.ts
@@ -1173,8 +1173,8 @@ Los ze alstublieft handmatig op in het configuratiebestand.</translation>
     </message>
     <message>
         <location filename="../../src/config/generalconf.cpp" line="540"/>
-        <source>Imgur API Key</source>
-        <translation>Imgur API Key</translation>
+        <source>Imgur Application Client ID</source>
+        <translation>Imgur Application Client ID</translation>
     </message>
     <message>
         <location filename="../../src/config/generalconf.cpp" line="571"/>

--- a/data/translations/Internationalization_pl.ts
+++ b/data/translations/Internationalization_pl.ts
@@ -1181,8 +1181,8 @@ Rozwiąż błędy ręcznie w pliku konfiguracyjnym.</translation>
     </message>
     <message>
         <location filename="../../src/config/generalconf.cpp" line="540"/>
-        <source>Imgur API Key</source>
-        <translation>Imgur API Key</translation>
+        <source>Imgur Application Client ID</source>
+        <translation>Imgur Application Client ID</translation>
     </message>
     <message>
         <location filename="../../src/config/generalconf.cpp" line="571"/>

--- a/data/translations/Internationalization_pt_BR.ts
+++ b/data/translations/Internationalization_pt_BR.ts
@@ -1213,8 +1213,8 @@ Please solve them manually in the configuration file.</translation>
     </message>
     <message>
         <location filename="../../src/config/generalconf.cpp" line="540"/>
-        <source>Imgur API Key</source>
-        <translation>Imgur API Key</translation>
+        <source>Imgur Application Client ID</source>
+        <translation>Imgur Application Client ID</translation>
     </message>
     <message>
         <location filename="../../src/config/generalconf.cpp" line="571"/>

--- a/data/translations/Internationalization_ru.ts
+++ b/data/translations/Internationalization_ru.ts
@@ -1249,7 +1249,7 @@ Please solve them manually in the configuration file.</source>
     </message>
     <message>
         <location filename="../../src/config/generalconf.cpp" line="540"/>
-        <source>Imgur API Key</source>
+        <source>Imgur Application Client ID</source>
         <translation>Ключ API Imgur</translation>
     </message>
     <message>

--- a/data/translations/Internationalization_sk.ts
+++ b/data/translations/Internationalization_sk.ts
@@ -1221,8 +1221,8 @@ Riešte ich ručne v konfiguračnom súbore.</translation>
     </message>
     <message>
         <location filename="../../src/config/generalconf.cpp" line="540"/>
-        <source>Imgur API Key</source>
-        <translation>Imgur API Key</translation>
+        <source>Imgur Application Client ID</source>
+        <translation>Imgur Application Client ID</translation>
     </message>
     <message>
         <location filename="../../src/config/generalconf.cpp" line="571"/>

--- a/data/translations/Internationalization_sr_SP.ts
+++ b/data/translations/Internationalization_sr_SP.ts
@@ -1161,8 +1161,8 @@ Please solve them manually in the configuration file.</translation>
     </message>
     <message>
         <location filename="../../src/config/generalconf.cpp" line="540"/>
-        <source>Imgur API Key</source>
-        <translation>Imgur API Key</translation>
+        <source>Imgur Application Client ID</source>
+        <translation>Imgur Application Client ID</translation>
     </message>
     <message>
         <location filename="../../src/config/generalconf.cpp" line="571"/>

--- a/data/translations/Internationalization_sv_SE.ts
+++ b/data/translations/Internationalization_sv_SE.ts
@@ -1157,8 +1157,8 @@ Please solve them manually in the configuration file.</translation>
     </message>
     <message>
         <location filename="../../src/config/generalconf.cpp" line="540"/>
-        <source>Imgur API Key</source>
-        <translation>Imgur API Key</translation>
+        <source>Imgur Application Client ID</source>
+        <translation>Imgur Application Client ID</translation>
     </message>
     <message>
         <location filename="../../src/config/generalconf.cpp" line="571"/>

--- a/data/translations/Internationalization_tr.ts
+++ b/data/translations/Internationalization_tr.ts
@@ -1173,7 +1173,7 @@ Lütfen bunları yapılandırma dosyasında elle çözün.</translation>
     </message>
     <message>
         <location filename="../../src/config/generalconf.cpp" line="540"/>
-        <source>Imgur API Key</source>
+        <source>Imgur Application Client ID</source>
         <translation>Imgur API Anahtarı</translation>
     </message>
     <message>

--- a/data/translations/Internationalization_uk.ts
+++ b/data/translations/Internationalization_uk.ts
@@ -1249,7 +1249,7 @@ Please solve them manually in the configuration file.</source>
     </message>
     <message>
         <location filename="../../src/config/generalconf.cpp" line="540"/>
-        <source>Imgur API Key</source>
+        <source>Imgur Application Client ID</source>
         <translation>Ключ API Imgur</translation>
     </message>
     <message>

--- a/data/translations/Internationalization_vi.ts
+++ b/data/translations/Internationalization_vi.ts
@@ -1154,8 +1154,8 @@ Please solve them manually in the configuration file.</translation>
     </message>
     <message>
         <location filename="../../src/config/generalconf.cpp" line="540"/>
-        <source>Imgur API Key</source>
-        <translation>Imgur API Key</translation>
+        <source>Imgur Application Client ID</source>
+        <translation>Imgur Application Client ID</translation>
     </message>
     <message>
         <location filename="../../src/config/generalconf.cpp" line="571"/>

--- a/data/translations/Internationalization_zh_CN.ts
+++ b/data/translations/Internationalization_zh_CN.ts
@@ -1226,7 +1226,7 @@ Please solve them manually in the configuration file.</source>
     </message>
     <message>
         <location filename="../../src/config/generalconf.cpp" line="540"/>
-        <source>Imgur API Key</source>
+        <source>Imgur Application Client ID</source>
         <translation>Imgur API 键值</translation>
     </message>
     <message>

--- a/data/translations/Internationalization_zh_HK.ts
+++ b/data/translations/Internationalization_zh_HK.ts
@@ -1205,8 +1205,8 @@ Please solve them manually in the configuration file.</translation>
     </message>
     <message>
         <location filename="../../src/config/generalconf.cpp" line="540"/>
-        <source>Imgur API Key</source>
-        <translation>Imgur API Key</translation>
+        <source>Imgur Application Client ID</source>
+        <translation>Imgur Application Client ID</translation>
     </message>
     <message>
         <location filename="../../src/config/generalconf.cpp" line="571"/>

--- a/data/translations/Internationalization_zh_TW.ts
+++ b/data/translations/Internationalization_zh_TW.ts
@@ -1153,8 +1153,8 @@ Please solve them manually in the configuration file.</translation>
     </message>
     <message>
         <location filename="../../src/config/generalconf.cpp" line="540"/>
-        <source>Imgur API Key</source>
-        <translation>Imgur API Key</translation>
+        <source>Imgur Application Client ID</source>
+        <translation>Imgur Application Client ID</translation>
     </message>
     <message>
         <location filename="../../src/config/generalconf.cpp" line="571"/>

--- a/src/config/generalconf.cpp
+++ b/src/config/generalconf.cpp
@@ -537,7 +537,7 @@ void GeneralConf::initUploadHistoryMax()
 
 void GeneralConf::initUploadClientSecret()
 {
-    auto* box = new QGroupBox(tr("Imgur API Key"));
+    auto* box = new QGroupBox(tr("Imgur Application Client ID"));
     box->setFlat(true);
     m_layout->addWidget(box);
 


### PR DESCRIPTION
Per https://github.com/flameshot-org/flameshot/issues/2718

I didn't mess with the translations other than the rename.