### PR TITLE
applauncherwidget: enter key to launch current/first shown app

### DIFF
--- a/src/tools/launcher/applauncherwidget.cpp
+++ b/src/tools/launcher/applauncherwidget.cpp
@@ -305,6 +305,16 @@ void AppLauncherWidget::keyPressEvent(QKeyEvent* keyEvent)
 {
     if (keyEvent->key() == Qt::Key_Escape) {
         close();
+    } else if(keyEvent->key() == Qt::Key_Return) {
+        auto* widget = (QListWidget*)m_tabWidget->currentWidget();
+        if(m_filterList->isVisible()) widget = m_filterList;
+        auto* item = widget->currentItem();
+        if(item == nullptr) {
+            item = widget->item(0);
+            widget->setCurrentItem(item);
+        }
+        QModelIndex const idx = widget->currentIndex();
+        AppLauncherWidget::launch(idx);
     } else {
         QWidget::keyPressEvent(keyEvent);
     }


### PR DESCRIPTION
Currently with the open with program dialog, you have to click the application with the mouse. This can be inconvenient, especially when using keyboard shortcuts such as `ctrl+O`, and/or typing a filter.

This code allows for pressing the enter key to open.

If there is a "Currently selected" item, (e.g. one uses `shift+tab` to focus the control, and arrow keys to select), it will open that selected item.

If there is no current selection, it will use the first visible item.