### PR TITLE
Change text references from "arguments" to "subcommands"

### DIFF
--- a/src/cli/commandlineparser.cpp
+++ b/src/cli/commandlineparser.cpp
@@ -24,7 +24,7 @@ auto helpOption =
   CommandOption({ "h", "help" }, QStringLiteral("Displays this help"));
 
 QString optionsToString(const QList<CommandOption>& options,
-                        const QList<CommandArgument>& arguments)
+                        const QList<CommandArgument>& subcommands)
 {
     int size = 0; // track the largest size
     QStringList dashedOptionList;
@@ -42,10 +42,10 @@ QString optionsToString(const QList<CommandOption>& options,
         }
         dashedOptionList << joinedDashedOptions;
     }
-    // check the length of the arguments
-    for (auto const& arg : arguments) {
-        if (arg.name().length() > size) {
-            size = arg.name().length();
+    // check the length of the subcommands
+    for (auto const& subcommand : subcommands) {
+        if (subcommand.name().length() > size) {
+            size = subcommand.name().length();
         }
     }
     // generate the text
@@ -60,17 +60,17 @@ QString optionsToString(const QList<CommandOption>& options,
                         .arg(options.at(i).description().replace(
                           QLatin1String("\n"), linePadding));
         }
-        if (!arguments.isEmpty()) {
+        if (!subcommands.isEmpty()) {
             result += QLatin1String("\n");
         }
     }
-    if (!arguments.isEmpty()) {
-        result += QObject::tr("Arguments") + ":\n";
+    if (!subcommands.isEmpty()) {
+        result += QObject::tr("Subcommands") + ":\n";
     }
-    for (const auto& argument : arguments) {
+    for (const auto& subcommand : subcommands) {
         result += QStringLiteral("  %1  %2\n")
-                    .arg(argument.name().leftJustified(size, ' '))
-                    .arg(argument.description());
+                    .arg(subcommand.name().leftJustified(size, ' '))
+                    .arg(subcommand.description());
     }
     return result;
 }
@@ -326,7 +326,7 @@ void CommandLineParser::printHelp(QStringList args, const Node* node)
         argName = qApp->applicationName();
     }
     QString argText =
-      node->subNodes.isEmpty() ? "" : "[" + QObject::tr("arguments") + "]";
+      node->subNodes.isEmpty() ? "" : "[" + QObject::tr("subcommands") + "]";
     helpText += (QObject::tr("Usage") + ": %1 [%2-" + QObject::tr("options") +
                  QStringLiteral("] %3\n\n"))
                   .arg(args.join(QStringLiteral(" ")))
@@ -339,9 +339,9 @@ void CommandLineParser::printHelp(QStringList args, const Node* node)
     helpText += "\n\n";
 
     // add command options and subarguments
-    QList<CommandArgument> subArgs;
+    QList<CommandArgument> subcommands;
     for (const Node& n : node->subNodes) {
-        subArgs.append(n.argument);
+        subcommands.append(n.argument);
     }
     auto modifiedOptions = node->options;
     if (m_withHelp) {
@@ -350,7 +350,7 @@ void CommandLineParser::printHelp(QStringList args, const Node* node)
     if (m_withVersion && node == &m_parseTree) {
         modifiedOptions << versionOption;
     }
-    helpText += optionsToString(modifiedOptions, subArgs);
+    helpText += optionsToString(modifiedOptions, subcommands);
     // print it
     out << helpText;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -173,8 +173,9 @@ int main(int argc, char* argv[])
       QObject::tr("Powerful yet simple to use screenshot software."));
     parser.setGeneralErrorMessage(QObject::tr("See") + " flameshot --help.");
     // Arguments
-    CommandArgument fullArgument(QStringLiteral("full"),
-                                 QObject::tr("Capture the entire desktop."));
+    CommandArgument fullArgument(
+      QStringLiteral("full"),
+      QObject::tr("Capture screenshot of all monitors at the same time."));
     CommandArgument launcherArgument(QStringLiteral("launcher"),
                                      QObject::tr("Open the capture launcher."));
     CommandArgument guiArgument(
@@ -182,8 +183,9 @@ int main(int argc, char* argv[])
       QObject::tr("Start a manual capture in GUI mode."));
     CommandArgument configArgument(QStringLiteral("config"),
                                    QObject::tr("Configure") + " flameshot.");
-    CommandArgument screenArgument(QStringLiteral("screen"),
-                                   QObject::tr("Capture a single screen."));
+    CommandArgument screenArgument(
+      QStringLiteral("screen"),
+      QObject::tr("Capture a screenshot of the specified monitor."));
 
     // Options
     CommandOption pathOption(


### PR DESCRIPTION
Fixes #3226 

**CHANGES**
This PR changes text references in the `--help` command screen from "arguments" to "subcommands". The change is propagated to variable names in the code to avoid confusion where appropriate. 

There are also some changes in the subcommand description text to match the `man` page more closely. 

**TESTING CRITERIA**
1. Open the help screen with the command `flameshot --help`.
2. Notice that instead of references to "arguments", there are now references to "subcommands". 
3. Notice that descriptions for "full" and "screen" subcommands have been updated to cover scenarios relating to multiple monitors.   

If you would like me to make any changes please don't hesitate to let me know.