### PR TITLE
Add screenshot capture method for D-Bus

### DIFF
--- a/data/dbus/org.flameshot.Flameshot.xml
+++ b/data/dbus/org.flameshot.Flameshot.xml
@@ -36,5 +36,15 @@
       <arg name="notification" type="s" direction="in"/>
     </method>
 
+    <!--
+       captureScreen:
+       @captureMode: Desired mode of capture.
+
+       Allow the user to capture a screenshot over DBus.
+    -->
+    <method name="captureScreen">
+      <arg name="captureMode" type="q" direction="in"/>
+    </method>
+
   </interface>
 </node>

--- a/data/dbus/org.flameshot.Flameshot.xml
+++ b/data/dbus/org.flameshot.Flameshot.xml
@@ -38,7 +38,7 @@
 
     <!--
        captureScreen:
-       @captureMode: Desired mode of capture.
+       @captureMode: Desired mode of capture, 0 for fullscreen, 1 for graphical, 2 for screen.
 
        Allow the user to capture a screenshot over DBus.
     -->

--- a/src/core/flameshotdbusadapter.cpp
+++ b/src/core/flameshotdbusadapter.cpp
@@ -27,10 +27,12 @@ void FlameshotDBusAdapter::attachPin(const QByteArray& data)
     FlameshotDaemon::instance()->attachPin(data);
 }
 
-void FlameshotDBusAdapter::captureScreen(const QString& captureMode) {
+void FlameshotDBusAdapter::captureScreen(const QString& captureMode)
+{
     int const captureModeInt = captureMode.toInt();
-    if(captureModeInt < 0 || captureModeInt > 3) {
+    if (captureModeInt < 0 || captureModeInt > 3) {
         return;
     }
-    Flameshot::instance()->requestCapture(CaptureRequest::CaptureMode(captureModeInt));
+    Flameshot::instance()->requestCapture(
+      CaptureRequest::CaptureMode(captureModeInt));
 }

--- a/src/core/flameshotdbusadapter.cpp
+++ b/src/core/flameshotdbusadapter.cpp
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: 2017-2019 Alejandro Sirgo Rica & Contributors
 
 #include "flameshotdbusadapter.h"
+#include "src/core/flameshot.h"
 #include "src/core/flameshotdaemon.h"
 
 FlameshotDBusAdapter::FlameshotDBusAdapter(QObject* parent)
@@ -24,4 +25,12 @@ void FlameshotDBusAdapter::attachTextToClipboard(const QString& text,
 void FlameshotDBusAdapter::attachPin(const QByteArray& data)
 {
     FlameshotDaemon::instance()->attachPin(data);
+}
+
+void FlameshotDBusAdapter::captureScreen(const QString& captureMode) {
+    int const captureModeInt = captureMode.toInt();
+    if(captureModeInt < 0 || captureModeInt > 3) {
+        return;
+    }
+    Flameshot::instance()->requestCapture(CaptureRequest::CaptureMode(captureModeInt));
 }

--- a/src/core/flameshotdbusadapter.h
+++ b/src/core/flameshotdbusadapter.h
@@ -19,4 +19,5 @@ public slots:
     Q_NOREPLY void attachTextToClipboard(const QString& text,
                                          const QString& notification);
     Q_NOREPLY void attachPin(const QByteArray& data);
+    Q_NOREPLY void captureScreen(const QString& captureMode);
 };


### PR DESCRIPTION
I've added a new D-Bus method allowing the screen to be captured via `dbus-send --session --dest=org.flameshot.Flameshot --type=method_call / org.flameshot.Flameshot.captureScreen string:1` for example.

Having a way to invoke a screen capture via an existing process improves performance drastically when running Flameshot via a shortcut for example, as the official recommended method of executing `flameshot gui` every time you want to take a screenshot spawns a new instance each time whereas this method allows it to be executed with the instance of Flameshot running in the system tray.

Please let me know if this is an improper use of D-Bus of course, I just believe it's a nice addition to improve performance.