### PR TITLE
Add generic wlroots DesktopInfo for compositors such as labwc

### DIFF
--- a/docs/Sway and wlroots support.md
+++ b/docs/Sway and wlroots support.md
@@ -15,6 +15,8 @@ export XDG_SESSION_DESKTOP=sway
 exec sway
 ```
 
+Other compositors, such as labwc, use `wlroots` as the XDG_CURRENT_DESKTOP value.
+
 You will also need to ensure that systemd/dbus is aware of these environment variables; this should be done **in your sway config** so that the DISPLAY and WAYLAND_DISPLAY variables are defined.
 
 (taken from [Sway wiki](https://github.com/swaywm/sway/wiki#gtk-applications-take-20-seconds-to-start)):

--- a/src/utils/desktopinfo.cpp
+++ b/src/utils/desktopinfo.cpp
@@ -43,6 +43,9 @@ DesktopInfo::WM DesktopInfo::windowManager()
         if (desktop.contains(QLatin1String("kde-plasma"))) {
             return DesktopInfo::KDE;
         }
+        if (desktop.contains(QLatin1String("wlroots"))) {
+            return DesktopInfo::WLROOTS;
+        }
     }
 
     if (!GNOME_DESKTOP_SESSION_ID.isEmpty()) {

--- a/src/utils/desktopinfo.h
+++ b/src/utils/desktopinfo.h
@@ -17,7 +17,8 @@ public:
         OTHER,
         QTILE,
         SWAY,
-        HYPRLAND
+        HYPRLAND,
+        WLROOTS
     };
 
     bool waylandDetected();

--- a/src/utils/screengrabber.cpp
+++ b/src/utils/screengrabber.cpp
@@ -131,6 +131,7 @@ QPixmap ScreenGrabber::grabEntireDesktop(bool& ok)
             case DesktopInfo::QTILE:
             case DesktopInfo::SWAY:
             case DesktopInfo::HYPRLAND:
+            case DesktopInfo::WLROOTS:
             case DesktopInfo::OTHER: {
 #ifndef USE_WAYLAND_GRIM
                 AbstractLogger::warning() << tr(


### PR DESCRIPTION
Compositors such as [labwc](https://github.com/labwc/labwc) use "wlroots" as their `XDG_CURRENT_DESKTOP`.

I like that they do that, and hope others do it as well, as it means Flameshot doesn't need to add an ∞ amount of case statements.