### PR TITLE
Fix pin tool wrong offset on Linux

### DIFF
--- a/src/tools/pin/pinwidget.cpp
+++ b/src/tools/pin/pinwidget.cpp
@@ -58,7 +58,7 @@ PinWidget::PinWidget(const QPixmap& pixmap,
     new QShortcut(Qt::Key_Escape, this, SLOT(close()));
 
     qreal devicePixelRatio = 1;
-#if defined(Q_OS_MACOS)
+#if defined(Q_OS_MACOS) || defined(Q_OS_LINUX)
     QScreen* currentScreen = QGuiAppCurrentScreen().currentScreen();
     if (currentScreen != nullptr) {
         devicePixelRatio = currentScreen->devicePixelRatio();
@@ -72,7 +72,7 @@ PinWidget::PinWidget(const QPixmap& pixmap,
     setWindowFlags(Qt::X11BypassWindowManagerHint);
 #endif
 
-#if defined(Q_OS_MACOS)
+#if defined(Q_OS_MACOS) || defined(Q_OS_LINUX)
     if (currentScreen != nullptr) {
         QPoint topLeft = currentScreen->geometry().topLeft();
         adjusted_pos.setX((adjusted_pos.x() - topLeft.x()) / devicePixelRatio +


### PR DESCRIPTION
The "pin" tool shows the screenshot at the wrong place (sometimes offscreen) on Linux when HiDPI is on:

![](https://github.com/flameshot-org/flameshot/assets/16379418/6d2dc8e5-8f82-47a9-a883-c61d5fb51979)
![Screenshot_20231009_154759](https://github.com/flameshot-org/flameshot/assets/16379418/620280a3-c625-4567-964a-6abad75bda31)
