### PR TITLE
Wayland daemon fix & hyprland multi window implementation

### DIFF
--- a/src/core/flameshotdaemon.cpp
+++ b/src/core/flameshotdaemon.cpp
@@ -108,11 +108,15 @@ void FlameshotDaemon::start()
 
 void FlameshotDaemon::createPin(const QPixmap& capture, QRect geometry)
 {
+    #ifdef USE_WAYLAND_GRIM
+    start();
+    #endif
     if (instance()) {
         instance()->attachPin(capture, geometry);
         return;
     }
-
+    
+    #ifndef USE_WAYLAND_GRIM
     QByteArray data;
     QDataStream stream(&data, QIODevice::WriteOnly);
     stream << capture;
@@ -120,15 +124,20 @@ void FlameshotDaemon::createPin(const QPixmap& capture, QRect geometry)
     QDBusMessage m = createMethodCall(QStringLiteral("attachPin"));
     m << data;
     call(m);
+    #endif
 }
 
 void FlameshotDaemon::copyToClipboard(const QPixmap& capture)
 {
+    #ifdef USE_WAYLAND_GRIM
+    start();
+    #endif
     if (instance()) {
         instance()->attachScreenshotToClipboard(capture);
         return;
     }
 
+    #ifndef USE_WAYLAND_GRIM
     QDBusMessage m =
       createMethodCall(QStringLiteral("attachScreenshotToClipboard"));
 
@@ -138,6 +147,7 @@ void FlameshotDaemon::copyToClipboard(const QPixmap& capture)
 
     m << data;
     call(m);
+    #endif
 }
 
 void FlameshotDaemon::copyToClipboard(const QString& text,

--- a/src/utils/confighandler.h
+++ b/src/utils/confighandler.h
@@ -126,6 +126,10 @@ public:
     CONFIG_GETTER_SETTER(uploadClientSecret, setUploadClientSecret, QString)
     CONFIG_GETTER_SETTER(saveLastRegion, setSaveLastRegion, bool)
     CONFIG_GETTER_SETTER(showSelectionGeometry, setShowSelectionGeometry, int)
+    CONFIG_GETTER_SETTER(showSelectionGeometryHideTime,
+                         showSelectionGeometryHideTime,
+                         int)
+
     // SPECIAL CASES
     bool startupLaunch();
     void setStartupLaunch(const bool);

--- a/src/utils/screengrabber.h
+++ b/src/utils/screengrabber.h
@@ -17,6 +17,7 @@ public:
     QPixmap grabScreen(QScreen* screenNumber, bool& ok);
     void freeDesktopPortal(bool& ok, QPixmap& res);
     void generalGrimScreenshot(bool& ok, QPixmap& res);
+    void generalHyprlandScreenshot(bool& ok, QPixmap& res);
     QRect desktopGeometry();
 
 private:

--- a/src/widgets/capture/capturewidget.h
+++ b/src/widgets/capture/capturewidget.h
@@ -92,7 +92,7 @@ private slots:
 
 public:
     void removeToolObject(int index = -1);
-    void showxywh(bool show = true);
+    void showxywh();
 
 protected:
     void paintEvent(QPaintEvent* paintEvent) override;


### PR DESCRIPTION
This PR is based on PR #3059 because it's unusable for me to debug otherwise.

This PR implements a Hyprland specific screenshot function, although some of this could easily be extended to other wayland DE's. The currently active screen is obtained from ```hyprctl activewindow``` which is the only hyprland specific part right now.

I have some questions before furthering development on this:

- I've Added some of the USE_WAYLAND_GRIM conditions, but there's also a waylandDetected() function. Does flameshot aim to dynamically detect wayland and run based on that or should we use the preprocessor to eliminate as much of these as possible. For example: the activateWindow() isn't implemented in wayland and we could solve this with either solutions.

- The clipboard, currently we keep the daemon running as long as necessary and watch it until flameshot no longer owns it to then end the program. Wayland also has the ```wl-copy,  wl-paste & wl-clipboard-persist``` programs. So the question is, do we want to daemon to offer the clipboard information or do we want to transfer these responsibilities to programs such as those mentioned before?

All in all, this PR is meant to bring flameshot to a more usable level for hyprland. I know there's currently a bug where the daemon doesn't always end when the clipboard data changes, but I want to know what direction flameshot heads in on the subject of clipboard information before digging deeper into that bug. Let me know if you need any extra information.

P.S. For hyprland users: ```windowrule = float, ^(flameshot)$``` will make the pinned screenshot immediately float ;)