### PR TITLE
Add BraceWrapping rules to .clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -4,3 +4,13 @@ IndentWidth: 4
 AccessModifierOffset: -4
 AlwaysBreakAfterDefinitionReturnType: None
 AlwaysBreakAfterReturnType: None
+
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterClass: true
+  AfterStruct: true
+  AfterEnum: true
+  AfterFunction: true
+  SplitEmptyFunction: false
+  SplitEmptyRecord: false
+  SplitEmptyNamespace: false

--- a/src/utils/confighandler.h
+++ b/src/utils/confighandler.h
@@ -25,7 +25,10 @@ class AbstractLogger;
  * `KEY` is the name of the generated getter function.
  */
 #define CONFIG_GETTER(KEY, TYPE)                                               \
-    TYPE KEY() { return value(QStringLiteral(#KEY)).value<TYPE>(); }
+    TYPE KEY()                                                                 \
+    {                                                                          \
+        return value(QStringLiteral(#KEY)).value<TYPE>();                      \
+    }
 
 /**
  * Declare and implement a setter for a config option. `FUNC` is the name of the


### PR DESCRIPTION
In clang 14 it seems the default behavior changed, which made the test-clang-format workflow fail in recent PRs. This PR makes the expected behavior explicit.