### PR TITLE
Refactor CMake

### DIFF
--- a/.github/workflows/Linux-pack.yml
+++ b/.github/workflows/Linux-pack.yml
@@ -418,8 +418,9 @@ jobs:
           mkdir -p ${APPIMAGE_DST_PATH}
 
           cd $GITHUB_WORKSPACE
-          cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=/usr -DUSE_LAUNCHER_ABSOLUTE_PATH:BOOL=OFF
-          make -j$(nproc) DESTDIR=${APPIMAGE_DST_PATH} install
+          cmake -S -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=/usr/"${APPIMAGE_DST_PATH}" -DUSE_LAUNCHER_ABSOLUTE_PATH:BOOL=OFF
+          cmake --build build --target install --config RelWithDebInfo -- -j$(nproc)
+
 
           $GITHUB_WORKSPACE/appimagetool -s deploy ${APPIMAGE_DST_PATH}/usr/share/applications/org.flameshot.Flameshot.desktop
 

--- a/.github/workflows/MacOS-pack.yml
+++ b/.github/workflows/MacOS-pack.yml
@@ -52,15 +52,12 @@ jobs:
 
       - name: Configure
         run: |
-          mkdir -p "${DIR_BULD}"
-          cd "${DIR_BULD}"
-          rm -rf ./src/flameshot.dmg ./src/flameshot.app/
-          cmake .. -DQt5_DIR=$(brew --prefix qt5)/lib/cmake/Qt5 -DUSE_MONOCHROME_ICON=True
+          rm -rf "${DIR_BULD}"/src/flameshot.dmg "${DIR_BULD}"/src/flameshot.app/
+          cmake -S . -B "${DIR_BULD}" -DQt5_DIR=$(brew --prefix qt5)/lib/cmake/Qt5 -DUSE_MONOCHROME_ICON=True
 
       - name: Compile
         run: |
-          cd "${DIR_BULD}"
-          make
+          cmake --build "${DIR_BULD}"
 
       - name: Create key-chain and import certificate
         run: |

--- a/README.md
+++ b/README.md
@@ -471,29 +471,26 @@ brew install cmake
 After installing all the dependencies, finally run the following commands in the sources root directory:
 
 ```shell
-mkdir build
-cd build
-cmake ../
-make
+cmake -S . -B build && cmake --build build
 ```
 
 NOTE: for macOS you should replace command
 
 ```shell
-cmake ../
+cmake -S . -B build
 ```
 
 to
 
 ```shell
-cmake ../ -DQt5_DIR=$(brew --prefix qt5)/lib/cmake/Qt5
+cmake -S . -B build -DQt5_DIR=$(brew --prefix qt5)/lib/cmake/Qt5
 ```
 
-When `make` command completed you can launch flameshot from `project_folder/build/src` folder
+When `cmake --build build` command completed you can launch flameshot from `project_folder/build/src` folder
 
 ### Install
 
