### PR TITLE
our sponsor AnonAddy has rebranded to addy.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,4 +536,4 @@ Thanks to sponsors:
 - [Namecheap](https://www.namecheap.com/)
 - [JetBrains](https://www.jetbrains.com/)
 - [SignPath](https://signpath.io/)
-- [AnonAddy](https://anonaddy.com)
+- [addy.io](https://addy.io/)


### PR DESCRIPTION
More info about the rebranding here:

https://addy.io/blog/anonaddy-has-rebranded-as-addy-io/

I also emailed them and they sent me an instruction list of what logo to use and what URL to use.