### PR TITLE
added functionality to save to disk on shift+double click

### DIFF
--- a/src/config/generalconf.cpp
+++ b/src/config/generalconf.cpp
@@ -48,6 +48,7 @@ GeneralConf::GeneralConf(QWidget* parent)
     initShowSidePanelButton();
     initUseJpgForClipboard();
     initCopyOnDoubleClick();
+    initSaveOnShiftDoubleClick();
     initSaveAfterCopy();
     initCopyPathAfterSave();
     initCopyAndCloseAfterUpload();
@@ -82,6 +83,7 @@ void GeneralConf::_updateComponents(bool allowEmptySavePath)
     m_antialiasingPinZoom->setChecked(config.antialiasingPinZoom());
     m_useJpgForClipboard->setChecked(config.useJpgForClipboard());
     m_copyOnDoubleClick->setChecked(config.copyOnDoubleClick());
+    m_saveOnShiftDoubleClick->setChecked(config.saveOnShiftDoubleClick());
     m_uploadWithoutConfirmation->setChecked(config.uploadWithoutConfirmation());
     m_historyConfirmationToDelete->setChecked(
       config.historyConfirmationToDelete());
@@ -425,6 +427,7 @@ void GeneralConf::initPredefinedColorPaletteLarge()
           ConfigHandler().setPredefinedColorPaletteLarge(checked);
       });
 }
+
 void GeneralConf::initCopyOnDoubleClick()
 {
     m_copyOnDoubleClick = new QCheckBox(tr("Copy on double click"), this);
@@ -434,6 +437,18 @@ void GeneralConf::initCopyOnDoubleClick()
 
     connect(m_copyOnDoubleClick, &QCheckBox::clicked, [](bool checked) {
         ConfigHandler().setCopyOnDoubleClick(checked);
+    });
+}
+
+void GeneralConf::initSaveOnShiftDoubleClick()
+{
+    m_saveOnShiftDoubleClick = new QCheckBox(tr("Save on shift double click"), this);
+    m_saveOnShiftDoubleClick->setToolTip(
+      tr("Enable Save to file on Shift + Double Click"));
+    m_scrollAreaLayout->addWidget(m_saveOnShiftDoubleClick);
+
+    connect(m_saveOnShiftDoubleClick, &QCheckBox::clicked, [](bool checked) {
+        ConfigHandler().setSaveOnShiftDoubleClick(checked);
     });
 }
 

--- a/src/config/generalconf.h
+++ b/src/config/generalconf.h
@@ -71,6 +71,7 @@ private:
     void initConfigButtons();
     void initCopyAndCloseAfterUpload();
     void initCopyOnDoubleClick();
+    void initSaveOnShiftDoubleClick();
     void initCopyPathAfterSave();
     void initHistoryConfirmationToDelete();
     void initPredefinedColorPaletteLarge();
@@ -130,6 +131,7 @@ private:
     QCheckBox* m_showMagnifier;
     QCheckBox* m_squareMagnifier;
     QCheckBox* m_copyOnDoubleClick;
+    QCheckBox* m_saveOnShiftDoubleClick;
     QCheckBox* m_showSelectionGeometry;
     QComboBox* m_selectGeometryLocation;
     QSpinBox* m_xywhTimeout;

--- a/src/config/shortcutswidget.cpp
+++ b/src/config/shortcutswidget.cpp
@@ -166,6 +166,11 @@ void ShortcutsWidget::loadShortcuts()
                 m_shortcuts << (QStringList() << "" << tool->description()
                                               << tr("Left Double-click"));
             }
+        } else if (shortcutName == "TYPE_SAVE") {
+            if (m_config.saveOnShiftDoubleClick()) {
+                m_shortcuts << (QStringList() << "" << tool->description()
+                                              << tr("Shift + Left Double-click"));
+            }
         }
         delete tool;
     }

