### PR TITLE
Don't initialize Notifications dbus if disabled

### DIFF
--- a/src/utils/systemnotification.cpp
+++ b/src/utils/systemnotification.cpp
@@ -24,6 +24,9 @@ SystemNotification::SystemNotification(QObject* parent)
   , m_interface(nullptr)
 {
 #if !(defined(Q_OS_MACOS) || defined(Q_OS_WIN))
+    if (!ConfigHandler().showDesktopNotification()) {
+        return;
+    }
     m_interface =
       new QDBusInterface(QStringLiteral("org.freedesktop.Notifications"),
                          QStringLiteral("/org/freedesktop/Notifications"),


### PR DESCRIPTION
This PR fixes an issue where Flameshot hangs while it's waiting for the notifications QDBusInterface to initialize.

Some systems don't come with a notifications daemon by default, which causes the QDBusInterface constructor to block for 5-20 seconds, during which flameshot hangs and cannot copy the screenshot into the clipboard buffer.

I tested this on Linux on KDE Plasma 6 with Wayland enabled. CMake flags are `cmake .. -GNinja -DUSE_WAYLAND_CLIPBOARD=1`

- ~~might fix https://github.com/flameshot-org/flameshot/issues/3529~~
- ~~might fix https://github.com/flameshot-org/flameshot/issues/3479~~

~~Only *might* fix, because the assumption is that the issue names are misnomers, and that the true issue is just that the screenshot is copied to clipboard after 5-20 seconds without any hint (except systemd logs)~~

Edit: Ignore the potentially fixed issues, there are more things afoot with those.