### PR TITLE
fix content-type header in imgur uploader request

### DIFF
--- a/src/tools/imgupload/storages/imgur/imguruploader.cpp
+++ b/src/tools/imgupload/storages/imgur/imguruploader.cpp
@@ -74,7 +74,7 @@ void ImgurUploader::upload()
     url.setQuery(urlQuery);
     QNetworkRequest request(url);
     request.setHeader(QNetworkRequest::ContentTypeHeader,
-                      "application/application/x-www-form-urlencoded");
+                      "application/x-www-form-urlencoded");
     request.setRawHeader("Authorization",
                          QStringLiteral("Client-ID %1")
                            .arg(ConfigHandler().uploadClientSecret())


### PR DESCRIPTION
The request made to imgur has an incorrect content-type header.

Original (incorrect):
*application/x-www-form-urlencoded*

Modified (correct):
**application/x-www-form-urlencoded**