### PR TITLE
Allows users to modify the opacity value of the marker tool.

### DIFF
--- a/src/config/generalconf.cpp
+++ b/src/config/generalconf.cpp
@@ -59,6 +59,7 @@ GeneralConf::GeneralConf(QWidget* parent)
     initUploadClientSecret();
     initPredefinedColorPaletteLarge();
     initShowSelectionGeometry();
+    initMarkerOpacity();
 
     m_layout->addStretch();
 
@@ -717,6 +718,27 @@ void GeneralConf::initSquareMagnifier()
     });
 }
 
+void GeneralConf::initMarkerOpacity()
+{
+    auto* tobox = new QHBoxLayout();
+
+    int opacity =
+      ConfigHandler().value("markerOpacity").toInt();
+    m_xywhOpacity = new QSpinBox();
+    m_xywhOpacity->setRange(0, 100);
+    m_xywhOpacity->setToolTip(
+      tr("Percentage value of marker opacity, higher is darker"));
+    m_xywhOpacity->setValue(opacity);
+    tobox->addWidget(m_xywhOpacity);
+    tobox->addWidget(new QLabel(tr("Set marker opacity (%)")));
+
+    m_scrollAreaLayout->addLayout(tobox);
+    connect(m_xywhOpacity,
+            SIGNAL(valueChanged(int)),
+            this,
+            SLOT(setMarkOpacity(int)));
+}
+
 void GeneralConf::initShowSelectionGeometry()
 {
     auto* tobox = new QHBoxLayout();
@@ -771,6 +793,11 @@ void GeneralConf::initShowSelectionGeometry()
     selGeoLayout->addWidget(m_selectGeometryLocation);
     vboxLayout->addLayout(selGeoLayout);
     vboxLayout->addStretch();
+}
+
+void GeneralConf::setMarkOpacity(int value)
+{
+    ConfigHandler().setValue("markerOpacity", value);
 }
 
 void GeneralConf::setSelGeoHideTime(int v)

--- a/src/config/generalconf.h
+++ b/src/config/generalconf.h
@@ -57,6 +57,7 @@ private slots:
     void setSaveAsFileExtension(QString extension);
     void setGeometryLocation(int index);
     void setSelGeoHideTime(int v);
+    void setMarkOpacity(int value);
 
 private:
     const QString chooseFolder(const QString currentPath = "");
@@ -90,6 +91,7 @@ private:
     void initUploadClientSecret();
     void initSaveLastRegion();
     void initShowSelectionGeometry();
+    void initMarkerOpacity();
 
     void _updateComponents(bool allowEmptySavePath);
 
@@ -133,4 +135,5 @@ private:
     QCheckBox* m_showSelectionGeometry;
     QComboBox* m_selectGeometryLocation;
     QSpinBox* m_xywhTimeout;
+    QSpinBox* m_xywhOpacity;
 };

--- a/src/tools/marker/markertool.cpp
+++ b/src/tools/marker/markertool.cpp
@@ -55,7 +55,7 @@ void MarkerTool::process(QPainter& painter, const QPixmap& pixmap)
     qreal opacity = painter.opacity();
     auto pen = painter.pen();
     painter.setCompositionMode(QPainter::CompositionMode_Multiply);
-    painter.setOpacity(0.35);
+    painter.setOpacity(m_config.trueMarkerOpacity());
     painter.setPen(QPen(color(), size()));
     painter.drawLine(points().first, points().second);
     painter.setPen(pen);
@@ -70,7 +70,7 @@ void MarkerTool::paintMousePreview(QPainter& painter,
     qreal opacity = painter.opacity();
     auto pen = painter.pen();
     painter.setCompositionMode(QPainter::CompositionMode_Multiply);
-    painter.setOpacity(0.35);
+    painter.setOpacity(m_config.trueMarkerOpacity());
     painter.setPen(QPen(context.color, PADDING_VALUE + context.toolSize));
     painter.drawLine(context.mousePos, context.mousePos);
     painter.setPen(pen);

--- a/src/tools/marker/markertool.h
+++ b/src/tools/marker/markertool.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "src/tools/abstracttwopointtool.h"
+#include "src/utils/confighandler.h"
 
 class MarkerTool : public AbstractTwoPointTool
 {
@@ -27,4 +28,7 @@ protected:
 public slots:
     void drawStart(const CaptureContext& context) override;
     void pressed(CaptureContext& context) override;
+
+private:
+    ConfigHandler m_config;
 };

--- a/src/utils/confighandler.cpp
+++ b/src/utils/confighandler.cpp
@@ -124,7 +124,8 @@ static QMap<class QString, QSharedPointer<ValueHandler>>
     OPTION("copyOnDoubleClick"           ,Bool               ( false         )),
     OPTION("uploadClientSecret"          ,String             ( "313baf0c7b4d3ff"            )),
     OPTION("showSelectionGeometry"  , BoundedInt               (0,5,4)),
-    OPTION("showSelectionGeometryHideTime", LowerBoundedInt       (0, 3000))
+    OPTION("showSelectionGeometryHideTime", LowerBoundedInt       (0, 3000)),
+    OPTION("markerOpacity"               ,BoundedInt         (0, 100, 35     ))
 };
 
 static QMap<QString, QSharedPointer<KeySequence>> recognizedShortcuts = {
@@ -790,6 +791,11 @@ bool ConfigHandler::isShortcut(const QString& key) const
 QString ConfigHandler::baseName(QString key) const
 {
     return QFileInfo(key).baseName();
+}
+
+float ConfigHandler::trueMarkerOpacity()
+{
+    return float(markerOpacity())/100;
 }
 
 // STATIC MEMBER DEFINITIONS

--- a/src/utils/confighandler.h
+++ b/src/utils/confighandler.h
@@ -121,12 +121,14 @@ public:
     CONFIG_GETTER_SETTER(uploadClientSecret, setUploadClientSecret, QString)
     CONFIG_GETTER_SETTER(saveLastRegion, setSaveLastRegion, bool)
     CONFIG_GETTER_SETTER(showSelectionGeometry, setShowSelectionGeometry, int)
+    CONFIG_GETTER_SETTER(markerOpacity, setMarkerOpacity, int)
     // SPECIAL CASES
     bool startupLaunch();
     void setStartupLaunch(const bool);
     void setAllTheButtons();
     void setToolSize(CaptureTool::Type toolType, int size);
     int toolSize(CaptureTool::Type toolType);
+    float trueMarkerOpacity();
 
     // DEFAULTS
     QString filenamePatternDefault();


### PR DESCRIPTION
Code was run through the code formatter.

Related to this Enhancement request  #3007

I couldn't figure out why it was changed from 0.5 to 0.35 in 2017 [commit in question](https://github.com/flameshot-org/flameshot/commit/d849e9dbf5f1cb759f1ed2c226e380cc2d24fac9), nor why it was 0.5 originally. It seems to function fine though. I made 0.35 the default, so there should be no differences detected by users.

I am rather rusty with C++ and very unfamiliar with this project, so this should be reviewed.