### PR TITLE
Close Latest Uploads window using escape key

### DIFF
--- a/src/widgets/uploadhistory.cpp
+++ b/src/widgets/uploadhistory.cpp
@@ -8,6 +8,7 @@
 #include <QDateTime>
 #include <QDesktopWidget>
 #include <QFileInfo>
+#include <QKeyEvent>
 #include <QPixmap>
 
 void scaleThumbnail(QPixmap& pixmap)
@@ -95,6 +96,13 @@ void UploadHistory::addLine(const QString& path, const QString& fileName)
     });
 
     ui->historyContainer->addWidget(line);
+}
+
+void UploadHistory::keyPressEvent(QKeyEvent* event)
+{
+    if (event->key() == Qt::Key_Escape) {
+        close();
+    }
 }
 
 UploadHistory::~UploadHistory()

--- a/src/widgets/uploadhistory.h
+++ b/src/widgets/uploadhistory.h
@@ -27,6 +27,9 @@ private:
     void setEmptyMessage();
     void addLine(QString const&, QString const&);
 
+protected:
+    void keyPressEvent(QKeyEvent* event);
+
     Ui::UploadHistory* ui;
 };
 #endif // UPLOADHISTORY_H


### PR DESCRIPTION
This change adds the ability to close **Latest Uploads** window using the escape (esc) key
Signed-off-by: Adlane Hichem BRIKI <briki.adlanehichem@gmail.com>