### PR TITLE
Fix documentation of `flameshot gui --help`

### DIFF
--- a/data/man/man1/flameshot.1
+++ b/data/man/man1/flameshot.1
@@ -125,7 +125,7 @@ Valid for subcommands: config
 .PP
 \-g, \-\-print-geometry
 .RS 4
-Print geometry of the selection in the format W H X Y. Does nothing if raw is specified
+Print geometry of the selection in the format WxH+X+Y. Does nothing if raw is specified
 .br
 Valid for subcommands: gui
 .RE

--- a/data/shell-completion/flameshot.zsh
+++ b/data/shell-completion/flameshot.zsh
@@ -22,7 +22,7 @@ _flameshot_gui_opts=(
     {-d,--delay}'[Delay time in milliseconds]'
     "--region[Screenshot region to select <WxH+X+Y or string>]"
     {-r,--raw}'[Print raw PNG capture]'
-    {-g,--print-geometry}'[Print geometry of the selection in the format W H X Y. Does nothing if raw is specified]'
+    {-g,--print-geometry}'[Print geometry of the selection in the format WxH+X+Y. Does nothing if raw is specified]'
     {-u,--upload}'[Upload screenshot]'
     "--pin[Pin the capture to the screen]"
     {-s,--accept-on-select}'[Accept capture as soon as a selection is made]'

--- a/data/translations/Internationalization_bg.ts
+++ b/data/translations/Internationalization_bg.ts
@@ -1883,8 +1883,8 @@ Please solve them manually in the configuration file.</translation>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="219"/>
-        <source>Print geometry of the selection in the format W H X Y. Does nothing if raw is specified</source>
-        <translation>Print geometry of the selection in the format W H X Y. Does nothing if raw is specified</translation>
+        <source>Print geometry of the selection in the format WxH+X+Y. Does nothing if raw is specified</source>
+        <translation>Print geometry of the selection in the format WxH+X+Y. Does nothing if raw is specified</translation>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="223"/>

--- a/data/translations/Internationalization_ca.ts
+++ b/data/translations/Internationalization_ca.ts
@@ -1891,8 +1891,8 @@ Please solve them manually in the configuration file.</translation>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="219"/>
-        <source>Print geometry of the selection in the format W H X Y. Does nothing if raw is specified</source>
-        <translation>Print geometry of the selection in the format W H X Y. Does nothing if raw is specified</translation>
+        <source>Print geometry of the selection in the format WxH+X+Y. Does nothing if raw is specified</source>
+        <translation>Print geometry of the selection in the format WxH+X+Y. Does nothing if raw is specified</translation>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="223"/>

--- a/data/translations/Internationalization_cs.ts
+++ b/data/translations/Internationalization_cs.ts
@@ -1962,7 +1962,7 @@ Vyřešte je, prosím, ručně v souboru s nastavením.</translation>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="219"/>
-        <source>Print geometry of the selection in the format W H X Y. Does nothing if raw is specified</source>
+        <source>Print geometry of the selection in the format WxH+X+Y. Does nothing if raw is specified</source>
         <translation>Zobrazit natočení výběru ve formátu Š V X Y. Nedělá nic, pokud je zadáno nezpracovaný</translation>
     </message>
     <message>

--- a/data/translations/Internationalization_da.ts
+++ b/data/translations/Internationalization_da.ts
@@ -1538,7 +1538,7 @@ Please solve them manually in the configuration file.</source>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="213"/>
-        <source>Print geometry of the selection in the format W H X Y. Does nothing if raw is specified</source>
+        <source>Print geometry of the selection in the format WxH+X+Y. Does nothing if raw is specified</source>
         <translation></translation>
     </message>
     <message>

--- a/data/translations/Internationalization_de_DE.ts
+++ b/data/translations/Internationalization_de_DE.ts
@@ -1915,7 +1915,7 @@ Bitte beseitige sie manuell in der Konfigurationsdatei.</translation>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="219"/>
-        <source>Print geometry of the selection in the format W H X Y. Does nothing if raw is specified</source>
+        <source>Print geometry of the selection in the format WxH+X+Y. Does nothing if raw is specified</source>
         <translation>Geometrie der Auswahl im Format B H X Y ausgeben. Ignoriert, falls raw ausgewählt ist</translation>
     </message>
     <message>

--- a/data/translations/Internationalization_el.ts
+++ b/data/translations/Internationalization_el.ts
@@ -1891,8 +1891,8 @@ Please solve them manually in the configuration file.</source>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="219"/>
-        <source>Print geometry of the selection in the format W H X Y. Does nothing if raw is specified</source>
-        <translation>Εκτύπωση γεωμετρίας της επιλογής στη μορφή W H X Y. Δεν κάνει τίποτα εάν έχει καθοριστεί raw</translation>
+        <source>Print geometry of the selection in the format WxH+X+Y. Does nothing if raw is specified</source>
+        <translation>Εκτύπωση γεωμετρίας της επιλογής στη μορφή WxH+X+Y. Δεν κάνει τίποτα εάν έχει καθοριστεί raw</translation>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="223"/>

--- a/data/translations/Internationalization_es.ts
+++ b/data/translations/Internationalization_es.ts
@@ -1914,8 +1914,8 @@ Por favor, resuélvelos manualmente en el archivo de configuración.</translatio
     </message>
     <message>
         <location filename="../../src/main.cpp" line="219"/>
-        <source>Print geometry of the selection in the format W H X Y. Does nothing if raw is specified</source>
-        <translation>Imprimir geometría de la selección en el formato W H X Y. No hace nada si se especifica que no se procese</translation>
+        <source>Print geometry of the selection in the format WxH+X+Y. Does nothing if raw is specified</source>
+        <translation>Imprimir geometría de la selección en el formato WxH+X+Y. No hace nada si se especifica que no se procese</translation>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="223"/>

--- a/data/translations/Internationalization_eu.ts
+++ b/data/translations/Internationalization_eu.ts
@@ -1950,8 +1950,8 @@ Please solve them manually in the configuration file.</translation>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="219"/>
-        <source>Print geometry of the selection in the format W H X Y. Does nothing if raw is specified</source>
-        <translation>Inprimatu hautapenaren geometria W H X Y formatuan (Zabalera, Altuera, X ardatza, Y ardatza). Ez du ezer egiten jatorrizkoa zehazten bada</translation>
+        <source>Print geometry of the selection in the format WxH+X+Y. Does nothing if raw is specified</source>
+        <translation>Inprimatu hautapenaren geometria WxH+X+Y formatuan (Zabalera, Altuera, X ardatza, Y ardatza). Ez du ezer egiten jatorrizkoa zehazten bada</translation>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="223"/>

--- a/data/translations/Internationalization_fa.ts
+++ b/data/translations/Internationalization_fa.ts
@@ -1887,8 +1887,8 @@ Please solve them manually in the configuration file.</translation>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="219"/>
-        <source>Print geometry of the selection in the format W H X Y. Does nothing if raw is specified</source>
-        <translation>مختصات گزیده را در قالب «W H X Y» چاپ می‌کند. اگر چیزی مشخص نشده باشد، هیچ کاری انجام نمی‌دهد</translation>
+        <source>Print geometry of the selection in the format WxH+X+Y. Does nothing if raw is specified</source>
+        <translation>مختصات گزیده را در قالب «WxH+X+Y» چاپ می‌کند. اگر چیزی مشخص نشده باشد، هیچ کاری انجام نمی‌دهد</translation>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="223"/>

--- a/data/translations/Internationalization_fi.ts
+++ b/data/translations/Internationalization_fi.ts
@@ -1891,7 +1891,7 @@ Ratkaise ne käsin muuttamalla asetustiedostoa.</translation>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="219"/>
-        <source>Print geometry of the selection in the format W H X Y. Does nothing if raw is specified</source>
+        <source>Print geometry of the selection in the format WxH+X+Y. Does nothing if raw is specified</source>
         <translation>Tulosta valinta sivuasetuksilla muodossa L K X Y. Ei tee mitään, jos raaka on määritetty</translation>
     </message>
     <message>

--- a/data/translations/Internationalization_fr.ts
+++ b/data/translations/Internationalization_fr.ts
@@ -1906,8 +1906,8 @@ Veuillez résoudre ce problème manuellement depuis le fichier de configuration.
     </message>
     <message>
         <location filename="../../src/main.cpp" line="219"/>
-        <source>Print geometry of the selection in the format W H X Y. Does nothing if raw is specified</source>
-        <translation>Print geometry of the selection in the format W H X Y. Does nothing if raw is specified</translation>
+        <source>Print geometry of the selection in the format WxH+X+Y. Does nothing if raw is specified</source>
+        <translation>Print geometry of the selection in the format WxH+X+Y. Does nothing if raw is specified</translation>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="223"/>

--- a/data/translations/Internationalization_gl.ts
+++ b/data/translations/Internationalization_gl.ts
@@ -1883,8 +1883,8 @@ Please solve them manually in the configuration file.</translation>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="219"/>
-        <source>Print geometry of the selection in the format W H X Y. Does nothing if raw is specified</source>
-        <translation>Print geometry of the selection in the format W H X Y. Does nothing if raw is specified</translation>
+        <source>Print geometry of the selection in the format WxH+X+Y. Does nothing if raw is specified</source>
+        <translation>Print geometry of the selection in the format WxH+X+Y. Does nothing if raw is specified</translation>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="223"/>

--- a/data/translations/Internationalization_grc.ts
+++ b/data/translations/Internationalization_grc.ts
@@ -1076,8 +1076,8 @@ Press Space to open the side panel.</translation>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="183"/>
-        <source>Print geometry of the selection in the format W H X Y. Does nothing if raw is specified</source>
-        <translation>Print geometry of the selection in the format W H X Y. Does nothing if raw is specified</translation>
+        <source>Print geometry of the selection in the format WxH+X+Y. Does nothing if raw is specified</source>
+        <translation>Print geometry of the selection in the format WxH+X+Y. Does nothing if raw is specified</translation>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="187"/>

--- a/data/translations/Internationalization_he.ts
+++ b/data/translations/Internationalization_he.ts
@@ -1899,8 +1899,8 @@ Please solve them manually in the configuration file.</source>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="219"/>
-        <source>Print geometry of the selection in the format W H X Y. Does nothing if raw is specified</source>
-        <translation>הדפסת גאומטרית הבחירה בתבנית W H X Y. לא עושה דבר אם צוין &apos;גלמי&apos;</translation>
+        <source>Print geometry of the selection in the format WxH+X+Y. Does nothing if raw is specified</source>
+        <translation>הדפסת גאומטרית הבחירה בתבנית WxH+X+Y. לא עושה דבר אם צוין &apos;גלמי&apos;</translation>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="223"/>

--- a/data/translations/Internationalization_hu.ts
+++ b/data/translations/Internationalization_hu.ts
@@ -1673,7 +1673,7 @@ Lehet, hogy meg kepp adnod egy &apos;\&apos; karaktert a &apos;#&apos; karakter 
         <translation>A Flameshot alapértelmezés szerint fut a háttérben és ikont helyez el a tálcán a beállítások elérése érdekében.</translation>
     </message>
     <message>
-        <source>Print geometry of the selection in the format W H X Y. Does nothing if raw is specified</source>
+        <source>Print geometry of the selection in the format WxH+X+Y. Does nothing if raw is specified</source>
         <translation>A kijelölés geometriáját írja ki Sz M X Y (Szélesség Magasság X pozíció Y pozíció) formátumban. Nem csinál semmit, hogyha a nyers opció aktív</translation>
     </message>
     <message>

--- a/data/translations/Internationalization_id.ts
+++ b/data/translations/Internationalization_id.ts
@@ -1899,8 +1899,8 @@ Mohon atasi mereka secara manual di file konfigurasi.</translation>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="219"/>
-        <source>Print geometry of the selection in the format W H X Y. Does nothing if raw is specified</source>
-        <translation>Cetak geometri pilihan dalam format W H X Y. Tidak melakukan apa pun jika raw ditentukan</translation>
+        <source>Print geometry of the selection in the format WxH+X+Y. Does nothing if raw is specified</source>
+        <translation>Cetak geometri pilihan dalam format WxH+X+Y. Tidak melakukan apa pun jika raw ditentukan</translation>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="223"/>

--- a/data/translations/Internationalization_it_IT.ts
+++ b/data/translations/Internationalization_it_IT.ts
@@ -1736,8 +1736,8 @@ Si prega di risolverli manualmente nel file di configurazione.</translation>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="219"/>
-        <source>Print geometry of the selection in the format W H X Y. Does nothing if raw is specified</source>
-        <translation>Stampa la geometria della selezione nel formato W H X Y. Non fa nulla se raw è specificato</translation>
+        <source>Print geometry of the selection in the format WxH+X+Y. Does nothing if raw is specified</source>
+        <translation>Stampa la geometria della selezione nel formato WxH+X+Y. Non fa nulla se raw è specificato</translation>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="223"/>

--- a/data/translations/Internationalization_ja.ts
+++ b/data/translations/Internationalization_ja.ts
@@ -1890,8 +1890,8 @@ Please solve them manually in the configuration file.</translation>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="219"/>
-        <source>Print geometry of the selection in the format W H X Y. Does nothing if raw is specified</source>
-        <translation>Print geometry of the selection in the format W H X Y. Does nothing if raw is specified</translation>
+        <source>Print geometry of the selection in the format WxH+X+Y. Does nothing if raw is specified</source>
+        <translation>Print geometry of the selection in the format WxH+X+Y. Does nothing if raw is specified</translation>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="223"/>

--- a/data/translations/Internationalization_ka.ts
+++ b/data/translations/Internationalization_ka.ts
@@ -1882,8 +1882,8 @@ Please solve them manually in the configuration file.</translation>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="219"/>
-        <source>Print geometry of the selection in the format W H X Y. Does nothing if raw is specified</source>
-        <translation>Print geometry of the selection in the format W H X Y. Does nothing if raw is specified</translation>
+        <source>Print geometry of the selection in the format WxH+X+Y. Does nothing if raw is specified</source>
+        <translation>Print geometry of the selection in the format WxH+X+Y. Does nothing if raw is specified</translation>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="223"/>

--- a/data/translations/Internationalization_ko.ts
+++ b/data/translations/Internationalization_ko.ts
@@ -1911,8 +1911,8 @@ Please solve them manually in the configuration file.</translation>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="219"/>
-        <source>Print geometry of the selection in the format W H X Y. Does nothing if raw is specified</source>
-        <translation>Print geometry of the selection in the format W H X Y. Does nothing if raw is specified</translation>
+        <source>Print geometry of the selection in the format WxH+X+Y. Does nothing if raw is specified</source>
+        <translation>Print geometry of the selection in the format WxH+X+Y. Does nothing if raw is specified</translation>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="223"/>

--- a/data/translations/Internationalization_nb_NO.ts
+++ b/data/translations/Internationalization_nb_NO.ts
@@ -1883,8 +1883,8 @@ Please solve them manually in the configuration file.</translation>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="219"/>
-        <source>Print geometry of the selection in the format W H X Y. Does nothing if raw is specified</source>
-        <translation>Print geometry of the selection in the format W H X Y. Does nothing if raw is specified</translation>
+        <source>Print geometry of the selection in the format WxH+X+Y. Does nothing if raw is specified</source>
+        <translation>Print geometry of the selection in the format WxH+X+Y. Does nothing if raw is specified</translation>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="223"/>

--- a/data/translations/Internationalization_nl.ts
+++ b/data/translations/Internationalization_nl.ts
@@ -1884,7 +1884,7 @@ Please solve them manually in the configuration file.</source>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="219"/>
-        <source>Print geometry of the selection in the format W H X Y. Does nothing if raw is specified</source>
+        <source>Print geometry of the selection in the format WxH+X+Y. Does nothing if raw is specified</source>
         <translation>Afmetingen van de selectie tonen in B H X Y. Niet van toepassing als &apos;onbewerkt&apos; is opgegeven.</translation>
     </message>
     <message>

--- a/data/translations/Internationalization_nl_NL.ts
+++ b/data/translations/Internationalization_nl_NL.ts
@@ -1910,8 +1910,8 @@ Los ze alstublieft handmatig op in het configuratiebestand.</translation>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="219"/>
-        <source>Print geometry of the selection in the format W H X Y. Does nothing if raw is specified</source>
-        <translation>Print de geometrie van de selectie in het formaat W H X Y. Doet niets als raw is opgegeven</translation>
+        <source>Print geometry of the selection in the format WxH+X+Y. Does nothing if raw is specified</source>
+        <translation>Print de geometrie van de selectie in het formaat WxH+X+Y. Doet niets als raw is opgegeven</translation>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="223"/>

--- a/data/translations/Internationalization_pl.ts
+++ b/data/translations/Internationalization_pl.ts
@@ -1922,8 +1922,8 @@ Rozwiąż błędy ręcznie w pliku konfiguracyjnym.</translation>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="219"/>
-        <source>Print geometry of the selection in the format W H X Y. Does nothing if raw is specified</source>
-        <translation>Drukuj geometrię zaznaczenia w formacie W H X Y. Brak efektu jeśli wybrano nieprzetwarzanie</translation>
+        <source>Print geometry of the selection in the format WxH+X+Y. Does nothing if raw is specified</source>
+        <translation>Drukuj geometrię zaznaczenia w formacie WxH+X+Y. Brak efektu jeśli wybrano nieprzetwarzanie</translation>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="223"/>

--- a/data/translations/Internationalization_pt_BR.ts
+++ b/data/translations/Internationalization_pt_BR.ts
@@ -1954,8 +1954,8 @@ Please solve them manually in the configuration file.</translation>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="219"/>
-        <source>Print geometry of the selection in the format W H X Y. Does nothing if raw is specified</source>
-        <translation>Imprime a geometria da seleção no formato W H X Y. Não faz nada se raw for especificado</translation>
+        <source>Print geometry of the selection in the format WxH+X+Y. Does nothing if raw is specified</source>
+        <translation>Imprime a geometria da seleção no formato WxH+X+Y. Não faz nada se raw for especificado</translation>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="223"/>

--- a/data/translations/Internationalization_ru.ts
+++ b/data/translations/Internationalization_ru.ts
@@ -2073,8 +2073,8 @@ Please solve them manually in the configuration file.</source>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="219"/>
-        <source>Print geometry of the selection in the format W H X Y. Does nothing if raw is specified</source>
-        <translation>Распечатать геометрию выделения в формате W H X Y. Ничего не делает, если указано raw</translation>
+        <source>Print geometry of the selection in the format WxH+X+Y. Does nothing if raw is specified</source>
+        <translation>Распечатать геометрию выделения в формате WxH+X+Y. Ничего не делает, если указано raw</translation>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="223"/>

--- a/data/translations/Internationalization_sk.ts
+++ b/data/translations/Internationalization_sk.ts
@@ -1908,7 +1908,7 @@ Riešte ich ručne v konfiguračnom súbore.</translation>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="219"/>
-        <source>Print geometry of the selection in the format W H X Y. Does nothing if raw is specified</source>
+        <source>Print geometry of the selection in the format WxH+X+Y. Does nothing if raw is specified</source>
         <translation>Zobraziť geometriu výberu vo formáte Š D X Y. Neurobí nič pri nastavení raw</translation>
     </message>
     <message>

--- a/data/translations/Internationalization_sr_SP.ts
+++ b/data/translations/Internationalization_sr_SP.ts
@@ -1894,8 +1894,8 @@ Please solve them manually in the configuration file.</translation>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="219"/>
-        <source>Print geometry of the selection in the format W H X Y. Does nothing if raw is specified</source>
-        <translation>Print geometry of the selection in the format W H X Y. Does nothing if raw is specified</translation>
+        <source>Print geometry of the selection in the format WxH+X+Y. Does nothing if raw is specified</source>
+        <translation>Print geometry of the selection in the format WxH+X+Y. Does nothing if raw is specified</translation>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="223"/>

--- a/data/translations/Internationalization_sv_SE.ts
+++ b/data/translations/Internationalization_sv_SE.ts
@@ -1894,8 +1894,8 @@ Please solve them manually in the configuration file.</translation>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="219"/>
-        <source>Print geometry of the selection in the format W H X Y. Does nothing if raw is specified</source>
-        <translation>Print geometry of the selection in the format W H X Y. Does nothing if raw is specified</translation>
+        <source>Print geometry of the selection in the format WxH+X+Y. Does nothing if raw is specified</source>
+        <translation>Print geometry of the selection in the format WxH+X+Y. Does nothing if raw is specified</translation>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="223"/>

--- a/data/translations/Internationalization_sw.ts
+++ b/data/translations/Internationalization_sw.ts
@@ -1885,7 +1885,7 @@ Please solve them manually in the configuration file.</source>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="219"/>
-        <source>Print geometry of the selection in the format W H X Y. Does nothing if raw is specified</source>
+        <source>Print geometry of the selection in the format WxH+X+Y. Does nothing if raw is specified</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/data/translations/Internationalization_ta.ts
+++ b/data/translations/Internationalization_ta.ts
@@ -1885,7 +1885,7 @@ Please solve them manually in the configuration file.</source>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="219"/>
-        <source>Print geometry of the selection in the format W H X Y. Does nothing if raw is specified</source>
+        <source>Print geometry of the selection in the format WxH+X+Y. Does nothing if raw is specified</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/data/translations/Internationalization_tr.ts
+++ b/data/translations/Internationalization_tr.ts
@@ -1906,8 +1906,8 @@ Lütfen bunları yapılandırma dosyasında elle çözün.</translation>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="219"/>
-        <source>Print geometry of the selection in the format W H X Y. Does nothing if raw is specified</source>
-        <translation>Seçimin geometrisini W H X Y biçiminde yazdırır. Raw belirtilirse hiçbir şey yapmaz</translation>
+        <source>Print geometry of the selection in the format WxH+X+Y. Does nothing if raw is specified</source>
+        <translation>Seçimin geometrisini WxH+X+Y biçiminde yazdırır. Raw belirtilirse hiçbir şey yapmaz</translation>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="223"/>

--- a/data/translations/Internationalization_uk.ts
+++ b/data/translations/Internationalization_uk.ts
@@ -2073,8 +2073,8 @@ Please solve them manually in the configuration file.</source>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="219"/>
-        <source>Print geometry of the selection in the format W H X Y. Does nothing if raw is specified</source>
-        <translation>Геометрія друку виділеного файлу у форматі W H X Y. Якщо нічого не вказано, нічого не робиться</translation>
+        <source>Print geometry of the selection in the format WxH+X+Y. Does nothing if raw is specified</source>
+        <translation>Геометрія друку виділеного файлу у форматі WxH+X+Y. Якщо нічого не вказано, нічого не робиться</translation>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="223"/>

--- a/data/translations/Internationalization_vi.ts
+++ b/data/translations/Internationalization_vi.ts
@@ -1883,8 +1883,8 @@ Please solve them manually in the configuration file.</translation>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="219"/>
-        <source>Print geometry of the selection in the format W H X Y. Does nothing if raw is specified</source>
-        <translation>Print geometry of the selection in the format W H X Y. Does nothing if raw is specified</translation>
+        <source>Print geometry of the selection in the format WxH+X+Y. Does nothing if raw is specified</source>
+        <translation>Print geometry of the selection in the format WxH+X+Y. Does nothing if raw is specified</translation>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="223"/>

--- a/data/translations/Internationalization_zh_CN.ts
+++ b/data/translations/Internationalization_zh_CN.ts
@@ -1959,8 +1959,8 @@ Please solve them manually in the configuration file.</source>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="219"/>
-        <source>Print geometry of the selection in the format W H X Y. Does nothing if raw is specified</source>
-        <translation>使用 W H X Y 的格式输出选区几何参数。如果指定了 raw 参数则什么也不做</translation>
+        <source>Print geometry of the selection in the format WxH+X+Y. Does nothing if raw is specified</source>
+        <translation>使用 WxH+X+Y 的格式输出选区几何参数。如果指定了 raw 参数则什么也不做</translation>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="223"/>

--- a/data/translations/Internationalization_zh_HK.ts
+++ b/data/translations/Internationalization_zh_HK.ts
@@ -1926,8 +1926,8 @@ Please solve them manually in the configuration file.</translation>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="219"/>
-        <source>Print geometry of the selection in the format W H X Y. Does nothing if raw is specified</source>
-        <translation>Print geometry of the selection in the format W H X Y. Does nothing if raw is specified</translation>
+        <source>Print geometry of the selection in the format WxH+X+Y. Does nothing if raw is specified</source>
+        <translation>Print geometry of the selection in the format WxH+X+Y. Does nothing if raw is specified</translation>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="223"/>

--- a/data/translations/Internationalization_zh_TW.ts
+++ b/data/translations/Internationalization_zh_TW.ts
@@ -1882,8 +1882,8 @@ Please solve them manually in the configuration file.</translation>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="219"/>
-        <source>Print geometry of the selection in the format W H X Y. Does nothing if raw is specified</source>
-        <translation>Print geometry of the selection in the format W H X Y. Does nothing if raw is specified</translation>
+        <source>Print geometry of the selection in the format WxH+X+Y. Does nothing if raw is specified</source>
+        <translation>Print geometry of the selection in the format WxH+X+Y. Does nothing if raw is specified</translation>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="223"/>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -221,7 +221,7 @@ int main(int argc, char* argv[])
                                  QObject::tr("Print raw PNG capture"));
     CommandOption selectionOption(
       { "g", "print-geometry" },
-      QObject::tr("Print geometry of the selection in the format W H X Y. Does "
+      QObject::tr("Print geometry of the selection in the format WxH+X+Y. Does "
                   "nothing if raw is specified"));
     CommandOption screenNumberOption(
       { "n", "number" },


### PR DESCRIPTION
In
https://github.com/flameshot-org/flameshot/commit/6432490c316baa89fe3f5a6910539a1157614577, the format of `--print-geometry` changed from `W H X Y` to `WxH+X+Y`, but it looks like we forgot to update the docs accordingly.