### PR TITLE
Add option to disable abort notification

### DIFF
--- a/flameshot.example.ini
+++ b/flameshot.example.ini
@@ -42,6 +42,9 @@
 ;; Show desktop notifications (bool)
 ;showDesktopNotification=true
 ;
+;; Show abort notifications (bool)
+;showAbortNotification=true
+;
 ;; Filename pattern using C++ strftime formatting
 ;filenamePattern=%F_%H-%M
 ;

--- a/src/config/generalconf.cpp
+++ b/src/config/generalconf.cpp
@@ -38,6 +38,7 @@ GeneralConf::GeneralConf(QWidget* parent)
 #endif
     initShowTrayIcon();
     initShowDesktopNotification();
+    initShowAbortNotification();
 #if !defined(DISABLE_UPDATE_CHECKER)
     initCheckForUpdates();
 #endif
@@ -76,6 +77,7 @@ void GeneralConf::_updateComponents(bool allowEmptySavePath)
     m_helpMessage->setChecked(config.showHelp());
     m_sidePanelButton->setChecked(config.showSidePanelButton());
     m_sysNotifications->setChecked(config.showDesktopNotification());
+    m_abortNotifications->setChecked(config.showAbortNotification());
     m_autostart->setChecked(config.startupLaunch());
     m_copyURLAfterUpload->setChecked(config.copyURLAfterUpload());
     m_saveAfterCopy->setChecked(config.saveAfterCopy());
@@ -136,6 +138,11 @@ void GeneralConf::showSidePanelButtonChanged(bool checked)
 void GeneralConf::showDesktopNotificationChanged(bool checked)
 {
     ConfigHandler().setShowDesktopNotification(checked);
+}
+
+void GeneralConf::showAbortNotificationChanged(bool checked)
+{
+    ConfigHandler().setShowAbortNotification(checked);
 }
 
 #if !defined(DISABLE_UPDATE_CHECKER)
@@ -288,6 +295,18 @@ void GeneralConf::initShowDesktopNotification()
             &QCheckBox::clicked,
             this,
             &GeneralConf::showDesktopNotificationChanged);
+}
+
+void GeneralConf::initShowAbortNotification()
+{
+    m_abortNotifications = new QCheckBox(tr("Show abort notifications"), this);
+    m_abortNotifications->setToolTip(tr("Enable abort notifications"));
+    m_scrollAreaLayout->addWidget(m_abortNotifications);
+
+    connect(m_abortNotifications,
+            &QCheckBox::clicked,
+            this,
+            &GeneralConf::showAbortNotificationChanged);
 }
 
 void GeneralConf::initShowTrayIcon()

--- a/src/config/generalconf.h
+++ b/src/config/generalconf.h
@@ -37,6 +37,7 @@ private slots:
     void saveLastRegion(bool checked);
     void showSidePanelButtonChanged(bool checked);
     void showDesktopNotificationChanged(bool checked);
+    void showAbortNotificationChanged(bool checked);
 #if !defined(DISABLE_UPDATE_CHECKER)
     void checkForUpdatesChanged(bool checked);
 #endif
@@ -78,6 +79,7 @@ private:
     void initSaveAfterCopy();
     void initScrollArea();
     void initShowDesktopNotification();
+    void initShowAbortNotification();
     void initShowHelp();
     void initShowMagnifier();
     void initShowSidePanelButton();
@@ -100,6 +102,7 @@ private:
     QVBoxLayout* m_scrollAreaLayout;
     QScrollArea* m_scrollArea;
     QCheckBox* m_sysNotifications;
+    QCheckBox* m_abortNotifications;
     QCheckBox* m_showTray;
     QCheckBox* m_helpMessage;
     QCheckBox* m_sidePanelButton;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -63,7 +63,12 @@ void requestCaptureAndWait(const CaptureRequest& req)
 #endif
     });
     QObject::connect(flameshot, &Flameshot::captureFailed, []() {
-        AbstractLogger::info() << "Screenshot aborted.";
+        AbstractLogger::Target logTarget = static_cast<AbstractLogger::Target>(
+          ConfigHandler().showAbortNotification()
+            ? AbstractLogger::Target::Default
+            : AbstractLogger::Target::Default &
+                ~AbstractLogger::Target::Notification);
+        AbstractLogger::info(logTarget) << "Screenshot aborted.";
         qApp->exit(1);
     });
     qApp->exec();

--- a/src/utils/confighandler.cpp
+++ b/src/utils/confighandler.cpp
@@ -77,6 +77,7 @@ static QMap<class QString, QSharedPointer<ValueHandler>>
     OPTION("showHelp"                    ,Bool               ( true          )),
     OPTION("showSidePanelButton"         ,Bool               ( true          )),
     OPTION("showDesktopNotification"     ,Bool               ( true          )),
+    OPTION("showAbortNotification"       ,Bool               ( true          )),
     OPTION("disabledTrayIcon"            ,Bool               ( false         )),
     OPTION("historyConfirmationToDelete" ,Bool               ( true          )),
 #if !defined(DISABLE_UPDATE_CHECKER)

--- a/src/utils/confighandler.h
+++ b/src/utils/confighandler.h
@@ -86,6 +86,7 @@ public:
     CONFIG_GETTER_SETTER(showDesktopNotification,
                          setShowDesktopNotification,
                          bool)
+    CONFIG_GETTER_SETTER(showAbortNotification, setShowAbortNotification, bool)
     CONFIG_GETTER_SETTER(filenamePattern, setFilenamePattern, QString)
     CONFIG_GETTER_SETTER(disabledTrayIcon, setDisabledTrayIcon, bool)
     CONFIG_GETTER_SETTER(drawThickness, setDrawThickness, int)


### PR DESCRIPTION
Closes https://github.com/flameshot-org/flameshot/issues/3287

It's my first PR here so not too familiar with the codebase, hope the way of excluding the logger target is how it's intended to be used (still logs to files/stderr).
I ran clang-format and tested it on Linux.

> I think it should be Enabled by default, at least for the next few versions, and then we can ask the community how they feel about it. This way the backlash would be minimal.
(https://github.com/flameshot-org/flameshot/issues/3287#issuecomment-1664139462)

![image](https://github.com/flameshot-org/flameshot/assets/55899582/67cdebe7-61c8-446d-873a-e17262cd11c9)
