### PR TITLE
Properly constructs external app command line

### DIFF
--- a/src/tools/launcher/applauncherwidget.cpp
+++ b/src/tools/launcher/applauncherwidget.cpp
@@ -98,16 +98,22 @@ void AppLauncherWidget::launch(const QModelIndex& index)
     }
     // Heuristically, if there is a % in the command we assume it is the file name slot
     QString command = index.data(Qt::UserRole).toString();
+    QStringList prog_args = command.split(" ");
     // no quotes because it is going in an array!
     if (command.contains("%"))
-        command = command.replace(QRegExp("(\\%.)"),  m_tempFile );
+    {
+        // but that means we need to substitute IN the array not the string!
+        for ( auto& i : prog_args)
+        {
+            if (i
+                .contains("%")) i.replace(QRegExp("(\\%.)"), m_tempFile);
+        }
+    }
     else
     {
          // we really should append the file name if there
-        command.append(m_tempFile); // were no replacements
+        prog_args.append(m_tempFile); // were no replacements
     }
-
-    QStringList prog_args = command.split(" ");
     QString app_name = prog_args.at(0);
     bool inTerminal =
       index.data(Qt::UserRole + 1).toBool() || m_terminalCheckbox->isChecked();

--- a/src/utils/desktopfileparse.cpp
+++ b/src/utils/desktopfileparse.cpp
@@ -100,7 +100,11 @@ DesktopAppData DesktopFileParser::parseDesktopFile(const QString& fileName,
 
 int DesktopFileParser::processDirectory(const QDir& dir)
 {
-    QStringList entries = dir.entryList(QDir::NoDotAndDotDot | QDir::Files);
+    // Note that https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html
+    // says files must end in .desktop or .directory
+    // So filtering by .desktop stops us reading things like editor backups
+    // .kdelnk is long deprecated
+    QStringList entries = dir.entryList({"*.desktop"},QDir::NoDotAndDotDot | QDir::Files);
     bool ok;
     int length = m_appList.length();
     for (QString file : entries) {


### PR DESCRIPTION
See Issue #2708

The code to launch an external tool assumes the desktop file has a command like:

/usr/bin/XXX %f

It fails if the command is more like:
/usr/bin/XXX --important-option %f

The update looks for a % in the string. If so, it replaces %. (which is probably %f; this is how the original code did it) with the file name. If there is no %, it just appends the file name. Then it builds a proper command argument for QProcess::startDetached. That involves removing the program name and passing the array of arguments. 

Because the arguments are in an array you do NOT want to quote it (as the original code does) because it is not going through the shell so trying to open "X.png" literally looks for a file with the name <quote>X<dot>png<quote>.
