### PR TITLE
Disable grim's png compression

### DIFF
--- a/src/utils/screengrabber.cpp
+++ b/src/utils/screengrabber.cpp
@@ -34,6 +34,9 @@ void ScreenGrabber::generalGrimScreenshot(bool& ok, QPixmap& res)
     QProcess Process;
     QString program = "grim";
     QStringList arguments;
+    // Disable PNG compression
+    arguments << "-l"
+              << "0";
     arguments << "-";
     Process.start(program, arguments);
     if (Process.waitForFinished()) {


### PR DESCRIPTION
Grim by default used level 6 for compressing PDFs, which could take as long as a second depending on the hardware. This caused a big delay when taking a screenshot with grim, leading to a bad user experience. This commit sets  the compression level to 0(uncompressed) radically speeding up the process of taking a screenshot(down to just a few ms on my machine).