### PR TITLE
Use QStandardPaths::ApplicationsLocation (XDG_*) for open with

### DIFF
--- a/src/tools/launcher/applauncherwidget.cpp
+++ b/src/tools/launcher/applauncherwidget.cpp
@@ -62,13 +62,14 @@ AppLauncherWidget::AppLauncherWidget(const QPixmap& p, QWidget* parent)
         m_parser.processDirectory(allUserAppsFolder);
     }
 #else
-    QString dirLocal = QDir::homePath() + "/.local/share/applications/";
-    QDir appsDirLocal(dirLocal);
-    m_parser.processDirectory(appsDirLocal);
+    QStringList appsLocations =
+      QStandardPaths::standardLocations(QStandardPaths::ApplicationsLocation);
 
-    QString dir = QStringLiteral("/usr/share/applications/");
-    QDir appsDir(dir);
-    m_parser.processDirectory(appsDir);
+    for (auto appsLocation : appsLocations) {
+        QDir appsDir(appsLocation);
+        m_parser.processDirectory(QDir(appsDir));
+    }
+
 #endif
 
     initAppMap();


### PR DESCRIPTION
Use QStandardPaths::standardLocations(QStandardPaths::ApplicationsLocation) to get directories to look for desktop files for the open with option instead of hardcoded default dirs.

This might fix #1868 and #3046 for snap and flatpak users since they seem to use custom XDG_DATA_DIRS and XDG_DATA_HOME. Fixes the open with menu on my NixOS.

https://doc.qt.io/qt-5/qstandardpaths.html
