### PR TITLE
Add new option where arrow can be drawn in a reveresed way. Fixed #2144

### DIFF
--- a/src/config/generalconf.cpp
+++ b/src/config/generalconf.cpp
@@ -65,6 +65,7 @@ GeneralConf::GeneralConf(QWidget* parent)
     initShowMagnifier();
     initSquareMagnifier();
     initJpegQuality();
+    initReverseArrow();
     // this has to be at the end
     initConfigButtons();
     updateComponents();
@@ -93,6 +94,7 @@ void GeneralConf::_updateComponents(bool allowEmptySavePath)
     m_showMagnifier->setChecked(config.showMagnifier());
     m_squareMagnifier->setChecked(config.squareMagnifier());
     m_saveLastRegion->setChecked(config.saveLastRegion());
+    m_reverseArrow->setChecked(config.reverseArrow());
 
 #if !defined(Q_OS_WIN)
     m_autoCloseIdleDaemon->setChecked(config.autoCloseIdleDaemon());
@@ -799,6 +801,16 @@ void GeneralConf::initJpegQuality()
             &GeneralConf::setJpegQuality);
 }
 
+void GeneralConf::initReverseArrow()
+{
+    m_reverseArrow = new QCheckBox(tr("Reverse arrow"), this);
+    m_reverseArrow->setToolTip(tr("Draw the arrow head first"));
+    m_scrollAreaLayout->addWidget(m_reverseArrow);
+
+    connect(
+      m_reverseArrow, &QCheckBox::clicked, this, &GeneralConf::setReverseArrow);
+}
+
 void GeneralConf::setSelGeoHideTime(int v)
 {
     ConfigHandler().setValue("showSelectionGeometryHideTime", v);
@@ -828,4 +840,9 @@ void GeneralConf::setSaveAsFileExtension(const QString& extension)
 void GeneralConf::useJpgForClipboardChanged(bool checked)
 {
     ConfigHandler().setUseJpgForClipboard(checked);
+}
+
+void GeneralConf::setReverseArrow(bool checked)
+{
+    ConfigHandler().setReverseArrow(checked);
 }

--- a/src/config/generalconf.h
+++ b/src/config/generalconf.h
@@ -58,6 +58,7 @@ private slots:
     void setGeometryLocation(int index);
     void setSelGeoHideTime(int v);
     void setJpegQuality(int v);
+    void setReverseArrow(bool checked);
 
 private:
     const QString chooseFolder(const QString& currentPath = "");
@@ -92,6 +93,7 @@ private:
     void initSaveLastRegion();
     void initShowSelectionGeometry();
     void initJpegQuality();
+    void initReverseArrow();
 
     void _updateComponents(bool allowEmptySavePath);
 
@@ -136,4 +138,5 @@ private:
     QComboBox* m_selectGeometryLocation;
     QSpinBox* m_xywhTimeout;
     QSpinBox* m_jpegQuality;
+    QCheckBox* m_reverseArrow;
 };

--- a/src/tools/arrow/arrowtool.cpp
+++ b/src/tools/arrow/arrowtool.cpp
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: 2017-2019 Alejandro Sirgo Rica & Contributors
 
 #include "arrowtool.h"
+#include "confighandler.h"
 #include <cmath>
 
 namespace {
@@ -148,10 +149,15 @@ void ArrowTool::copyParams(const ArrowTool* from, ArrowTool* to)
 
 void ArrowTool::process(QPainter& painter, const QPixmap& pixmap)
 {
+    bool isArrowReversed = ConfigHandler().reverseArrow();
+
+    const QPoint& head = isArrowReversed ? points().second : points().first;
+    const QPoint& tail = isArrowReversed ? points().first : points().second;
+
     Q_UNUSED(pixmap)
     painter.setPen(QPen(color(), size()));
-    painter.drawLine(getShorterLine(points().first, points().second, size()));
-    m_arrowPath = getArrowHead(points().first, points().second, size());
+    painter.drawLine(getShorterLine(head, tail, size()));
+    m_arrowPath = getArrowHead(head, tail, size());
     painter.fillPath(m_arrowPath, QBrush(color()));
 }
 

--- a/src/utils/confighandler.cpp
+++ b/src/utils/confighandler.cpp
@@ -125,7 +125,8 @@ static QMap<class QString, QSharedPointer<ValueHandler>>
     OPTION("uploadClientSecret"          ,String             ( "313baf0c7b4d3ff"            )),
     OPTION("showSelectionGeometry"  , BoundedInt               (0,5,4)),
     OPTION("showSelectionGeometryHideTime", LowerBoundedInt       (0, 3000)),
-    OPTION("jpegQuality", BoundedInt     (0,100,75))
+    OPTION("jpegQuality", BoundedInt     (0,100,75)),
+    OPTION("reverseArrow"                    ,Bool               ( false      )),
 };
 
 static QMap<QString, QSharedPointer<KeySequence>> recognizedShortcuts = {

--- a/src/utils/confighandler.h
+++ b/src/utils/confighandler.h
@@ -127,6 +127,7 @@ public:
     CONFIG_GETTER_SETTER(saveLastRegion, setSaveLastRegion, bool)
     CONFIG_GETTER_SETTER(showSelectionGeometry, setShowSelectionGeometry, int)
     CONFIG_GETTER_SETTER(jpegQuality, setJpegQuality, int)
+    CONFIG_GETTER_SETTER(reverseArrow, setReverseArrow, bool)
     CONFIG_GETTER_SETTER(showSelectionGeometryHideTime,
                          showSelectionGeometryHideTime,
                          int)


### PR DESCRIPTION
This PR attempts to fix #2144 where arrow can be drawn in a reversed way.
The head will be drawn first, the tail later.
This behavior can be toggled via configuration.

TODO Add showcase videos and images.
