### PR TITLE
fixed capturewidget on windows with multiple monitors

### DIFF
--- a/src/core/flameshot.cpp
+++ b/src/core/flameshot.cpp
@@ -116,7 +116,7 @@ CaptureWidget* Flameshot::gui(const CaptureRequest& req)
         m_captureWindow = new CaptureWidget(req);
 
 #ifdef Q_OS_WIN
-        m_captureWindow->show();
+        // m_captureWindow->show(); // No more needed
 #elif defined(Q_OS_MACOS)
         // In "Emulate fullscreen mode"
         m_captureWindow->showFullScreen();

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -132,9 +132,6 @@ CaptureWidget::CaptureWidget(const CaptureRequest& req,
                 topLeft.setY(topLeftScreen.y());
             }
         }
-        show();
-        move(topLeft);
-        resize(pixmap().size());
 #elif defined(Q_OS_MACOS)
         // Emulate fullscreen mode
         //        setWindowFlags(Qt::WindowStaysOnTopHint |
@@ -254,6 +251,10 @@ CaptureWidget::CaptureWidget(const CaptureRequest& req,
     }
 
     updateCursor();
+
+    show();
+    move(topLeft);
+    resize(pixmap().size());
 }
 
 CaptureWidget::~CaptureWidget()

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -132,6 +132,7 @@ CaptureWidget::CaptureWidget(const CaptureRequest& req,
                 topLeft.setY(topLeftScreen.y());
             }
         }
+        show();
         move(topLeft);
         resize(pixmap().size());
 #elif defined(Q_OS_MACOS)


### PR DESCRIPTION
### Problem:
I have two displays, but when I try to take a screenshot, only one displays

![only one monitor gui](https://user-images.githubusercontent.com/5127671/182245696-9c8e3f91-12b2-46d7-8601-6e810362fe3c.png)

### For reproduce:
  -  Place the second display to the left of the main display
  - This will make negative coordinates for him.
  - Then try to take a screenshot and it will set the window top left corner to x: 0 y: 0. But should be in this case at x: -1920 y: 0

### System:
  -   Flameshot v12.1.0 (96c2c82e) Compiled with Qt 5.15.2
  -  windows 10.0.19044