### PR TITLE
Fix tray icon handling on Windows (#2774)

### DIFF
--- a/src/config/generalconf.cpp
+++ b/src/config/generalconf.cpp
@@ -102,9 +102,8 @@ void GeneralConf::_updateComponents(bool allowEmptySavePath)
     if (allowEmptySavePath || !config.savePath().isEmpty()) {
         m_savePath->setText(config.savePath());
     }
-#if defined(Q_OS_LINUX) || defined(Q_OS_UNIX)
+
     m_showTray->setChecked(!config.disabledTrayIcon());
-#endif
 }
 
 void GeneralConf::updateComponents()
@@ -283,7 +282,6 @@ void GeneralConf::initShowDesktopNotification()
 
 void GeneralConf::initShowTrayIcon()
 {
-#if defined(Q_OS_LINUX) || defined(Q_OS_UNIX)
     m_showTray = new QCheckBox(tr("Show tray icon"), this);
     m_showTray->setToolTip(tr("Show icon in the system tray"));
     m_scrollAreaLayout->addWidget(m_showTray);
@@ -291,7 +289,6 @@ void GeneralConf::initShowTrayIcon()
     connect(m_showTray, &QCheckBox::clicked, this, [](bool checked) {
         ConfigHandler().setDisabledTrayIcon(!checked);
     });
-#endif
 }
 
 void GeneralConf::initHistoryConfirmationToDelete()


### PR DESCRIPTION
Currently all tray icon options are ignored on Windows with #ifdefs, which is not needed from functional point of view. This patch removes these restrictions and user is able to decide if tray icon is wanted or not.

Only disadvantage: Since CLI parsing is currently disabled for Windows, users cannot reach the flameshot config GUI anymore after disabling the tray! So one has to edit the ini manually to restore the tray.
https://github.com/flameshot-org/flameshot/blob/57c8e8d893669cd83d8b279ea3ff6db50b16aa48/src/main.cpp#L149-L153
Disabling the CLI for Windows might not be needed as well. If I find some time, I'll maybe have a look on this and test it (see #2118).