### PR TITLE
Implement basic functionality: detect a single-line box around mouse cursor.

### DIFF
--- a/data/shell-completion/flameshot.fish
+++ b/data/shell-completion/flameshot.fish
@@ -83,6 +83,7 @@ __flameshot_complete gui -l "print-geometry"    -s "g"  -f   -d "Print geometry 
 __flameshot_complete gui -l "upload"            -s "u"  -f   -d "Upload the screenshot"
 __flameshot_complete gui -l "pin"                       -f   -d "Pin the screenshot to the screen"
 __flameshot_complete gui -l "accept-on-select"  -s "s"  -f   -d "Accept capture as soon as a selection is made"
+__flameshot_complete gui -l "post"              -s "q"  -f   -d "Capture the post the mouse is hovering over"
 
 # SCREEN subcommand
 __flameshot_complete screen                             -f

--- a/data/shell-completion/flameshot.fish
+++ b/data/shell-completion/flameshot.fish
@@ -83,7 +83,7 @@ __flameshot_complete gui -l "print-geometry"    -s "g"  -f   -d "Print geometry 
 __flameshot_complete gui -l "upload"            -s "u"  -f   -d "Upload the screenshot"
 __flameshot_complete gui -l "pin"                       -f   -d "Pin the screenshot to the screen"
 __flameshot_complete gui -l "accept-on-select"  -s "s"  -f   -d "Accept capture as soon as a selection is made"
-__flameshot_complete gui -l "post"              -s "q"  -f   -d "Capture the post the mouse is hovering over"
+__flameshot_complete gui -l "box"               -s "q"  -f   -d "Capture the box around the mouse cursor"
 
 # SCREEN subcommand
 __flameshot_complete screen                             -f

--- a/src/core/capturerequest.cpp
+++ b/src/core/capturerequest.cpp
@@ -86,3 +86,13 @@ void CaptureRequest::setInitialSelection(const QRect& selection)
 {
     m_initialSelection = selection;
 }
+
+void CaptureRequest::setCheckForBox()
+{
+    checkForBox = true;
+}
+
+bool CaptureRequest::getCheckForBox() const
+{
+    return checkForBox;
+}

--- a/src/core/capturerequest.h
+++ b/src/core/capturerequest.h
@@ -49,6 +49,8 @@ public:
     void addSaveTask(const QString& path = QString());
     void addPinTask(const QRect& pinWindowGeometry);
     void setInitialSelection(const QRect& selection);
+    void setCheckForBox();
+    bool getCheckForBox() const;
 
 private:
     CaptureMode m_mode;
@@ -57,6 +59,7 @@ private:
     ExportTask m_tasks;
     QVariant m_data;
     QRect m_pinWindowGeometry, m_initialSelection;
+    bool checkForBox = false;
 
     CaptureRequest() {}
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -124,11 +124,6 @@ void reinitializeAsQApplication(int& argc, char* argv[])
     configureApp(true);
 }
 
-QRect getSurroundingBox(QPoint pos)
-{
-    return QRect(pos.x()-50, pos.y()-50, 100, 100); // BUGBUG for now, a 100x100 square centered on the mouse cursor
-}
-
 int main(int argc, char* argv[])
 {
 #ifdef Q_OS_LINUX
@@ -199,8 +194,8 @@ int main(int argc, char* argv[])
       QStringLiteral("path"));
     CommandOption clipboardOption(
       { "c", "clipboard" }, QObject::tr("Save the capture to the clipboard"));
-    CommandOption postOption(
-      { "q", "post" }, QObject::tr("Capture the post the mouse is hovering over"));
+    CommandOption boxOption(
+      { "q", "box" }, QObject::tr("Capture the box around the mouse cursor"));
     CommandOption pinOption("pin",
                             QObject::tr("Pin the capture to the screen"));
     CommandOption uploadOption({ "u", "upload" },
@@ -326,7 +321,7 @@ int main(int argc, char* argv[])
     auto versionOption = parser.addVersionOption();
     parser.AddOptions({ pathOption,
                         clipboardOption,
-                        postOption,
+                        boxOption,
                         delayOption,
                         regionOption,
                         useLastRegionOption,
@@ -399,7 +394,7 @@ int main(int argc, char* argv[])
         QString region = parser.value(regionOption);
         bool useLastRegion = parser.isSet(useLastRegionOption);
         bool clipboard = parser.isSet(clipboardOption);
-        bool post = parser.isSet(postOption);
+        bool box = parser.isSet(boxOption);
         bool raw = parser.isSet(rawImageOption);
         bool printGeometry = parser.isSet(selectionOption);
         bool pin = parser.isSet(pinOption);
@@ -437,12 +432,9 @@ int main(int argc, char* argv[])
                 req.addSaveTask();
             }
         }
-        // If the "find a post" option is set, look for one under the mouse cursor.
-        if ( parser.isSet(postOption) ) {
-            QPoint pos = QCursor::pos();
-            QRect r;
-            r = getSurroundingBox(pos);
-            req.setInitialSelection(r);
+        // If the "find a box" option is set, set a flag in the req to look for it later.
+        if (box) {
+            req.setCheckForBox();
         }
         requestCaptureAndWait(req);
     } else if (parser.isSet(fullArgument)) { // FULL


### PR DESCRIPTION
Implement basic functionality: detect a single-line box around mouse cursor.

This addresses Issue #3416 (I am new at this, please guide me if I’m making mistakes).

Invoke with "flameshot gui --box", while the mouse cursor is inside a box, preferably over a background color.

I changed it to "box" instead of "post" as that's more general.

This is my first "large" contribution so please let me know if there's anything I missed?  Thanks!  (I had wanted to comment on the above issue, but it appears if I comment it will close it, which wasn’t what I wanted.  So, making the Pull Request first, instead.)

ISSUES:

1. Note that I have not translated any strings that I added into other languages.

2. I have not updated documentation.

3. I have not tested on multiple monitors.

FUTURE:

1. Want to add the two features I mentioned in Issue #3416: allow for rounded corners by ignoring a percentage, or a certain number of pixels, of the ends of the lines being detected; and, an option to keep detecting until a border of a certain size has been found.

2. Want to add the "background color detection" mentioned in Issue #3416: basically, count the pixels of each different color inside the box being checked, and the highest count is the background.  (For efficiency: save the result and then only add the "box/lines just inside the four edges" to the calculation, similar to how the line-detection code only checks for the first and last pixels of an already-detected line as it grows in place.)

3. Want to add another icon/button, so the user can click that, then click anywhere on the screen, and have it perform the box detection and auto-select a region.  In other words, freeze the screen first, then select.  One use case is: hover over a link which causes a popup to appear, and the user wants to capture that popup.  Trying to move the mouse inside the box to be captured, though, moves the mouse off the link, and the popup goes away.  So to capture those, will need this additional feature.

GENERAL ISSUES:

1. I'd like to merge the strings in the code with the strings in flameshot.fish; there's duplication there, and the risk is that someone may update one, and not the other.  Can they pull from a common source?  (Probably I should create an "Issue" about this?)