### PR TITLE
New option to hide cursor for wlroots-based grim

### DIFF
--- a/src/config/generalconf.cpp
+++ b/src/config/generalconf.cpp
@@ -79,6 +79,7 @@ void GeneralConf::_updateComponents(bool allowEmptySavePath)
     m_sidePanelButton->setChecked(config.showSidePanelButton());
     m_sysNotifications->setChecked(config.showDesktopNotification());
     m_autostart->setChecked(config.startupLaunch());
+    m_hideCursor->setChecked(config.hideCursor());
     m_copyURLAfterUpload->setChecked(config.copyURLAfterUpload());
     m_saveAfterCopy->setChecked(config.saveAfterCopy());
     m_copyPathAfterSave->setChecked(config.copyPathAfterSave());
@@ -409,9 +410,26 @@ void GeneralConf::initAutostart()
 void GeneralConf::initHideCursor()
 {
     m_hideCursor = new QCheckBox(tr("Hide cursor in screenshots"), this);
-    m_hideCursor->setToolTip(tr("Don't include the cursor in screenshots"));
-    m_scrollAreaLayout->addWidget(m_hideCursor);
 
+#if !defined(Q_OS_LINUX) && !defined(Q_OS_UNIX)
+    m_hideCursor->setEnabled(false);
+#else
+    if (m_info.waylandDetected()){
+        switch (m_info.windowManager()) {
+            case DesktopInfo::GNOME:
+            case DesktopInfo::KDE:
+                m_hideCursor->setEnabled(false);
+                m_hideCursor->setToolTip(tr("Cursor hiding is not supported on this "
+                                            "desktop environment"));
+                break;
+            default:
+                m_hideCursor->setEnabled(true);
+                m_hideCursor->setToolTip(tr("Don't include the cursor in screenshots"));
+                break;
+        }
+    }
+#endif
+    m_scrollAreaLayout->addWidget(m_hideCursor);
     connect(
       m_hideCursor, &QCheckBox::clicked, this, &GeneralConf::hideCursorChanged);
 }

--- a/src/config/generalconf.cpp
+++ b/src/config/generalconf.cpp
@@ -19,6 +19,7 @@
 #include <QStandardPaths>
 #include <QTextCodec>
 #include <QVBoxLayout>
+#include <desktopinfo.h>
 
 GeneralConf::GeneralConf(QWidget* parent)
   : QWidget(parent)
@@ -42,6 +43,7 @@ GeneralConf::GeneralConf(QWidget* parent)
     initCheckForUpdates();
 #endif
     initShowStartupLaunchMessage();
+    initHideCursor();
     initAllowMultipleGuiInstances();
     initSaveLastRegion();
     initShowHelp();
@@ -160,6 +162,10 @@ void GeneralConf::autostartChanged(bool checked)
     ConfigHandler().setStartupLaunch(checked);
 }
 
+void GeneralConf::hideCursorChanged(bool checked)
+{
+    ConfigHandler().setHideCursor(checked);
+}
 void GeneralConf::importConfiguration()
 {
     QString fileName = QFileDialog::getOpenFileName(this, tr("Import"));
@@ -264,6 +270,7 @@ void GeneralConf::initSaveLastRegion()
             this,
             &GeneralConf::saveLastRegion);
 }
+
 
 void GeneralConf::initShowSidePanelButton()
 {
@@ -397,6 +404,16 @@ void GeneralConf::initAutostart()
 
     connect(
       m_autostart, &QCheckBox::clicked, this, &GeneralConf::autostartChanged);
+}
+
+void GeneralConf::initHideCursor()
+{
+    m_hideCursor = new QCheckBox(tr("Hide cursor in screenshots"), this);
+    m_hideCursor->setToolTip(tr("Don't include the cursor in screenshots"));
+    m_scrollAreaLayout->addWidget(m_hideCursor);
+
+    connect(
+      m_hideCursor, &QCheckBox::clicked, this, &GeneralConf::hideCursorChanged);
 }
 
 void GeneralConf::initShowStartupLaunchMessage()

--- a/src/config/generalconf.cpp
+++ b/src/config/generalconf.cpp
@@ -19,7 +19,6 @@
 #include <QStandardPaths>
 #include <QTextCodec>
 #include <QVBoxLayout>
-#include <desktopinfo.h>
 
 GeneralConf::GeneralConf(QWidget* parent)
   : QWidget(parent)

--- a/src/config/generalconf.h
+++ b/src/config/generalconf.h
@@ -40,6 +40,7 @@ private slots:
 #if !defined(DISABLE_UPDATE_CHECKER)
     void checkForUpdatesChanged(bool checked);
 #endif
+    void hideCursorChanged(bool checked);
     void allowMultipleGuiInstancesChanged(bool checked);
     void autoCloseIdleDaemonChanged(bool checked);
     void autostartChanged(bool checked);
