### PR TITLE
Allow for default external application

### DIFF
--- a/docs/OptionNotes.md
+++ b/docs/OptionNotes.md
@@ -1,0 +1,20 @@
+Notes on adding new options to Flameshot
+========================================
+
+Let's add extPgmTerminal as a boolena:
+
+1. Create the getter/setter in configHandler:
+
+   src/utils/configHandler.h - `CONFIG_GETTER_SETTER(extPgmTerminal,setExtPgmTerminal,bool)`
+
+2. Add the option to the file parser:
+
+    src/utils/confighandler.cpp - `OPTION("extPgmTerminal"             ,Bool               ( false              ))`
+
+3. Add widgets to src/config/*.cpp/h
+   1. add member variable
+   2. add init function
+   3. connect signals to created function or lambda
+   
+   
+

--- a/src/config/generalconf.cpp
+++ b/src/config/generalconf.cpp
@@ -88,9 +88,8 @@ void GeneralConf::_updateComponents(bool allowEmptySavePath)
     m_showMagnifier->setChecked(config.showMagnifier());
     m_squareMagnifier->setChecked(config.squareMagnifier());
     m_saveLastRegion->setChecked(config.saveLastRegion());
-    m_useExtPgm->setChecked(config.useDefaultExtPgm());
+    m_useExtPgm->setChecked(config.useDefaultExtPgmOnAlt());
     m_useExtPgmTerm->setChecked(config.extPgmTerminal());
-    m_showSelectionGeometry->setChecked(config.showSelectionGeometry());
     m_xywhTimeout->setValue(config.showSelectionGeometryHideTime());
 
 #if !defined(Q_OS_WIN)
@@ -716,19 +715,24 @@ void GeneralConf::initSquareMagnifier()
 
 void GeneralConf::initExtPgm()
 {
-    m_useExtPgm =
-      new QCheckBox(tr("Use default program (set program via launcher)"), this);
+    m_useExtPgm = new QCheckBox(
+      tr("Use default program on Alt+Click (set program via launcher)"), this);
+    m_useExtPgm->setToolTip(tr(
+      "When checked, Alt+left click on the launch button will open the default "
+      "program, if set and a regular left click will allow you to select a "
+      "program. If not "
+      "checked, the operation is reversed."));
     m_useExtPgmTerm =
       new QCheckBox(tr("Default program run in terminal"), this);
     m_scrollAreaLayout->addWidget(m_useExtPgm);
     m_scrollAreaLayout->addWidget(m_useExtPgmTerm);
     connect(m_useExtPgm, &QCheckBox::clicked, [](bool checked) {
-        ConfigHandler().setUseDefaultExtPgm(checked);
+        ConfigHandler().setUseDefaultExtPgmOnAlt(checked);
     });
     connect(m_useExtPgmTerm, &QCheckBox::clicked, [](bool checked) {
         ConfigHandler().setExtPgmTerminal(checked);
     });
-    m_useExtPgm->setChecked(ConfigHandler().useDefaultExtPgm());
+    m_useExtPgm->setChecked(ConfigHandler().useDefaultExtPgmOnAlt());
     m_useExtPgmTerm->setChecked(ConfigHandler().extPgmTerminal());
 }
 
@@ -794,8 +798,8 @@ void GeneralConf::setSelGeoHideTime(int v)
 
 void GeneralConf::setGeometryLocation(int index)
 {
-    ConfigHandler().setValue("showSelectionGeometry",
-                             m_selectGeometryLocation->itemData(index));
+    ConfigHandler().setShowSelectionGeometry(
+      m_selectGeometryLocation->itemData(index).toInt());
 }
 
 void GeneralConf::togglePathFixed()

--- a/src/config/generalconf.cpp
+++ b/src/config/generalconf.cpp
@@ -57,6 +57,7 @@ GeneralConf::GeneralConf(QWidget* parent)
     initUploadClientSecret();
     initPredefinedColorPaletteLarge();
     initShowSelectionGeometry();
+    initExtPgm();
 
     m_layout->addStretch();
 
@@ -87,6 +88,10 @@ void GeneralConf::_updateComponents(bool allowEmptySavePath)
     m_showMagnifier->setChecked(config.showMagnifier());
     m_squareMagnifier->setChecked(config.squareMagnifier());
     m_saveLastRegion->setChecked(config.saveLastRegion());
+    m_useExtPgm->setChecked(config.useDefaultExtPgm());
+    m_useExtPgmTerm->setChecked(config.extPgmTerminal());
+    m_showSelectionGeometry->setChecked(config.showSelectionGeometry());
+    m_xywhTimeout->setValue(config.showSelectionGeometryHideTime());
 
 #if !defined(Q_OS_WIN)
     m_autoCloseIdleDaemon->setChecked(config.autoCloseIdleDaemon());
@@ -709,12 +714,29 @@ void GeneralConf::initSquareMagnifier()
     });
 }
 
+void GeneralConf::initExtPgm()
+{
+    m_useExtPgm =
+      new QCheckBox(tr("Use default program (set program via launcher)"), this);
+    m_useExtPgmTerm =
+      new QCheckBox(tr("Default program run in terminal"), this);
+    m_scrollAreaLayout->addWidget(m_useExtPgm);
+    m_scrollAreaLayout->addWidget(m_useExtPgmTerm);
+    connect(m_useExtPgm, &QCheckBox::clicked, [](bool checked) {
+        ConfigHandler().setUseDefaultExtPgm(checked);
+    });
+    connect(m_useExtPgmTerm, &QCheckBox::clicked, [](bool checked) {
+        ConfigHandler().setExtPgmTerminal(checked);
+    });
+    m_useExtPgm->setChecked(ConfigHandler().useDefaultExtPgm());
+    m_useExtPgmTerm->setChecked(ConfigHandler().extPgmTerminal());
+}
+
 void GeneralConf::initShowSelectionGeometry()
 {
     auto* tobox = new QHBoxLayout();
 
-    int timeout =
-      ConfigHandler().value("showSelectionGeometryHideTime").toInt();
+    int timeout = ConfigHandler().showSelectionGeometryHideTime();
     m_xywhTimeout = new QSpinBox();
     m_xywhTimeout->setRange(0, INT_MAX);
     m_xywhTimeout->setToolTip(
@@ -751,7 +773,7 @@ void GeneralConf::initShowSelectionGeometry()
     m_selectGeometryLocation->addItem(tr("Center"), GeneralConf::xywh_center);
 
     // pick up int from config and use findData
-    int pos = ConfigHandler().value("showSelectionGeometry").toInt();
+    int pos = ConfigHandler().showSelectionGeometry();
     m_selectGeometryLocation->setCurrentIndex(
       m_selectGeometryLocation->findData(pos));
 
@@ -767,7 +789,7 @@ void GeneralConf::initShowSelectionGeometry()
 
 void GeneralConf::setSelGeoHideTime(int v)
 {
-    ConfigHandler().setValue("showSelectionGeometryHideTime", v);
+    ConfigHandler().setShowSelectionGeometryHideTime(v);
 }
 
 void GeneralConf::setGeometryLocation(int index)

--- a/src/config/generalconf.h
+++ b/src/config/generalconf.h
@@ -125,7 +125,6 @@ private:
     QCheckBox* m_showMagnifier;
     QCheckBox* m_squareMagnifier;
     QCheckBox* m_copyOnDoubleClick;
-    QCheckBox* m_showSelectionGeometry;
     QComboBox* m_selectGeometryLocation;
     QSpinBox* m_xywhTimeout;
     QCheckBox* m_useExtPgm;

--- a/src/config/generalconf.h
+++ b/src/config/generalconf.h
@@ -86,6 +86,7 @@ private:
     void initUploadClientSecret();
     void initSaveLastRegion();
     void initShowSelectionGeometry();
+    void initExtPgm();
 
     void _updateComponents(bool allowEmptySavePath);
 
@@ -127,4 +128,6 @@ private:
     QCheckBox* m_showSelectionGeometry;
     QComboBox* m_selectGeometryLocation;
     QSpinBox* m_xywhTimeout;
+    QCheckBox* m_useExtPgm;
+    QCheckBox* m_useExtPgmTerm;
 };

--- a/src/tools/capturecontext.h
+++ b/src/tools/capturecontext.h
@@ -32,6 +32,8 @@ struct CaptureContext
     // Mode of the capture widget
     bool fullscreen;
     CaptureRequest request = CaptureRequest::GRAPHICAL_MODE;
+    // mouse modifiers
+    Qt::KeyboardModifiers mouseModifiers = Qt::NoModifier;
 
     QPixmap selectedScreenshotArea() const;
 };

--- a/src/tools/capturetool.h
+++ b/src/tools/capturetool.h
@@ -75,7 +75,9 @@ public:
         // increase tool size for all tools
         REQ_INCREASE_TOOL_SIZE,
         // decrease tool size for all tools
-        REQ_DECREASE_TOOL_SIZE
+        REQ_DECREASE_TOOL_SIZE,
+        // External Widget with ALT modifier
+        REQ_ADD_EXTERNAL_WIDGETS_ALT
     };
 
     explicit CaptureTool(QObject* parent = nullptr)
@@ -121,6 +123,7 @@ public:
     // If the type is TYPE_EXTERNAL_WIDGET it is created outside as an
     // individual widget.
     virtual QWidget* widget() { return nullptr; }
+    virtual QWidget* widget(bool alt) { return widget(); }
     // When the tool is selected this method is called and the widget is added
     // to the configuration panel inside the main widget.
     virtual QWidget* configurationWidget() { return nullptr; }

--- a/src/tools/launcher/applaunchertool.cpp
+++ b/src/tools/launcher/applaunchertool.cpp
@@ -38,6 +38,11 @@ QWidget* AppLauncher::widget()
     return new AppLauncherWidget(capture);
 }
 
+QWidget* AppLauncher::widget(bool alt)
+{
+    return new AppLauncherWidget(capture, alt);
+}
+
 CaptureTool* AppLauncher::copy(QObject* parent)
 {
     return new AppLauncher(parent);
@@ -47,6 +52,9 @@ void AppLauncher::pressed(CaptureContext& context)
 {
     capture = context.selectedScreenshotArea();
     emit requestAction(REQ_CAPTURE_DONE_OK);
-    emit requestAction(REQ_ADD_EXTERNAL_WIDGETS);
+    if (context.mouseModifiers & Qt::AltModifier) {
+        emit requestAction(REQ_ADD_EXTERNAL_WIDGETS_ALT);
+    } else
+        emit requestAction(REQ_ADD_EXTERNAL_WIDGETS);
     emit requestAction(REQ_CLOSE_GUI);
 }

--- a/src/tools/launcher/applaunchertool.h
+++ b/src/tools/launcher/applaunchertool.h
@@ -18,6 +18,7 @@ public:
     QString description() const override;
 
     QWidget* widget() override;
+    QWidget* widget(bool alt = false) override;
 
     CaptureTool* copy(QObject* parent = nullptr) override;
 

--- a/src/tools/launcher/applauncherwidget.cpp
+++ b/src/tools/launcher/applauncherwidget.cpp
@@ -34,13 +34,15 @@ QMap<QString, QString> catIconNames(
     { "Utility", "applications-utilities" } });
 }
 
-AppLauncherWidget::AppLauncherWidget(const QPixmap& p, QWidget* parent)
+AppLauncherWidget::AppLauncherWidget(const QPixmap& p,
+                                     bool alt,
+                                     QWidget* parent)
   : QWidget(parent)
   , m_pixmap(p)
 {
     QString cmd = ConfigHandler().extPgm();
     setAttribute(Qt::WA_DeleteOnClose);
-    if (ConfigHandler().useDefaultExtPgm() == false || cmd.isEmpty()) {
+    if (ConfigHandler().useDefaultExtPgmOnAlt() == alt || cmd.isEmpty()) {
         setWindowIcon(QIcon(GlobalValues::iconPath()));
         setWindowTitle(tr("Open With"));
 
@@ -106,7 +108,7 @@ void AppLauncherWidget::launch(const QModelIndex& index)
         ConfigHandler().setExtPgmTerminal(inTerminal);
         // we assume if we are setting the default program we also want to use
         // it
-        ConfigHandler().setUseDefaultExtPgm(true);
+        ConfigHandler().setUseDefaultExtPgmOnAlt(true);
     }
     launchCmd(command, inTerminal);
 }

--- a/src/tools/launcher/applauncherwidget.h
+++ b/src/tools/launcher/applauncherwidget.h
@@ -17,7 +17,9 @@ class AppLauncherWidget : public QWidget
 {
     Q_OBJECT
 public:
-    explicit AppLauncherWidget(const QPixmap& p, QWidget* parent = nullptr);
+    explicit AppLauncherWidget(const QPixmap& p,
+                               bool alt = false,
+                               QWidget* parent = nullptr);
 
 private slots:
     void launch(const QModelIndex& index);

--- a/src/tools/launcher/applauncherwidget.h
+++ b/src/tools/launcher/applauncherwidget.h
@@ -21,6 +21,7 @@ public:
 
 private slots:
     void launch(const QModelIndex& index);
+    void launchCmd(QString& command, bool inTerminal);
     void checkboxClicked(const bool enabled);
     void searchChanged(const QString& text);
 
@@ -37,6 +38,7 @@ private:
     QString m_tempFile;
     bool m_keepOpen;
     QMap<QString, QVector<DesktopAppData>> m_appsMap;
+    QCheckBox* m_setAsDefaultCheckbox;
     QCheckBox* m_keepOpenCheckbox;
     QCheckBox* m_terminalCheckbox;
     QVBoxLayout* m_layout;

--- a/src/utils/confighandler.cpp
+++ b/src/utils/confighandler.cpp
@@ -124,7 +124,7 @@ static QMap<class QString, QSharedPointer<ValueHandler>>
     OPTION("showSelectionGeometry"  , BoundedInt               (0,5,4)),
     OPTION("showSelectionGeometryHideTime", LowerBoundedInt       (0, 3000)),
     OPTION("extPgm"                     ,String             ( ""                )),
-    OPTION("useDefaultExtPgm"           ,Bool                ( false             )),
+    OPTION("useDefaultExtPgmOnAlt"      ,Bool                ( true             )),
     OPTION("extPgmTerminal"             ,Bool               ( false              ))
 };
 

--- a/src/utils/confighandler.cpp
+++ b/src/utils/confighandler.cpp
@@ -122,7 +122,10 @@ static QMap<class QString, QSharedPointer<ValueHandler>>
     OPTION("copyOnDoubleClick"           ,Bool               ( false         )),
     OPTION("uploadClientSecret"          ,String             ( "313baf0c7b4d3ff"            )),
     OPTION("showSelectionGeometry"  , BoundedInt               (0,5,4)),
-    OPTION("showSelectionGeometryHideTime", LowerBoundedInt       (0, 3000))
+    OPTION("showSelectionGeometryHideTime", LowerBoundedInt       (0, 3000)),
+    OPTION("extPgm"                     ,String             ( ""                )),
+    OPTION("useDefaultExtPgm"           ,Bool                ( false             )),
+    OPTION("extPgmTerminal"             ,Bool               ( false              ))
 };
 
 static QMap<QString, QSharedPointer<KeySequence>> recognizedShortcuts = {

--- a/src/utils/confighandler.h
+++ b/src/utils/confighandler.h
@@ -124,7 +124,7 @@ public:
     CONFIG_GETTER_SETTER(showSelectionGeometryHideTime,
                          setShowSelectionGeometryHideTime,
                          int);
-    CONFIG_GETTER_SETTER(useDefaultExtPgm, setUseDefaultExtPgm, bool)
+    CONFIG_GETTER_SETTER(useDefaultExtPgmOnAlt, setUseDefaultExtPgmOnAlt, bool)
     CONFIG_GETTER_SETTER(extPgm, setExtPgm, QString)
     CONFIG_GETTER_SETTER(extPgmTerminal, setExtPgmTerminal, bool)
     // SPECIAL CASES

--- a/src/utils/confighandler.h
+++ b/src/utils/confighandler.h
@@ -121,6 +121,12 @@ public:
     CONFIG_GETTER_SETTER(uploadClientSecret, setUploadClientSecret, QString)
     CONFIG_GETTER_SETTER(saveLastRegion, setSaveLastRegion, bool)
     CONFIG_GETTER_SETTER(showSelectionGeometry, setShowSelectionGeometry, int)
+    CONFIG_GETTER_SETTER(showSelectionGeometryHideTime,
+                         setShowSelectionGeometryHideTime,
+                         int);
+    CONFIG_GETTER_SETTER(useDefaultExtPgm, setUseDefaultExtPgm, bool)
+    CONFIG_GETTER_SETTER(extPgm, setExtPgm, QString)
+    CONFIG_GETTER_SETTER(extPgmTerminal, setExtPgmTerminal, bool)
     // SPECIAL CASES
     bool startupLaunch();
     void setStartupLaunch(const bool);

--- a/src/widgets/capture/capturetoolbutton.cpp
+++ b/src/widgets/capture/capturetoolbutton.cpp
@@ -99,6 +99,7 @@ QIcon CaptureToolButton::icon() const
 void CaptureToolButton::mousePressEvent(QMouseEvent* e)
 {
     activateWindow();
+    mouseModifier = e->modifiers();
     if (e->button() == Qt::LeftButton) {
         emit pressedButtonLeftClick(this);
         emit pressed();

--- a/src/widgets/capture/capturetoolbutton.h
+++ b/src/widgets/capture/capturetoolbutton.h
@@ -27,6 +27,7 @@ public:
     QString description() const;
     QIcon icon() const;
     CaptureTool* tool() const;
+    Qt::KeyboardModifiers mouseModifier = Qt::NoModifier;
 
     void setColor(const QColor& c);
     void animatedShow();

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -387,8 +387,7 @@ void CaptureWidget::xywhTick()
 
 void CaptureWidget::showxywh(bool show)
 {
-    int timeout =
-      ConfigHandler().value("showSelectionGeometryHideTime").toInt();
+    int timeout = ConfigHandler().showSelectionGeometryHideTime();
     m_xywhDisplay = show;
     m_xywhTimer.stop();
     repaint();
@@ -512,13 +511,13 @@ void CaptureWidget::paintEvent(QPaintEvent* paintEvent)
     QPainter painter(this);
     GeneralConf::xywh_position position =
       static_cast<GeneralConf::xywh_position>(
-        ConfigHandler().value("showSelectionGeometry").toInt());
+        ConfigHandler().showSelectionGeometry());
     /* QPainter::save and restore is somewhat costly so we try to guess
        if we need to do it here. What that means is that if you add
        anything to the paintEvent and want to save/restore you should
        add a test to the below if statement -- also if you change
-       any of the conditions that current trigger it you'll need to change here,
-       too
+       any of the conditions that current trigger it you'll need to change
+       here, too
     */
     bool save = false;
     if (((position != GeneralConf::xywh_none &&
@@ -1226,6 +1225,7 @@ void CaptureWidget::setState(CaptureToolButton* b)
         // The tool is active during the pressed().
         // This must be done in order to handle tool requests correctly.
         m_activeTool = b->tool();
+        m_context.mouseModifiers = b->mouseModifier;
         m_activeTool->pressed(m_context);
         m_activeTool = backup;
     }
@@ -1297,10 +1297,16 @@ void CaptureWidget::handleToolSignal(CaptureTool::Request r)
             }
             break;
         case CaptureTool::REQ_ADD_EXTERNAL_WIDGETS:
+        case CaptureTool::REQ_ADD_EXTERNAL_WIDGETS_ALT:
             if (!m_activeTool) {
                 break;
             } else {
-                QWidget* w = m_activeTool->widget();
+                QWidget* w;
+                if (r == CaptureTool::REQ_ADD_EXTERNAL_WIDGETS_ALT)
+                    w = m_activeTool->widget();
+                else
+                    w = m_activeTool->widget(true);
+
                 w->setAttribute(Qt::WA_DeleteOnClose);
                 w->activateWindow();
                 w->show();


### PR DESCRIPTION
As discussed in #2091 this is my take on allowing a default external app. The changes are:

1. Modifier state is captured with mouse input and made available "upstream"
2. By default, there is no default program set and until there is, nothing is different than before
3. When launching an external program, there is a new checkbox to make the program the default
4. If a default program is set, by default Alt+Click on the external tool launches with no dialog; Click operates as usual
5. There is an option to swap the Alt+Click behavior with click (e.g., Alt+Click opens dialog, click opens default)

If there is no default Alt+Click and Click are the same.

We may not need to expose the run in terminal option to the user?

Could probably use better popout text on the help for the option

There are a few other misc changes in here to clean up some of the options stuff from the XYWH change; also a quick write-up on how to add a new option.

Note there is also a new request for the Alt+Click that is consumed as a click by anything else. However, it would be possible to add shift, click, control modifiers to other tools using this much more easily.

