### PR TITLE
Control pin opacity with Ctrl+wheel scroll

### DIFF
--- a/src/tools/pin/pinwidget.h
+++ b/src/tools/pin/pinwidget.h
@@ -24,6 +24,7 @@ protected:
     void mousePressEvent(QMouseEvent*) override;
     void mouseMoveEvent(QMouseEvent*) override;
     void keyPressEvent(QKeyEvent*) override;
+    void wheelEvent(QWheelEvent*) override;
     void enterEvent(QEvent*) override;
     void leaveEvent(QEvent*) override;
 
@@ -32,7 +33,6 @@ protected:
 
 private:
     bool gestureEvent(QGestureEvent* event);
-    bool scrollEvent(QWheelEvent* e);
     void pinchTriggered(QPinchGesture*);
     void closePin();
 


### PR DESCRIPTION
The context menu buttons are unusable (because each click on them closes the context menu)
And it's nearly impossible to get focus on the pinned window to change its opacity with 0-9 keys
Moved to a proper event for the sake of clean code.