### PR TITLE
added randomize pixels function to pixelate tool

### DIFF
--- a/src/tools/pixelate/pixelatetool.cpp
+++ b/src/tools/pixelate/pixelatetool.cpp
@@ -8,6 +8,8 @@
 #include <QGraphicsScene>
 #include <QImage>
 #include <QPainter>
+#include <algorithm>
+#include <cstring>
 
 PixelateTool::PixelateTool(QObject* parent)
   : AbstractTwoPointTool(parent)
@@ -78,10 +80,21 @@ void PixelateTool::process(QPainter& painter, const QPixmap& pixmap)
         QPixmap t = pixmap.copy(selectionScaled);
         t = t.scaled(size, Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
         t = t.scaled(selection.width(), selection.height());
-        painter.drawImage(selection, t.toImage());
+        QImage image = t.toImage();
+        image = randomizePixels(image);
+        painter.drawImage(selection, image);
     }
 }
 
+QImage PixelateTool::randomizePixels(const QImage& image)
+{
+    QVector<QRgb> pixels(image.height() * image.width());
+    std::memcpy(pixels.data(), image.bits(), image.byteCount());
+    std::random_shuffle(pixels.begin(), pixels.end());
+    QImage shuffledImage(image.width(), image.height(), image.format());
+    std::memcpy(shuffledImage.bits(), pixels.data(), image.byteCount());
+    return shuffledImage;
+}
 void PixelateTool::drawSearchArea(QPainter& painter, const QPixmap& pixmap)
 {
     Q_UNUSED(pixmap)

--- a/src/tools/pixelate/pixelatetool.h
+++ b/src/tools/pixelate/pixelatetool.h
@@ -24,6 +24,7 @@ public:
 
 protected:
     CaptureTool::Type type() const override;
+    QImage randomizePixels(const QImage& image);
 
 public slots:
     void pressed(CaptureContext& context) override;


### PR DESCRIPTION
### Fixes #3289 

## Concerns
Pixelate tool's look changes completely. It now looks like white noise

## Changes 
- Added a randomize pixels function to pixelate tool
- Utilized `random_shuffle` from `<algorithm>` and `memcpy` from `<cstring>`

## Results of cursory test
### before
![lorem before](https://github.com/flameshot-org/flameshot/assets/60501848/27f3f05b-8e32-4a1a-9b3d-11a4a4aef930)

### after
![lorem after](https://github.com/flameshot-org/flameshot/assets/60501848/8ae7ff4e-3d7d-45b1-90b7-7e0c88d05116)



