### PR TITLE
CMake: Add missing copying icons commands

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -45,6 +45,15 @@ if (APPLE)
             COMMAND bash "-c" "iconutil -o \"${FLAMESHOT_ICNS}\" -c icns ${FLAMESHOT_ICONSET}"
     )
 
+    execute_process(
+        COMMAND bash "-c" "rm -R \"${FLAMESHOT_ICONSET}\""
+    )
+
+    execute_process(
+        # copy icon from cache generated on the localhost if generation on CI failed
+        COMMAND bash "-c" "[[ -r '\"${FLAMESHOT_ICNS}\"' ]] || cp \"${CMAKE_SOURCE_DIR}\"/packaging/macos/flameshot.icns \"${FLAMESHOT_ICNS}\""
+    )
+
     # Set application icon
     set(MACOSX_BUNDLE_ICON_FILE flameshot.icns)
 


### PR DESCRIPTION
Those copy operations are deleted in this commit 5e5fdb12a022b71237b340fc1c5f8a8887a8c779 This commit adds them with the new `CMake` variables.