### PR TITLE
Added flat button layout in region capture mode

### DIFF
--- a/src/config/generalconf.cpp
+++ b/src/config/generalconf.cpp
@@ -59,6 +59,7 @@ GeneralConf::GeneralConf(QWidget* parent)
     initUploadClientSecret();
     initPredefinedColorPaletteLarge();
     initShowSelectionGeometry();
+    initFlatButtonsLayout();
 
     m_layout->addStretch();
 
@@ -645,6 +646,16 @@ void GeneralConf::initCopyPathAfterSave()
     m_scrollAreaLayout->addWidget(m_copyPathAfterSave);
     connect(m_copyPathAfterSave, &QCheckBox::clicked, [](bool checked) {
         ConfigHandler().setCopyPathAfterSave(checked);
+    });
+}
+
+void GeneralConf::initFlatButtonsLayout()
+{
+    m_useFlatButtonsLayout = new QCheckBox(tr("Use flat layout for buttons"), this);
+    m_useFlatButtonsLayout->setToolTip(tr("Force arrange tool buttons in a line"));
+    m_scrollAreaLayout->addWidget(m_useFlatButtonsLayout);
+    connect(m_useFlatButtonsLayout, &QCheckBox::clicked, [](bool checked) {
+        ConfigHandler().setUseFlatButtonsLayout(checked);
     });
 }
 

--- a/src/config/generalconf.h
+++ b/src/config/generalconf.h
@@ -72,6 +72,7 @@ private:
     void initCopyAndCloseAfterUpload();
     void initCopyOnDoubleClick();
     void initCopyPathAfterSave();
+    void initFlatButtonsLayout();
     void initHistoryConfirmationToDelete();
     void initPredefinedColorPaletteLarge();
     void initSaveAfterCopy();
@@ -133,4 +134,5 @@ private:
     QCheckBox* m_showSelectionGeometry;
     QComboBox* m_selectGeometryLocation;
     QSpinBox* m_xywhTimeout;
+    QCheckBox* m_useFlatButtonsLayout;
 };

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -27,6 +27,7 @@ target_sources(
           history.cpp
           strfparse.cpp
           request.cpp
+          layoututils.cpp
 )
 
 IF (WIN32)

--- a/src/utils/confighandler.cpp
+++ b/src/utils/confighandler.cpp
@@ -124,7 +124,8 @@ static QMap<class QString, QSharedPointer<ValueHandler>>
     OPTION("copyOnDoubleClick"           ,Bool               ( false         )),
     OPTION("uploadClientSecret"          ,String             ( "313baf0c7b4d3ff"            )),
     OPTION("showSelectionGeometry"  , BoundedInt               (0,5,4)),
-    OPTION("showSelectionGeometryHideTime", LowerBoundedInt       (0, 3000))
+    OPTION("showSelectionGeometryHideTime", LowerBoundedInt       (0, 3000)),
+    OPTION("useFlatButtonsLayout"         ,Bool               ( false         )),
 };
 
 static QMap<QString, QSharedPointer<KeySequence>> recognizedShortcuts = {

--- a/src/utils/confighandler.h
+++ b/src/utils/confighandler.h
@@ -126,6 +126,7 @@ public:
     CONFIG_GETTER_SETTER(uploadClientSecret, setUploadClientSecret, QString)
     CONFIG_GETTER_SETTER(saveLastRegion, setSaveLastRegion, bool)
     CONFIG_GETTER_SETTER(showSelectionGeometry, setShowSelectionGeometry, int)
+    CONFIG_GETTER_SETTER(useFlatButtonsLayout, setUseFlatButtonsLayout, bool)
     // SPECIAL CASES
     bool startupLaunch();
     void setStartupLaunch(const bool);

--- a/src/utils/layoututils.cpp
+++ b/src/utils/layoututils.cpp
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2017-2019 Alejandro Sirgo Rica & Contributors
+
+#include "layoututils.h"
+
+namespace layoututils
+{
+
+bool adjustRectInsideAnother(const QRect& parent, QRect& inner)
+{
+    if (inner.width() > parent.width() || inner.height() > parent.height()) {
+        return false;
+    }
+
+    if (inner.left() < parent.left()) {
+        inner.moveLeft(parent.left());
+    }
+    if (inner.right() > parent.right()) {
+        inner.moveRight(parent.right());
+    }
+    if (inner.top() < parent.top()) {
+        inner.moveTop(parent.top());
+    }
+    if (inner.bottom() > parent.bottom()) {
+        inner.moveBottom(parent.bottom());
+    }
+    return true;
+}
+
+}

--- a/src/utils/layoututils.h
+++ b/src/utils/layoututils.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <QRect>
+
+namespace layoututils
+{
+bool adjustRectInsideAnother(const QRect &parent, QRect &inner);;
+}

--- a/src/widgets/capture/buttonhandler.h
+++ b/src/widgets/capture/buttonhandler.h
@@ -61,7 +61,7 @@ private:
     bool m_buttonsAreInside;
     bool m_blockedRight;
     bool m_blockedLeft;
-    bool m_blockedBotton;
+    bool m_blockedBottom;
     bool m_blockedTop;
     bool m_oneHorizontalBlocked;
     bool m_horizontalyBlocked;
@@ -73,7 +73,7 @@ private:
     void updateBlockedSides();
     void expandSelection();
     void positionButtonsInside(int index);
-    void ensureSelectionMinimunSize();
+    void ensureSelectionMinimumSize();
     void moveButtonsToPoints(const QVector<QPoint>& points, int& index);
     void adjustHorizontalCenter(QPoint& center);
 };


### PR DESCRIPTION
Fixes #3195

Added an option to force flat layout for tool buttons  
![settings](https://github.com/flameshot-org/flameshot/assets/18731681/ed5eda1b-72e8-492a-ba6d-fe3e0970134e)
![general](https://github.com/flameshot-org/flameshot/assets/18731681/bcb1c084-46b3-4d7d-ae9a-be805b5da7b4)

All buttons are laid out in a line even in a small selection region
![general_small](https://github.com/flameshot-org/flameshot/assets/18731681/9cb7fc33-f621-4b89-955a-b83b1d84809a)

Correctly handles cases when there's not enough space to present buttons in the middle of the selection. Pushes all buttons towards an empty space  
![overflow_left](https://github.com/flameshot-org/flameshot/assets/18731681/689aa0bd-8608-4309-9dc1-f003c1e3bb6b)
![overflow_right](https://github.com/flameshot-org/flameshot/assets/18731681/79a5bda9-2b21-4acc-9266-7dac611e9733)

If there is not enough space to place buttons on the bottom of selection, they are moved to the top
![overflow_bot](https://github.com/flameshot-org/flameshot/assets/18731681/cd4089c7-4961-4fe6-9be2-b8f3254f78f8)

And the final case, when there's no room for buttons both at the top and at the bottom, use bottom with overlap into the content
![fullscreen](https://github.com/flameshot-org/flameshot/assets/18731681/c7379e6f-71fa-44bc-bf59-9b8c6bdb8418)
