### PR TITLE
DesktopFileParser only reads .desktop files

### DIFF
--- a/src/utils/desktopfileparse.cpp
+++ b/src/utils/desktopfileparse.cpp
@@ -100,7 +100,11 @@ DesktopAppData DesktopFileParser::parseDesktopFile(const QString& fileName,
 
 int DesktopFileParser::processDirectory(const QDir& dir)
 {
-    QStringList entries = dir.entryList(QDir::NoDotAndDotDot | QDir::Files);
+    // Note that https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html
+    // says files must end in .desktop or .directory
+    // So filtering by .desktop stops us reading things like editor backups
+    // .kdelnk is long deprecated
+    QStringList entries = dir.entryList({"*.desktop"},QDir::NoDotAndDotDot | QDir::Files);
     bool ok;
     int length = m_appList.length();
     for (QString file : entries) {


### PR DESCRIPTION
The current code picks up anything in the application(s) directory including things like editor backups. 

Simple change, but mildly controversial since a very long time ago you might have had .kdelnk files in there. 