--- a/src/utils/confighandler.cpp
+++ b/src/utils/confighandler.cpp
@@ -122,6 +122,7 @@ static QMap<class QString, QSharedPointer<ValueHandler>>
     // NOTE: If another tool size is added besides drawThickness and
     // drawFontSize, remember to update ConfigHandler::toolSize
     OPTION("copyOnDoubleClick"           ,Bool               ( false         )),
+    OPTION("saveOnShiftDoubleClick"      ,Bool               ( false         )),
     OPTION("uploadClientSecret"          ,String             ( "313baf0c7b4d3ff"            )),
     OPTION("showSelectionGeometry"  , BoundedInt               (0,5,4)),
     OPTION("showSelectionGeometryHideTime", LowerBoundedInt       (0, 3000))

--- a/src/utils/confighandler.h
+++ b/src/utils/confighandler.h
@@ -118,6 +118,7 @@ public:
     CONFIG_GETTER_SETTER(showMagnifier, setShowMagnifier, bool)
     CONFIG_GETTER_SETTER(squareMagnifier, setSquareMagnifier, bool)
     CONFIG_GETTER_SETTER(copyOnDoubleClick, setCopyOnDoubleClick, bool)
+    CONFIG_GETTER_SETTER(saveOnShiftDoubleClick, setSaveOnShiftDoubleClick, bool)
     CONFIG_GETTER_SETTER(uploadClientSecret, setUploadClientSecret, QString)
     CONFIG_GETTER_SETTER(saveLastRegion, setSaveLastRegion, bool)
     CONFIG_GETTER_SETTER(showSelectionGeometry, setShowSelectionGeometry, int)

--- a/src/widgets/capture/capturetoolbutton.cpp
+++ b/src/widgets/capture/capturetoolbutton.cpp
@@ -66,6 +66,11 @@ void CaptureToolButton::initButton()
         ConfigHandler().copyOnDoubleClick()) {
         tooltip += QStringLiteral(" (%1Left Double-Click)")
                      .arg(shortcut.isEmpty() ? QString() : shortcut + " or ");
+    } else if (m_buttonType == CaptureTool::TYPE_SAVE &&
+        ConfigHandler().saveOnShiftDoubleClick()) {
+        tooltip += QStringLiteral(" (%1Shift + Left Double-Click)")
+                     .arg(shortcut.isEmpty() ? QString() : shortcut + " or ");
+
     } else if (!shortcut.isEmpty()) {
         tooltip += QStringLiteral(" (%1)").arg(shortcut);
     }

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -12,6 +12,7 @@
 #include "capturewidget.h"
 #include "abstractlogger.h"
 #include "copytool.h"
+#include "savetool.h"
 #include "src/config/cacheutils.h"
 #include "src/config/generalconf.h"
 #include "src/core/flameshot.h"
@@ -780,6 +781,16 @@ void CaptureWidget::mouseDoubleClickEvent(QMouseEvent* event)
         }
     } else if (m_selection->geometry().contains(event->pos())) {
         if ((event->button() == Qt::LeftButton) &&
+            (event->modifiers() == Qt::ShiftModifier) && 
+            (m_config.saveOnShiftDoubleClick())) {
+            SaveTool saveTool;
+            connect(&saveTool,
+                    &SaveTool::requestAction,
+                    this,
+                    &CaptureWidget::handleToolSignal);
+            saveTool.pressed(m_context);
+            qApp->processEvents(QEventLoop::ExcludeUserInputEvents);
+        } else if ((event->button() == Qt::LeftButton) &&
             (m_config.copyOnDoubleClick())) {
             CopyTool copyTool;
             connect(&copyTool,


### PR DESCRIPTION
* added boolean configuration option saveOnShiftDoubleClick

* added condition for doubleclick + shift in mouseDoubleClickEvent handler which creates saveTool instance and emulates click

fixes #2877

regarding #3010 respectively tests/problems:
i tested without a running daemon and with "flameshot gui". my part was working but the normal double click functionality did not work, which has nothing to do with my change but is an open issue #2982 

compiled with libqt5core5a 5.15.6+dfsg-5 and tested on xorg/awesomewm on debian experimental