### PR TITLE
Fix update cis

### DIFF
--- a/.github/workflows/Linux-pack.yml
+++ b/.github/workflows/Linux-pack.yml
@@ -563,7 +563,7 @@ jobs:
           echo "================================"
           echo "VERSION=${last_committed_tag:1}" >> $GITHUB_ENV
       - name: Packaging snap
-        uses: snapcore/action-build@v1
+        uses: snapcore/action-build@v1.2.0
         id: snapcraft
         with: 
           snapcraft-args: --enable-experimental-extensions

--- a/.github/workflows/Linux-pack.yml
+++ b/.github/workflows/Linux-pack.yml
@@ -2,16 +2,24 @@ name: Packaging(Linux)
 
 on:
   push:
-    branches:
-      - master
+    branches: [ master ]
     paths-ignore:
       - 'README.md'
       - 'LICENSE'
+      - 'CODE_OF_CONDUCT.md'
+      - 'shell.nix'
+      - 'docs/**'
 
   pull_request:
+    branches: [ master ]
     paths-ignore:
       - 'README.md'
       - 'LICENSE'
+      - 'CODE_OF_CONDUCT.md'
+      - 'shell.nix'
+      - 'docs/**'
+
+  workflow_dispatch:
 
 env:
   PRODUCT: flameshot

--- a/.github/workflows/MacOS-pack.yml
+++ b/.github/workflows/MacOS-pack.yml
@@ -2,17 +2,24 @@ name: Packaging(MacOS)
 
 on:
   push:
-    branches:
-      - master
-      - feature/RND-680-macos-.dmg-package-build
+    branches: [ master ]
     paths-ignore:
       - 'README.md'
       - 'LICENSE'
+      - 'CODE_OF_CONDUCT.md'
+      - 'shell.nix'
+      - 'docs/**'
 
   pull_request:
+    branches: [ master ]
     paths-ignore:
       - 'README.md'
       - 'LICENSE'
+      - 'CODE_OF_CONDUCT.md'
+      - 'shell.nix'
+      - 'docs/**'
+
+  workflow_dispatch:
 
 env:
   PRODUCT: flameshot

--- a/.github/workflows/Windows-pack.yml
+++ b/.github/workflows/Windows-pack.yml
@@ -90,7 +90,7 @@ jobs:
           echo "VERSION=$(cat CMakeLists.txt |grep 'set.*(.*FLAMESHOT_VERSION' | sed 's/[^0-9.]*//' |sed 's/)//g')" >> $GITHUB_ENV
 
       - name: Restore from cache and run vcpkg
-        uses: lukka/run-vcpkg@v11
+        uses: lukka/run-vcpkg@v11.5
         with:
           vcpkgArguments: ${{env.VCPKG_PACKAGES}}
           vcpkgDirectory: '${{ github.workspace }}\vcpkg'
@@ -100,13 +100,13 @@ jobs:
 
       - name: Cache Qt
         id: cache-qt
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ./build/Qt/${{ matrix.qt_ver }}/${{ matrix.config.qt_arch_install }}
           key: ${{ runner.os }}-QtCache/${{ matrix.qt_ver }}/${{ matrix.config.qt_arch }}
 
       - name: Install Qt
-        uses: jurplel/install-qt-action@v2
+        uses: jurplel/install-qt-action@v3.3.0
         with:
           version: ${{ matrix.qt_ver }}
           target:  ${{ matrix.qt_target }}

--- a/.github/workflows/Windows-pack.yml
+++ b/.github/workflows/Windows-pack.yml
@@ -2,17 +2,23 @@ name: Packaging(Windows)
 
 on:
   push:
-    branches:
-      - master
-      - fix*
+    branches: [ master ]
     paths-ignore:
       - 'README.md'
       - 'LICENSE'
+      - 'CODE_OF_CONDUCT.md'
+      - 'shell.nix'
+      - 'docs/**'
 
   pull_request:
+    branches: [ master ]
     paths-ignore:
       - 'README.md'
       - 'LICENSE'
+      - 'CODE_OF_CONDUCT.md'
+      - 'shell.nix'
+      - 'docs/**'
+
   workflow_dispatch:
 
 

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -110,13 +110,13 @@ jobs:
 
       - name: Cache Qt
         id: cache-qt
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ./build/Qt
           key: ${{ runner.os }}-QtCache
 
       - name: Install Qt
-        uses: jurplel/install-qt-action@v2
+        uses: jurplel/install-qt-action@v3.3.0
         with:
           version: 5.15.2
           target:  desktop

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -6,11 +6,20 @@ on:
     paths-ignore:
       - 'README.md'
       - 'LICENSE'
+      - 'CODE_OF_CONDUCT.md'
+      - 'shell.nix'
+      - 'docs/**'
+
   pull_request:
     branches: [ master ]
     paths-ignore:
       - 'README.md'
       - 'LICENSE'
+      - 'CODE_OF_CONDUCT.md'
+      - 'shell.nix'
+      - 'docs/**'
+
+  workflow_dispatch:
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -15,7 +15,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         ref: ${{ github.event.pull_request.head.sha }}
-    - uses: DoozyX/clang-format-lint-action@v0.13
+    - uses: DoozyX/clang-format-lint-action@v0.17
       with:
         source: './src'
         extensions: 'h,cpp'

--- a/.github/workflows/deploy-dev-docs.yml
+++ b/.github/workflows/deploy-dev-docs.yml
@@ -8,6 +8,8 @@ on:
       - 'docs/dev/**'
       - '.github/workflows/deploy-dev-docs.yml'
 
+  workflow_dispatch:
+
 jobs:
   build-and-deploy:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
I've updated everything to the latest minor or major version depending on if they have their major version tag following their latest stable minor version tag or not.

I have kept the `actions/upload-artifact` back in v3 because:
1. It seems there are breaking changes between `v3` -> `v4` ([more info](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md))
2. there is a PR (#3586) that have tried to update this for the Windows CI, so I would not change it to avoid duplicate and confusion