### PR TITLE
flameshot#2856: Display main key in keyboard shortcut as lower-case

### DIFF
--- a/src/utils/valuehandler.cpp
+++ b/src/utils/valuehandler.cpp
@@ -210,7 +210,7 @@ bool KeySequence::check(const QVariant& val)
 
 QVariant KeySequence::fallback()
 {
-    return m_fallback;
+    return process(m_fallback);
 }
 
 QString KeySequence::expected()
@@ -232,6 +232,11 @@ QVariant KeySequence::process(const QVariant& val)
     QString str(val.toString());
     if (str == "Enter") {
         return QKeySequence(Qt::Key_Return).toString();
+    }
+    if (str.length() > 0) {
+        // Make the "main" key in sequence (last one) lower-case.
+        const QCharRef& lastChar = str[str.length() - 1];
+        str.replace(str.length() - 1, 1, lastChar.toLower());
     }
     return str;
 }


### PR DESCRIPTION
# Description
This pull request proposes to display the main key of a key shortcut in lowercase instead of uppercase. For the motivation behind this change, see the discussion on the issue. Screenshots of this fix follow below. 

Lowercase s and c in ⌘s and ⌘c in the help screen.
<img width="314" alt="HelpScreenWithLowerCaseShortcuts" src="https://user-images.githubusercontent.com/12563382/193934323-6f6cb577-1606-47a4-accf-1010ac0785ab.png">

Lowercase shortcuts in the shortcut configuration screen.
<img width="591" alt="image" src="https://user-images.githubusercontent.com/12563382/193934557-cd095508-80e3-4858-bc6c-30f3d3704b5b.png">

Lowercase shortcuts in the capture tool tips.
<img width="343" alt="image" src="https://user-images.githubusercontent.com/12563382/193934848-0bdd8716-c5f0-4d55-988e-54a573ad5e31.png">

# Issue
#2856