### PR TITLE
Kde-connect share integration (#2551)

### DIFF
--- a/src/utils/desktopfileparse.cpp
+++ b/src/utils/desktopfileparse.cpp
@@ -33,6 +33,7 @@ DesktopAppData DesktopFileParser::parseDesktopFile(const QString& fileName,
     bool nameLocaleSet = false;
     bool descriptionLocaleSet = false;
     bool isApplication = false;
+    bool isService = false;
     QTextStream in(&file);
     // enter the desktop entry definition
     while (!in.atEnd() && in.readLine() != QLatin1String("[Desktop Entry]")) {
@@ -77,6 +78,9 @@ DesktopAppData DesktopFileParser::parseDesktopFile(const QString& fileName,
             if (line.contains(QLatin1String("Application"))) {
                 isApplication = true;
             }
+            if (line.contains(QLatin1String("Service"))) {
+                isService = true;
+            }
         } else if (line.startsWith(QLatin1String("Categories"))) {
             res.categories = line.mid(line.indexOf(QLatin1String("=")) + 1)
                                .split(QStringLiteral(";"));
@@ -92,7 +96,8 @@ DesktopAppData DesktopFileParser::parseDesktopFile(const QString& fileName,
         }
     }
     file.close();
-    if (res.exec.isEmpty() || res.name.isEmpty() || !isApplication) {
+    if (res.exec.isEmpty() || res.name.isEmpty() ||
+        (!isApplication && !isService)) {
         ok = false;
     }
     return res;


### PR DESCRIPTION
By allowing desktop files of Type "Service", issue #2551 would be fixed. Kde-Connect is shown and I was able to send the screenshot successfully to my mobile. Even if the shortcut is called "Open with", the file is copied onto the mobile device.
I don't know if there was a special reason not allowing Type "Service" apps, but at least on my machine this didn't cause any issue.

![Send to mobile](https://user-images.githubusercontent.com/26674558/179368218-136f4f57-6633-47ec-97b4-2dc0e4922a2b.png)

I successfully tested it on Manjaro with KDE. Tests on other desktop environments might be recommended.