### PR TITLE
fix: workaround macos fullscreen animation

### DIFF
--- a/src/core/flameshot.cpp
+++ b/src/core/flameshot.cpp
@@ -120,8 +120,9 @@ CaptureWidget* Flameshot::gui(const CaptureRequest& req)
 #ifdef Q_OS_WIN
         m_captureWindow->show();
 #elif defined(Q_OS_MACOS)
-        // In "Emulate fullscreen mode"
-        m_captureWindow->showFullScreen();
+        // Cannot use showFullScreen as macOS plays an animation on open and
+        // close which does not seem to be removable.
+        m_captureWindow->show();
         m_captureWindow->activateWindow();
         m_captureWindow->raise();
 #else

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -39,7 +39,6 @@
 #include <QPainter>
 #include <QScreen>
 #include <QShortcut>
-#include <QtCore/qnamespace.h>
 #include <draggablewidgetmaker.h>
 
 #if !defined(DISABLE_UPDATE_CHECKER)

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -39,6 +39,7 @@
 #include <QPainter>
 #include <QScreen>
 #include <QShortcut>
+#include <QtCore/qnamespace.h>
 #include <draggablewidgetmaker.h>
 
 #if !defined(DISABLE_UPDATE_CHECKER)
@@ -55,7 +56,11 @@
 CaptureWidget::CaptureWidget(const CaptureRequest& req,
                              bool fullScreen,
                              QWidget* parent)
-  : QWidget(parent)
+  : QWidget(parent
+#if defined(Q_OS_MACOS)
+  , Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint
+#endif
+  )
   , m_toolSizeByKeyboard(0)
   , m_mouseIsClicked(false)
   , m_captureDone(false)


### PR DESCRIPTION
**edit**: do not think this is viable due to https://github.com/flameshot-org/flameshot/issues/2886#issuecomment-2205197790

This would resolve #2886 at the cost of the system menu bar not being able to be visible as part of the capture window.

![image](https://github.com/flameshot-org/flameshot/assets/24465214/6944b967-b217-48b7-8d26-dd622d178639)

If there is something available in QT to put the window above the menu bar or disable the animation, we should use that instead. I couldn't find an API to do that though -- I feel like i0t has to be possible *somehow*, since the built-in screenshot command does not have this issue, and System Settings is able to draw overlays that are placed on top of the menu bar (if you have multiple monitors and re-arrange them, a red border surrounds the screen); Maybe this API is reserved for the system apps?

For now, I find this trade off reasonable as the fullscreen exit animation as shown in the issue is incredibly annoying, and most screenshots do not need to annotate the menu bar (you can still screenshot it, but the system bar is in the way for annotations).
