### PR TITLE
Recognize Qtile WM

### DIFF
--- a/src/utils/desktopinfo.cpp
+++ b/src/utils/desktopinfo.cpp
@@ -31,6 +31,9 @@ DesktopInfo::WM DesktopInfo::windowManager()
         if (desktop.contains(QLatin1String("GNOME"), Qt::CaseInsensitive)) {
             return DesktopInfo::GNOME;
         }
+        if (desktop.contains(QLatin1String("qtile"), Qt::CaseInsensitive)) {
+            return DesktopInfo::QTILE;
+        }
         if (desktop.contains(QLatin1String("sway"), Qt::CaseInsensitive)) {
             return DesktopInfo::SWAY;
         }

--- a/src/utils/desktopinfo.h
+++ b/src/utils/desktopinfo.h
@@ -15,6 +15,7 @@ public:
         GNOME,
         KDE,
         OTHER,
+        QTILE,
         SWAY
     };
 

--- a/src/utils/screengrabber.cpp
+++ b/src/utils/screengrabber.cpp
@@ -102,6 +102,7 @@ QPixmap ScreenGrabber::grabEntireDesktop(bool& ok)
         switch (m_info.windowManager()) {
             case DesktopInfo::GNOME:
             case DesktopInfo::KDE:
+            case DesktopInfo::QTILE:
             case DesktopInfo::SWAY: {
                 freeDesktopPortal(ok, res);
                 break;
@@ -110,7 +111,7 @@ QPixmap ScreenGrabber::grabEntireDesktop(bool& ok)
                 ok = false;
                 AbstractLogger::error()
                   << tr("Unable to detect desktop environment (GNOME? KDE? "
-                        "Sway? ...)");
+                        "Qile? Sway? ...)");
                 AbstractLogger::error()
                   << tr("Hint: try setting the XDG_CURRENT_DESKTOP environment "
                         "variable.");


### PR DESCRIPTION
Without this Flameshot won't work on Qtile Wayland.

An alternative would be to stop focuing on individual WMs and replace `SWAY` with `GENERIC_WAYLAND` and assigning recognized strings to that, or something similar, which would remove the need of explicitly having each recognized WM in the enum. Happy to amend the PR according to that if desired.