### PR TITLE
added qt5-image-formats-plugins as optional dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,6 +412,7 @@ Also you can open and build/debug the project in a C++ IDE. For example, in Qt C
 - Git
 - OpenSSL
 - CA Certificates
+- QT Image Formats
 
 #### Debian
 
@@ -423,7 +424,7 @@ apt install g++ cmake build-essential qtbase5-dev qttools5-dev-tools libqt5svg5-
 apt install libqt5dbus5 libqt5network5 libqt5core5a libqt5widgets5 libqt5gui5 libqt5svg5
 
 # Optional
-apt install git openssl ca-certificates
+apt install git openssl ca-certificates qt5-image-formats-plugins
 ```
 
 #### Fedora


### PR DESCRIPTION
Added qt5-image-formats-plugins as optional dependency to README.md

It's required for to able save in WebP format.

I only added for Debian, missing packages needs to be added for other distros. 