### PR TITLE
fix for QRect keep width and height

### DIFF
--- a/src/tools/accept/accepttool.cpp
+++ b/src/tools/accept/accepttool.cpp
@@ -51,7 +51,7 @@ void AcceptTool::pressed(CaptureContext& context)
     emit requestAction(REQ_CAPTURE_DONE_OK);
     if (context.request.tasks() & CaptureRequest::PIN) {
         QRect geometry = context.selection;
-        geometry.moveTopLeft(geometry.topLeft() + context.widgetOffset);
+        geometry.moveTo(geometry.topLeft() + context.widgetOffset);
         context.request.addTask(CaptureRequest::PIN);
     }
     emit requestAction(REQ_CLOSE_GUI);

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -276,7 +276,7 @@ CaptureWidget::~CaptureWidget()
         auto lastRegion = m_selection->geometry();
         setLastRegion(lastRegion);
         QRect geometry(m_context.selection);
-        geometry.setTopLeft(geometry.topLeft() + m_context.widgetOffset);
+        geometry.moveTo(geometry.topLeft() + m_context.widgetOffset);
         Flameshot::instance()->exportCapture(
           pixmap(), geometry, m_context.request);
     } else {


### PR DESCRIPTION
setTopLeft() call here will make QRect width and height changed, should use moveTo().
eg. when widgetOffset(-100, -100), geometry(x:0,y:0,w:100, h:100).
after setTopLeft(), geometry(x:-100,y:-100,w:200,h:200)
use moveTo, geometry(x:-100,y:-100,w:100,h:100)
fix i[ssue#3022](https://github.com/flameshot-org/flameshot/issues/3022)