### PR TITLE
Use pixmap's width and desktop's width to calculate DPR on Wayland

### DIFF
--- a/src/utils/screengrabber.cpp
+++ b/src/utils/screengrabber.cpp
@@ -73,13 +73,15 @@ void ScreenGrabber::freeDesktopPortal(bool& ok, QPixmap& res)
       this);
 
     QEventLoop loop;
-    const auto gotSignal = [&res, &loop](uint status, const QVariantMap& map) {
+    const auto gotSignal = [this, &res, &loop](uint status,
+                                               const QVariantMap& map) {
         if (status == 0) {
             // Parse this as URI to handle unicode properly
             QUrl uri = map.value("uri").toString();
             QString uriString = uri.toLocalFile();
             res = QPixmap(uriString);
-            res.setDevicePixelRatio(qApp->devicePixelRatio());
+            res.setDevicePixelRatio(res.width() /
+                                    double(desktopGeometry().width()));
             QFile imgFile(uriString);
             imgFile.remove();
         }


### PR DESCRIPTION
Without fractional scaling support in Qt5 and without a surface in Qt6, getting the real scale factor will require using Wayland protocol. However using Wayland protocol will add additional dependencies in flameshot. This fix uses pixmap's width and desktop's width to calculate the real DPR on Wayland.

Depends on https://invent.kde.org/plasma/xdg-desktop-portal-kde/-/merge_requests/186

Fixes #3164