-Simply use `make install` with privileges.
+Simply use `cmake --install build` with privileges.
 Note: If you install from source, there is no uninstaller, you will need to manually remove the files. Consider using [CMAKE_INSTALL_PREFIX](https://cmake.org/cmake/help/latest/variable/CMAKE_INSTALL_PREFIX.html) to install to a custom location for easy removal.
 
 ### FAQ

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,19 +9,17 @@ environment:
 build_script:
 - cmd: >-
 
-    mkdir build
-
-    cd build
-
     set QTDIR=%Qt5_INSTALL_DIR%
 
     set "VCINSTALLDIR=C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC"
 
     set "OPENSSL_ROOT_DIR=C:/OpenSSL-v111-Win64"
 
-    cmake c:\projects\source -G "Visual Studio 16 2019" -DCMAKE_BUILD_TYPE:STRING=Release -DENABLE_OPENSSL=ON -DRUN_IN_PLACE=OFF
+    cmake -S c:\projects\source -B build -G "Visual Studio 16 2019" -DCMAKE_BUILD_TYPE:STRING=Release -DENABLE_OPENSSL=ON -DRUN_IN_PLACE=OFF
 
-    cmake --build . --parallel 2 --config "Release"
+    cmake --build build --parallel 2 --config "Release"
+
+    cd build 
 
     cpack -G WIX -B package
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,42 +20,36 @@ set(CMAKE_AUTOUIC ON)
 
 # set application icon
 if (APPLE)
+    set(FLAMESHOT_ICONSET ${CMAKE_BINARY_DIR}/flameshot.iconset)
+    set(FLAMESHOT_ICNS ${CMAKE_BINARY_DIR}/flameshot.icns)
+
     # generate iconset
     execute_process(
-            COMMAND bash "-c" "mkdir -p flameshot.iconset"
-    )
-    execute_process(
-            COMMAND bash "-c" "sips -z 16 16     \"${CMAKE_SOURCE_DIR}\"/data/img/app/flameshot.monochrome.png --out flameshot.iconset/icon_16x16.png"
-            COMMAND bash "-c" "sips -z 32 32     \"${CMAKE_SOURCE_DIR}\"/data/img/app/flameshot.monochrome.png --out flameshot.iconset/icon_16x16@2x.png"
-            COMMAND bash "-c" "sips -z 32 32     \"${CMAKE_SOURCE_DIR}\"/data/img/app/flameshot.monochrome.png --out flameshot.iconset/icon_32x32.png"
-            COMMAND bash "-c" "sips -z 64 64     \"${CMAKE_SOURCE_DIR}\"/data/img/app/flameshot.monochrome.png --out flameshot.iconset/icon_32x32@2x.png"
-            COMMAND bash "-c" "sips -z 64 64     \"${CMAKE_SOURCE_DIR}\"/data/img/app/flameshot.monochrome.png --out flameshot.iconset/icon_64x64x.png"
-            COMMAND bash "-c" "sips -z 128 128   \"${CMAKE_SOURCE_DIR}\"/data/img/app/flameshot.monochrome.png --out flameshot.iconset/icon_64x64@2.png"
-            COMMAND bash "-c" "sips -z 128 128   \"${CMAKE_SOURCE_DIR}\"/data/img/app/flameshot.monochrome-1024.png --out flameshot.iconset/icon_128x128.png"
-            COMMAND bash "-c" "sips -z 256 256   \"${CMAKE_SOURCE_DIR}\"/data/img/app/flameshot.monochrome-1024.png --out flameshot.iconset/icon_128x128@2x.png"
-            COMMAND bash "-c" "sips -z 256 256   \"${CMAKE_SOURCE_DIR}\"/data/img/app/flameshot.monochrome-1024.png --out flameshot.iconset/icon_256x256.png"
-            COMMAND bash "-c" "sips -z 512 512   \"${CMAKE_SOURCE_DIR}\"/data/img/app/flameshot.monochrome-1024.png --out flameshot.iconset/icon_256x256@2x.png"
-            COMMAND bash "-c" "sips -z 512 512   \"${CMAKE_SOURCE_DIR}\"/data/img/app/flameshot.monochrome-1024.png --out flameshot.iconset/icon_512x512.png"
-            COMMAND bash "-c" "sips -z 1024 1024 \"${CMAKE_SOURCE_DIR}\"/data/img/app/flameshot.monochrome-1024.png --out flameshot.iconset/icon_512x512@2x.png"
-
-
-            COMMAND bash "-c" "iconutil -c icns flameshot.iconset"
+            COMMAND bash "-c" "mkdir -p \"${FLAMESHOT_ICONSET}\""
     )
 
     execute_process(
-            COMMAND bash "-c" "rm -R flameshot.iconset"
-    )
+            COMMAND bash "-c" "sips -z 16 16     \"${CMAKE_SOURCE_DIR}\"/data/img/app/flameshot.monochrome.png --out \"${FLAMESHOT_ICONSET}\"/icon_16x16.png"
+            COMMAND bash "-c" "sips -z 32 32     \"${CMAKE_SOURCE_DIR}\"/data/img/app/flameshot.monochrome.png --out \"${FLAMESHOT_ICONSET}\"/icon_16x16@2x.png"
+            COMMAND bash "-c" "sips -z 32 32     \"${CMAKE_SOURCE_DIR}\"/data/img/app/flameshot.monochrome.png --out \"${FLAMESHOT_ICONSET}\"/icon_32x32.png"
+            COMMAND bash "-c" "sips -z 64 64     \"${CMAKE_SOURCE_DIR}\"/data/img/app/flameshot.monochrome.png --out \"${FLAMESHOT_ICONSET}\"/icon_32x32@2x.png"
+            COMMAND bash "-c" "sips -z 64 64     \"${CMAKE_SOURCE_DIR}\"/data/img/app/flameshot.monochrome.png --out \"${FLAMESHOT_ICONSET}\"/icon_64x64x.png"
+            COMMAND bash "-c" "sips -z 128 128   \"${CMAKE_SOURCE_DIR}\"/data/img/app/flameshot.monochrome.png --out \"${FLAMESHOT_ICONSET}\"/icon_64x64@2.png"
+            COMMAND bash "-c" "sips -z 128 128   \"${CMAKE_SOURCE_DIR}\"/data/img/app/flameshot.monochrome-1024.png --out \"${FLAMESHOT_ICONSET}\"/icon_128x128.png"
+            COMMAND bash "-c" "sips -z 256 256   \"${CMAKE_SOURCE_DIR}\"/data/img/app/flameshot.monochrome-1024.png --out \"${FLAMESHOT_ICONSET}\"/icon_128x128@2x.png"
+            COMMAND bash "-c" "sips -z 256 256   \"${CMAKE_SOURCE_DIR}\"/data/img/app/flameshot.monochrome-1024.png --out \"${FLAMESHOT_ICONSET}\"/icon_256x256.png"
+            COMMAND bash "-c" "sips -z 512 512   \"${CMAKE_SOURCE_DIR}\"/data/img/app/flameshot.monochrome-1024.png --out \"${FLAMESHOT_ICONSET}\"/icon_256x256@2x.png"
+            COMMAND bash "-c" "sips -z 512 512   \"${CMAKE_SOURCE_DIR}\"/data/img/app/flameshot.monochrome-1024.png --out \"${FLAMESHOT_ICONSET}\"/icon_512x512.png"
+            COMMAND bash "-c" "sips -z 1024 1024 \"${CMAKE_SOURCE_DIR}\"/data/img/app/flameshot.monochrome-1024.png --out \"${FLAMESHOT_ICONSET}\"/icon_512x512@2x.png"
 
-    execute_process(
-            # copy icon from cache generated on the localhost if generation on CI failed
-            COMMAND bash "-c" "[[ -r 'flameshot.icns' ]] || cp \"${CMAKE_SOURCE_DIR}\"/packaging/macos/flameshot.icns ./"
+            COMMAND bash "-c" "iconutil -o \"${FLAMESHOT_ICNS}\" -c icns ${FLAMESHOT_ICONSET}"
     )
 
     # Set application icon
     set(MACOSX_BUNDLE_ICON_FILE flameshot.icns)
 
     # And this part tells CMake where to find and install the file itself
-    set(APP_ICON_MACOSX ${CMAKE_BINARY_DIR}/flameshot.icns)
+    set(APP_ICON_MACOSX ${FLAMESHOT_ICNS})
     set_source_files_properties(${APP_ICON_MACOSX} PROPERTIES MACOSX_PACKAGE_LOCATION "Resources")
 
     add_executable(flameshot MACOSX_BUNDLE main.cpp ${APP_ICON_MACOSX})


### PR DESCRIPTION
CMake uses absolute paths to generate icons for MacOS build. It fails on build commands different than the commands in [README.md](https://github.com/flameshot-org/flameshot/blob/master/README.md) file.

Example output
```
> rm -rf build &&  cmake -S . -B build    -DQt5_DIR=$(brew --prefix qt5)/lib/cmake/Qt5
-- The CXX compiler identification is AppleClang 14.0.0.14000029
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /Library/Developer/CommandLineTools/usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Setting build type to 'RelWithDebInfo' as none was specified.
CMake Warning at cmake/Cache.cmake:28 (message):
  ccache is enabled but was not found.  Not using it
Call Stack (most recent call first):
  CMakeLists.txt:84 (include)


-- Performing Test Wall_FLAG_SUPPORTED
-- Performing Test Wall_FLAG_SUPPORTED - Success
-- Performing Test pedantic_FLAG_SUPPORTED
-- Performing Test pedantic_FLAG_SUPPORTED - Success
-- Performing Test Wextra_FLAG_SUPPORTED
-- Performing Test Wextra_FLAG_SUPPORTED - Success
Flameshot predefined color palette large: false
-- Found Git: /usr/bin/git (found version "2.37.1 (Apple Git-137.1)") 
git found: /usr/bin/git in version     2.37.1 (Apple Git-137.1)
FLAMESHOT_GIT_HASH: 3ededae5
-- Configuring done
CMake Error at src/CMakeLists.txt:61 (add_executable):
  Cannot find source file:

    /Users/orkun/playground/opensource_projects/forked/flameshot/build/flameshot.icns

  Tried extensions .c .C .c++ .cc .cpp .cxx .cu .mpp .m .M .mm .ixx .cppm .h
  .hh .h++ .hm .hpp .hxx .in .txx .f .F .for .f77 .f90 .f95 .f03 .hip .ispc


-- Generating done
CMake Generate step failed.  Build files cannot be regenerated correctly.
``` 

**Solution**

`CMAKE_BINARY_DIR`  path was used in the generation of MacOS `flameshot.icns`

 Also 'make' commands were changed with 'cmake' counterparts.

**Changed Files**
[README.md](https://github.com/flameshot-org/flameshot/pull/3104/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L474)
[src/CMakeLists.txt](https://github.com/flameshot-org/flameshot/pull/3104/files#diff-148715d6ea0c0ea0a346af3f6bd610d010d490eca35ac6a9b408748f7ca9e3f4L24)
[.github/workflows/Linux-pack.yml](https://github.com/flameshot-org/flameshot/pull/3104/files#diff-cd89decf4962d0a4bbf59c41408224ddc1dd8d622ba0fe34eaecab50cb2676b1L418)
[.github/workflows/MacOS-pack.yml](https://github.com/flameshot-org/flameshot/pull/3104/files#diff-1931bd5beeaecabf17d82c0e4d1b537d232b5fe6e7f6d898637f2dfcad7643e6L52)
[appveyor.yml](https://github.com/flameshot-org/flameshot/pull/3104/files#diff-92ab9a36df5d8e9f7076f2fdec59492d1ac2d9cf27ea046767a7fc4d542ef3dcL12)