### PR TITLE
docs: fixed the spelling of the word 'recordig' to 'recording'.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -71,7 +71,7 @@ body:
   id: screenshots
   attributes:
     label: Screenshots or screen recordings
-    description: If you think it would be beneficial for us to understand the issue, please provide a screenshots or screen recordig. For screen recording you can use [Peek](https://github.com/phw/peek)
+    description: If you think it would be beneficial for us to understand the issue, please provide a screenshots or screen recording. For screen recording you can use [Peek](https://github.com/phw/peek)
 - type: textarea
   id: systeminfo
   attributes:


### PR DESCRIPTION
# Fixed Misspelled word in bug-report.yaml

Inside bug-report.yaml the word `recordig` is misspelled

```yaml
If you think it would be beneficial for us to understand the issue, please provide a screenshots or screen recordig. For screen recording you can use Peek
```

See issue https://github.com/flameshot-org/flameshot/issues/2795.