### PR TITLE
WIP: Add example of custom global shortcut on Windows

### DIFF
--- a/src/core/flameshot.cpp
+++ b/src/core/flameshot.cpp
@@ -37,6 +37,41 @@
 #include <QScreen>
 #endif
 
+#if defined(Q_OS_WIN)
+#include <Windows.h>
+
+HHOOK hook;
+bool isAltPressed = false;
+bool isShiftPressed = false;
+
+// Just an example of global shortcuts on Windows.
+// This is hardcoded Alt+Shift+3 shortcut
+LRESULT CALLBACK keyboardHook(int nCode, WPARAM wParam, LPARAM lParam) {
+    if (nCode >= 0) {
+        KBDLLHOOKSTRUCT *kbdStruct = (KBDLLHOOKSTRUCT *)lParam;
+        if (wParam == WM_SYSKEYDOWN) {
+            if (kbdStruct->vkCode == VK_LMENU) {
+                isAltPressed = true;
+            } else if (isAltPressed && isShiftPressed && kbdStruct->vkCode == '3') {
+                Flameshot::instance()->gui();
+                return 1;
+            }
+        } else if (wParam == WM_KEYDOWN) {
+            if (kbdStruct->vkCode == VK_LSHIFT) {
+                isShiftPressed = true;
+            }
+        } else if (wParam == WM_KEYUP) {
+            if (kbdStruct->vkCode == VK_LMENU) {
+                isAltPressed = false;
+            } else if (kbdStruct->vkCode == VK_LSHIFT) {
+                isShiftPressed = false;
+            }
+        }
+    }
+    return CallNextHookEx(hook, nCode, wParam, lParam);
+}
+#endif
+
 Flameshot::Flameshot()
   : m_captureWindow(nullptr)
   , m_haveExternalWidget(false)
@@ -68,6 +103,9 @@ Flameshot::Flameshot()
                      &QHotkey::activated,
                      qApp,
                      [this]() { history(); });
+#endif
+#if defined(Q_OS_WIN)
+    hook = SetWindowsHookEx(WH_KEYBOARD_LL, keyboardHook, NULL, 0);
 #endif
 }
 


### PR DESCRIPTION
Example of custom global shortcut on Windows - hardcoded Alt+Shift+3.
It's just prove of the concept

Feature discussed here:
https://github.com/flameshot-org/flameshot/issues/1341
https://github.com/flameshot-org/flameshot/pull/2168
and in other places - please link/comment them if they're needed here

@mmahmoudian It looks like we actually don't need [CLI on Windows](https://github.com/flameshot-org/flameshot/issues/1341#issuecomment-1126314750) to have custom global shortcuts on this OS, is it correct?
Please tell me if it's worth to finish this solution to have fully customizable shortcuts on Windows, so I'll try to do it.

P.S. I'm not a c++ dev, I've found the solution from ChatGPT, so maybe it's a really bad code but it seems to work for me for now