### PR TITLE
Include showStartupLaunchMessage in example ini file

### DIFF
--- a/flameshot.example.ini
+++ b/flameshot.example.ini
@@ -63,6 +63,9 @@
 ;; Launch at startup (bool)
 ;startupLaunch=true
 ;
+;; Show greeting message on startup (bool)
+;showStartupLaunchMessage=true
+;
 ;; Opacity of area outside selection (int in range 0-255)
 ;contrastOpacity=190
 ;


### PR DESCRIPTION
I found out about this option from Home Manager setting examples and was surprised to see it was not included in the official ini example. Adding it there should help discoverability of the setting.

Now using a non-master branch.