### PR TITLE
Fix Windows CI

### DIFF
--- a/.github/workflows/Windows-pack.yml
+++ b/.github/workflows/Windows-pack.yml
@@ -1,9 +1,10 @@
 name: Packaging(Windows)
 
 on:
+  workflow_dispatch
   push:
     branches:
-      - master*
+      - master
     paths-ignore:
       - 'README.md'
       - 'LICENSE'

--- a/.github/workflows/Windows-pack.yml
+++ b/.github/workflows/Windows-pack.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - fix*
     paths-ignore:
       - 'README.md'
       - 'LICENSE'

--- a/.github/workflows/Windows-pack.yml
+++ b/.github/workflows/Windows-pack.yml
@@ -81,7 +81,7 @@ jobs:
           echo "VERSION=$(cat CMakeLists.txt |grep 'set.*(.*FLAMESHOT_VERSION' | sed 's/[^0-9.]*//' |sed 's/)//g')" >> $GITHUB_ENV
 
       - name: Restore from cache and run vcpkg
-        uses: lukka/run-vcpkg@v4
+        uses: lukka/run-vcpkg@v11
         with:
           vcpkgArguments: ${{env.VCPKG_PACKAGES}}
           vcpkgDirectory: '${{ github.workspace }}\vcpkg'

--- a/.github/workflows/Windows-pack.yml
+++ b/.github/workflows/Windows-pack.yml
@@ -1,7 +1,6 @@
 name: Packaging(Windows)
 
 on:
-  workflow_dispatch
   push:
     branches:
       - master
@@ -13,6 +12,8 @@ on:
     paths-ignore:
       - 'README.md'
       - 'LICENSE'
+  workflow_dispatch:
+
 
 env:
   PRODUCT: flameshot


### PR DESCRIPTION
Due to certain deprications in the action workflow we use, the Windows CI was failing. It now works with minor warnings that I will try to fix in other PRs. I am putting this as a separate PR due to priority and because the current CI is completely failing and with these changes we just get some warnings, but at least the CI runs and produces the artifacts for our nightly builds.