### PR TITLE
Fixed issue with black screen when use 'screen' argument

### DIFF
--- a/src/core/capturerequest.cpp
+++ b/src/core/capturerequest.cpp
@@ -3,10 +3,7 @@
 
 #include "capturerequest.h"
 #include "confighandler.h"
-#include "imgupload/imguploadermanager.h"
-#include "pinwidget.h"
 #include "src/config/cacheutils.h"
-#include "src/utils/screenshotsaver.h"
 #include <QApplication>
 #include <QClipboard>
 #include <QDateTime>

--- a/src/core/flameshotdaemon.cpp
+++ b/src/core/flameshotdaemon.cpp
@@ -84,11 +84,7 @@ FlameshotDaemon::FlameshotDaemon()
             this,
             [this]() {
                 ConfigHandler config;
-                if (config.disabledTrayIcon()) {
-                    enableTrayIcon(false);
-                } else {
-                    enableTrayIcon(true);
-                }
+                enableTrayIcon(!config.disabledTrayIcon());
                 m_persist = !config.autoCloseIdleDaemon();
             });
 #endif

--- a/src/utils/screengrabber.cpp
+++ b/src/utils/screengrabber.cpp
@@ -174,7 +174,7 @@ QPixmap ScreenGrabber::grabScreen(QScreen* screen, bool& ok)
     } else {
         ok = true;
         return screen->grabWindow(
-          0, geometry.x(), geometry.y(), geometry.width(), geometry.height());
+          QApplication::desktop()->winId(), geometry.x(), geometry.y(), geometry.width(), geometry.height());
     }
     return p;
 }

--- a/src/utils/screengrabber.cpp
+++ b/src/utils/screengrabber.cpp
@@ -23,7 +23,8 @@
 
 ScreenGrabber::ScreenGrabber(QObject* parent)
   : QObject(parent)
-{}
+{
+}
 
 void ScreenGrabber::freeDesktopPortal(bool& ok, QPixmap& res)
 {
@@ -173,8 +174,11 @@ QPixmap ScreenGrabber::grabScreen(QScreen* screen, bool& ok)
         }
     } else {
         ok = true;
-        return screen->grabWindow(
-          QApplication::desktop()->winId(), geometry.x(), geometry.y(), geometry.width(), geometry.height());
+        return screen->grabWindow(QApplication::desktop()->winId(),
+                                  geometry.x(),
+                                  geometry.y(),
+                                  geometry.width(),
+                                  geometry.height());
     }
     return p;
 }


### PR DESCRIPTION
When trying to take a screenshot of the whole screen, we try to take pixels from the wrong window, which results in a black screen.
Hotfix to this issue: #2997