### PR TITLE
Make loading of languages consistent across invocation types

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -85,6 +85,45 @@ QSharedMemory* guiMutexLock()
     return shm;
 }
 
+QTranslator translator, qtTranslator;
+
+void configureApp(bool gui)
+{
+    if (gui) {
+        QApplication::setStyle(new StyleOverride);
+    }
+
+    // Configure translations
+    for (const QString& path : PathInfo::translationsPaths()) {
+        bool match = translator.load(QLocale(),
+                                     QStringLiteral("Internationalization"),
+                                     QStringLiteral("_"),
+                                     path);
+        if (match) {
+            break;
+        }
+    }
+
+    qtTranslator.load(QLocale::system(),
+                      "qt",
+                      "_",
+                      QLibraryInfo::location(QLibraryInfo::TranslationsPath));
+
+    auto app = QCoreApplication::instance();
+    app->installTranslator(&translator);
+    app->installTranslator(&qtTranslator);
+    app->setAttribute(Qt::AA_DontCreateNativeWidgetSiblings, true);
+}
+
+// TODO find a way so we don't have to do this
+/// Recreate the application as a QApplication
+void reinitializeAsQApplication(int argc, char* argv[])
+{
+    delete QCoreApplication::instance();
+    new QApplication(argc, argv);
+    configureApp(true);
+}
+
 int main(int argc, char* argv[])
 {
 #ifdef Q_OS_LINUX
@@ -105,31 +144,7 @@ int main(int argc, char* argv[])
 #else
         QtSingleApplication app(argc, argv);
 #endif
-        QApplication::setStyle(new StyleOverride);
-
-        QTranslator translator, qtTranslator;
-        QStringList trPaths = PathInfo::translationsPaths();
-
-        for (const QString& path : trPaths) {
-            bool match = translator.load(QLocale(),
-                                         QStringLiteral("Internationalization"),
-                                         QStringLiteral("_"),
-                                         path);
-            if (match) {
-                break;
-            }
-        }
-
-        qtTranslator.load(
-          QLocale::system(),
-          "qt",
-          "_",
-          QLibraryInfo::location(QLibraryInfo::TranslationsPath));
-
-        qApp->installTranslator(&translator);
-        qApp->installTranslator(&qtTranslator);
-        qApp->setAttribute(Qt::AA_DontCreateNativeWidgetSiblings, true);
-
+        configureApp(true);
         auto c = Flameshot::instance();
         FlameshotDaemon::start();
 
@@ -151,6 +166,7 @@ int main(int argc, char* argv[])
      * CLI parsing  |
      * ------------*/
     new QCoreApplication(argc, argv);
+    configureApp(false);
     CommandLineParser parser;
     // Add description
     parser.setDescription(
@@ -344,14 +360,12 @@ int main(int argc, char* argv[])
     Flameshot::setOrigin(Flameshot::CLI);
     if (parser.isSet(helpOption) || parser.isSet(versionOption)) {
     } else if (parser.isSet(launcherArgument)) { // LAUNCHER
-        delete qApp;
-        new QApplication(argc, argv);
+        reinitializeAsQApplication(argc, argv);
         Flameshot* flameshot = Flameshot::instance();
         flameshot->launcher();
         qApp->exec();
     } else if (parser.isSet(guiArgument)) { // GUI
-        delete qApp;
-        new QApplication(argc, argv);
+        reinitializeAsQApplication(argc, argv);
         // Prevent multiple instances of 'flameshot gui' from running if not
         // configured to do so.
         if (!ConfigHandler().allowMultipleGuiInstances()) {
@@ -414,10 +428,7 @@ int main(int argc, char* argv[])
         }
         requestCaptureAndWait(req);
     } else if (parser.isSet(fullArgument)) { // FULL
-        // Recreate the application as a QApplication
-        // TODO find a way so we don't have to do this
-        delete qApp;
-        new QApplication(argc, argv);
+        reinitializeAsQApplication(argc, argv);
 
         // Option values
         QString path = parser.value(pathOption);
@@ -452,10 +463,7 @@ int main(int argc, char* argv[])
         }
         requestCaptureAndWait(req);
     } else if (parser.isSet(screenArgument)) { // SCREEN
-        // Recreate the application as a QApplication
-        // TODO find a way so we don't have to do this
-        delete qApp;
-        new QApplication(argc, argv);
+        reinitializeAsQApplication(argc, argv);
 
         QString numberStr = parser.value(screenNumberOption);
         // Option values
@@ -526,8 +534,7 @@ int main(int argc, char* argv[])
         }
         if (!someFlagSet) {
             // Open gui when no options are given
-            delete qApp;
-            new QApplication(argc, argv);
+            reinitializeAsQApplication(argc, argv);
             QObject::connect(
               qApp, &QApplication::lastWindowClosed, qApp, &QApplication::quit);
             Flameshot::instance()->config();


### PR DESCRIPTION
Currently, languages are loaded only when invoking flameshot as a daemon, so localization doesn't work for the other invocation types. This fixes that.