### PR TITLE
Add shortcut for "Grab Color" feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ These shortcuts are available in GUI mode:
 | <kbd>M</kbd>                                          | Set the Marker as paint tool |
 | <kbd>T</kbd>                                          | Add text to your capture |
 | <kbd>B</kbd>                                          | Set Pixelate as the paint tool |
+| <kbd>G</kbd>                                          | Grab the color you want |
 | <kbd>←</kbd>, <kbd>↓</kbd>, <kbd>↑</kbd>, <kbd>→</kbd>                    | Move selection 1px                                             |
 | <kbd>Shift</kbd> + <kbd>←</kbd>, <kbd>↓</kbd>, <kbd>↑</kbd>, <kbd>→</kbd> | Resize selection 1px                                           |
 | <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>←</kbd>, <kbd>↓</kbd>, <kbd>↑</kbd>, <kbd>→</kbd> | Symmetrically resize selection 2px                                           |

--- a/src/config/shortcutswidget.cpp
+++ b/src/config/shortcutswidget.cpp
@@ -171,6 +171,7 @@ void ShortcutsWidget::loadShortcuts()
     }
 
     // additional tools that don't have their own buttons
+    appendShortcut("TYPE_COLORGRAB", tr("Grab a color"));
     appendShortcut("TYPE_TOGGLE_PANEL", tr("Toggle side panel"));
     appendShortcut("TYPE_RESIZE_LEFT", tr("Resize selection left 1px"));
     appendShortcut("TYPE_RESIZE_RIGHT", tr("Resize selection right 1px"));

--- a/src/utils/confighandler.cpp
+++ b/src/utils/confighandler.cpp
@@ -137,6 +137,7 @@ static QMap<QString, QSharedPointer<KeySequence>> recognizedShortcuts = {
     SHORTCUT("TYPE_RECTANGLE"           ,   "R"                     ),
     SHORTCUT("TYPE_CIRCLE"              ,   "C"                     ),
     SHORTCUT("TYPE_MARKER"              ,   "M"                     ),
+    SHORTCUT("TYPE_COLORGRAB"           ,   "G"                     ),
     SHORTCUT("TYPE_MOVESELECTION"       ,   "Ctrl+M"                ),
     SHORTCUT("TYPE_UNDO"                ,   "Ctrl+Z"                ),
     SHORTCUT("TYPE_COPY"                ,   "Ctrl+C"                ),

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -1512,6 +1512,10 @@ void CaptureWidget::removeToolObject(int index)
 
 void CaptureWidget::initShortcuts()
 {
+    newShortcut(QKeySequence(ConfigHandler().shortcut("TYPE_COLORGRAB")),
+                this,
+                SLOT(grabColor()));
+
     newShortcut(
       QKeySequence(ConfigHandler().shortcut("TYPE_UNDO")), this, SLOT(undo()));
 
@@ -1810,6 +1814,11 @@ QList<QShortcut*> CaptureWidget::newShortcut(const QKeySequence& key,
         shortcuts << new QShortcut(key, parent, slot);
     }
     return shortcuts;
+}
+
+void CaptureWidget::grabColor()
+{
+    m_sidePanel->startColorGrab();
 }
 
 void CaptureWidget::togglePanel()

--- a/src/widgets/capture/capturewidget.h
+++ b/src/widgets/capture/capturewidget.h
@@ -67,6 +67,7 @@ signals:
     void toolSizeChanged(int size);
 
 private slots:
+    void grabColor();
     void undo();
     void redo();
     void togglePanel();

--- a/src/widgets/panel/sidepanelwidget.h
+++ b/src/widgets/panel/sidepanelwidget.h
@@ -38,9 +38,9 @@ signals:
 public slots:
     void onToolSizeChanged(int tool);
     void onColorChanged(const QColor& color);
+    void startColorGrab();
 
 private slots:
-    void startColorGrab();
     void onColorGrabFinished();
     void onColorGrabAborted();
     void onTemporaryColorUpdated(const QColor& color);


### PR DESCRIPTION
Added a shortcut for the "Grab Color" feature, addressing the issue #3384.
Also updated the README for this shortcut.