### PR TITLE
restore old QT fallback

### DIFF
--- a/src/core/flameshot.cpp
+++ b/src/core/flameshot.cpp
@@ -144,7 +144,12 @@ void Flameshot::screen(CaptureRequest req, const int screenNumber)
 
     if (screenNumber < 0) {
         QPoint globalCursorPos = QCursor::pos();
-        screen = qApp->screenAt(globalCursorPos);
+        #if QT_VERSION > QT_VERSION_CHECK(5, 10, 0)
+          screen = qApp->screenAt(globalCursorPos);
+        #else
+          screen =
+            qApp->screens()[qApp->desktop()->screenNumber(globalCursorPos)];
+        #endif
     } else if (screenNumber >= qApp->screens().count()) {
         AbstractLogger() << QObject::tr(
           "Requested screen exceeds screen count");


### PR DESCRIPTION
solves https://github.com/flameshot-org/flameshot/issues/2692

this is the only thing necessary to successfully build on bionic (and other distros with Qt 5.9.X)