### PR TITLE
exclude documentation modifications from CI

### DIFF
--- a/.github/workflows/Linux-pack.yml
+++ b/.github/workflows/Linux-pack.yml
@@ -4,14 +4,17 @@ on:
   push:
     branches:
       - master
+      - fix*
     paths-ignore:
       - 'README.md'
       - 'LICENSE'
+      - 'docs/**'
 
   pull_request:
     paths-ignore:
       - 'README.md'
       - 'LICENSE'
+      - 'docs/**'
 
 env:
   PRODUCT: flameshot

--- a/.github/workflows/MacOS-pack.yml
+++ b/.github/workflows/MacOS-pack.yml
@@ -4,15 +4,17 @@ on:
   push:
     branches:
       - master
-      - feature/RND-680-macos-.dmg-package-build
+      - fix*
     paths-ignore:
       - 'README.md'
       - 'LICENSE'
+      - 'docs/**'
 
   pull_request:
     paths-ignore:
       - 'README.md'
       - 'LICENSE'
+      - 'docs/**'
 
 env:
   PRODUCT: flameshot

--- a/.github/workflows/Windows-pack.yml
+++ b/.github/workflows/Windows-pack.yml
@@ -8,11 +8,14 @@ on:
     paths-ignore:
       - 'README.md'
       - 'LICENSE'
+      - 'docs/**'
 
   pull_request:
     paths-ignore:
       - 'README.md'
       - 'LICENSE'
+      - 'docs/**'
+  
   workflow_dispatch:
 
 


### PR DESCRIPTION
This is to prevent CI to run when we only change the documentation of the project. CI's are computationally expensive and time consuming and therefore we can save some time and some electricity by running the CI when they are actually needed.