### PR TITLE
Fix nix direnv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,4 @@ data/flatpak/.flatpak-builder
 
 # Miscellaneous
 !docs/dev/Makefile
+.direnv

--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,4 @@
-{ pkgs ? import <nixpkgs> {} }:
+{ pkgs ? import <nixpkgs> { } }:
 
 pkgs.mkShell {
   nativeBuildInputs = with pkgs; [
@@ -7,5 +7,5 @@ pkgs.mkShell {
     qt5.qttools
     qt5.qtsvg
   ];
-  buildInputs = [ pkgs.qt5.qtbase ];
+  buildInputs = with pkgs; [ qt5.qtbase libsForQt5.kguiaddons ];
 }


### PR DESCRIPTION
This adds a missing package needed for compiling flameshot with USE_WAYLAND_CLIPBOARD and adds the .direnv directory(created by direnv when evaluating the .envrc file) to gitignore.