@@ -70,6 +71,7 @@ private:
     void initCheckForUpdates();
 #endif
     void initConfigButtons();
+    void initHideCursor();
     void initCopyAndCloseAfterUpload();
     void initCopyOnDoubleClick();
     void initCopyPathAfterSave();
@@ -102,6 +104,7 @@ private:
     QCheckBox* m_sysNotifications;
     QCheckBox* m_showTray;
     QCheckBox* m_helpMessage;
+    QCheckBox* m_hideCursor;
     QCheckBox* m_sidePanelButton;
 #if !defined(DISABLE_UPDATE_CHECKER)
     QCheckBox* m_checkForUpdates;

--- a/src/config/generalconf.h
+++ b/src/config/generalconf.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "src/utils/desktopinfo.h"
 #include <QScrollArea>
 #include <QWidget>
 
@@ -139,4 +140,6 @@ private:
     QComboBox* m_selectGeometryLocation;
     QSpinBox* m_xywhTimeout;
     QSpinBox* m_jpegQuality;
+
+    DesktopInfo m_info;
 };

--- a/src/utils/confighandler.cpp
+++ b/src/utils/confighandler.cpp
@@ -90,6 +90,7 @@ static QMap<class QString, QSharedPointer<ValueHandler>>
 #endif
     OPTION("startupLaunch"               ,Bool               ( false         )),
     OPTION("showStartupLaunchMessage"    ,Bool               ( true          )),
+    OPTION("hideCursor"                  ,Bool               ( true          )),
     OPTION("copyURLAfterUpload"          ,Bool               ( true          )),
     OPTION("copyPathAfterSave"           ,Bool               ( false         )),
     OPTION("antialiasingPinZoom"         ,Bool               ( true          )),

--- a/src/utils/confighandler.h
+++ b/src/utils/confighandler.h
@@ -101,6 +101,7 @@ public:
     CONFIG_GETTER_SETTER(showStartupLaunchMessage,
                          setShowStartupLaunchMessage,
                          bool)
+    CONFIG_GETTER_SETTER(hideCursor, setHideCursor, bool)
     CONFIG_GETTER_SETTER(contrastOpacity, setContrastOpacity, int)
     CONFIG_GETTER_SETTER(copyURLAfterUpload, setCopyURLAfterUpload, bool)
     CONFIG_GETTER_SETTER(historyConfirmationToDelete,

--- a/src/utils/screengrabber.cpp
+++ b/src/utils/screengrabber.cpp
@@ -37,7 +37,8 @@ void ScreenGrabber::generalGrimScreenshot(bool& ok, QPixmap& res)
     if (!ConfigHandler().hideCursor()) {
         arguments << "-c";
     }
-    arguments << "-";
+
+    arguments << "-";  // This argument should come last
     Process.start(program, arguments);
     if (Process.waitForFinished()) {
         res.loadFromData(Process.readAll());

--- a/src/utils/screengrabber.cpp
+++ b/src/utils/screengrabber.cpp
@@ -3,6 +3,7 @@
 
 #include "screengrabber.h"
 #include "abstractlogger.h"
+#include "src/utils/confighandler.h"
 #include "src/core/qguiappcurrentscreen.h"
 #include "src/utils/filenamehandler.h"
 #include "src/utils/systemnotification.h"
@@ -33,6 +34,9 @@ void ScreenGrabber::generalGrimScreenshot(bool& ok, QPixmap& res)
     QProcess Process;
     QString program = "grim";
     QStringList arguments;
+    if (!ConfigHandler().hideCursor()) {
+        arguments << "-c";
+    }
     arguments << "-";
     Process.start(program, arguments);
     if (Process.waitForFinished()) {
@@ -143,7 +147,7 @@ QPixmap ScreenGrabber::grabEntireDesktop(bool& ok)
 #else
                 AbstractLogger::warning()
                   << tr("grim's screenshot component is implemented based on "
-                        "wlroots, it may not be used in GNOME or similar "
+                        "wlroots, it may not be used in GNOME, KDE or similar "
                         "desktop environments");
                 generalGrimScreenshot(ok, res);
 #endif


### PR DESCRIPTION
- This PR adds an option to hide cursor for screenshots taken in DEs other than GNOME and KDE. The checkbox is therefore disabled in GNOME and KDE.
- In `screenGrabber.cpp`, the application decides to use either a DBus interface or the wlroots-based `grim` program depending on the desktop environment. Unfortunately, from what I understand, KDE and GNOME do not support wlr protocols, and the DBus interface does not provide an option to show or hide the cursor. Therefore, my changes (should) only apply to DEs that can utilize grim.
- `grim` includes the cursor in screenshots with `-c` argument. This PR basically just allows passing this option.
- The cursor is hidden by default. 

Partially resolves  flameshot-org/flameshot#3582

