### PR TITLE
Add method of editing a pinned screenshot

### DIFF
--- a/src/core/flameshotdaemon.h
+++ b/src/core/flameshotdaemon.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "pinwidget.h"
 #include <QByteArray>
 #include <QObject>
 #include <QtDBus/QDBusAbstractAdaptor>
@@ -27,6 +28,7 @@ public:
     static void copyToClipboard(const QPixmap& capture);
     static void copyToClipboard(const QString& text,
                                 const QString& notification = "");
+    static void editPin(PinWidget& pinned);
     static bool isThisInstanceHostingWidgets();
 
     void sendTrayNotification(

--- a/src/tools/pin/pinwidget.cpp
+++ b/src/tools/pin/pinwidget.cpp
@@ -7,6 +7,7 @@
 #include "pinwidget.h"
 #include "qguiappcurrentscreen.h"
 #include "screenshotsaver.h"
+#include "src/core/flameshotdaemon.h"
 #include "src/utils/confighandler.h"
 #include "src/utils/globalvalues.h"
 
@@ -328,6 +329,10 @@ void PinWidget::showContextMenu(const QPoint& pos)
             &PinWidget::decreaseOpacity);
     contextMenu.addAction(&decreaseOpacityAction);
 
+    QAction editAction(tr("Edit Pin"), this);
+    connect(&editAction, &QAction::triggered, this, &PinWidget::edit);
+    contextMenu.addAction(&editAction);
+
     QAction closePinAction(tr("Close"), this);
     connect(&closePinAction, &QAction::triggered, this, &PinWidget::closePin);
     contextMenu.addSeparator();
@@ -340,9 +345,15 @@ void PinWidget::copyToClipboard()
 {
     saveToClipboard(m_pixmap);
 }
+
 void PinWidget::saveToFile()
 {
     hide();
     saveToFilesystemGUI(m_pixmap);
     show();
+}
+
+void PinWidget::edit()
+{
+    FlameshotDaemon::editPin(*this);
 }

--- a/src/tools/pin/pinwidget.h
+++ b/src/tools/pin/pinwidget.h
@@ -61,4 +61,5 @@ private slots:
     void showContextMenu(const QPoint& pos);
     void copyToClipboard();
     void saveToFile();
+    void edit();
 };


### PR DESCRIPTION
Add a method to allow editing a pinned screenshot by initiating a new screenshot over top of the pinned image, and then closing the old pinned image on success.

Apologies for not proposing this method on the linked issue first, I wanted to have a poke at the code today and didn't expect to get this far.

This adds a new context menu to pinned screenshots. When selected the PinWidget will call the daemon to do the work. Thus this functionality only works when flameshot is running in daemon mode. The context menu options don't show up when not running in daemon mode (I don't know why they don't show up, other ones like the rotate and opacity ones also don't show up).

Here is a professional video recording of how it works:

https://github.com/flameshot-org/flameshot/assets/7419144/bd96a640-2446-4f38-bbb2-f360d7de8a11

This is not the ideal method of doing this, it doesn't actually edit the screenshot at all. I call it the "bait and switch" method of editing. The only previous attempt that I've soon to do this got caught up in dealing with screens with different DPI (#1565). While it would be amazing to be able to limit the whole "grab" region to be less than a screen, or even just one screen, I think this method of editing a pin in the full desktop capture mode is a step forward. It sure is for my workflow anyhow.

I'm not familiar with c++ or this codebase so if there looks to be anything weird in this PR it's probably due to ignorance.

I'm calling FlameshotDaemon from PinWidget, I'm not sure if I should be doing that or trying to access the Flameshot singleton directly, I just copied off of another tool which called `FlameshotDaemon::copyToClipboard()`.

I'm not sure if doing `.geometry() - .layout()->contentsMargins()` is the correct way to get the image geometry, I was guided by what attributes I could see in GammaRay while inspecting a running flameshot.

The method of disconnecting from the signals from within the lambdas is from here: https://stackoverflow.com/questions/14828678/disconnecting-lambda-functions-in-qt5

I contemplated calling the method in Flameshot "replacePin" or "captureFromPin" or something more technically accurate. But I figured the signature could stay a bit optimistic and if people would like the behaviour to be firmed up to match the goal in the future that could be done. Eg add functionality to the CaptureWidget to make it so you can't modify the selection region, change the grab region to be less than the whole desktop etc.

Known issues:

* you can move/resize the selection region, eg not just edit a pin but create a completely different one of a different region of the screen

Relates to: https://github.com/flameshot-org/flameshot/issues/954