### PR TITLE
Adds WebP Quality Config

### DIFF
--- a/flameshot.example.ini
+++ b/flameshot.example.ini
@@ -94,7 +94,7 @@
 ; jpegQuality=75
 ;
 ;; Set WebP Quality (int in range 0-100)
-; webpQuality=95
+; webpQuality=90
 ;
 ;; Shortcut Settings for all tools
 ;[Shortcuts]

--- a/flameshot.example.ini
+++ b/flameshot.example.ini
@@ -93,6 +93,9 @@
 ;; Set JPEG Quality (int in range 0-100)
 ; jpegQuality=75
 ;
+;; Set WebP Quality (int in range 0-100)
+; webpQuality=95
+;
 ;; Shortcut Settings for all tools
 ;[Shortcuts]
 ;TYPE_ARROW=A

--- a/src/config/generalconf.cpp
+++ b/src/config/generalconf.cpp
@@ -65,6 +65,7 @@ GeneralConf::GeneralConf(QWidget* parent)
     initShowMagnifier();
     initSquareMagnifier();
     initJpegQuality();
+    initWebPQuality();
     // this has to be at the end
     initConfigButtons();
     updateComponents();
@@ -799,6 +800,26 @@ void GeneralConf::initJpegQuality()
             &GeneralConf::setJpegQuality);
 }
 
+void GeneralConf::initWebPQuality()
+{
+    auto* tobox = new QHBoxLayout();
+
+    int quality = ConfigHandler().value("webpQuality").toInt();
+    m_webpQuality = new QSpinBox();
+    m_webpQuality->setRange(0, 100);
+    m_webpQuality->setToolTip(tr("Quality range of 0-100; Higher number is "
+                                 "better quality and larger file size"));
+    m_webpQuality->setValue(quality);
+    tobox->addWidget(m_webpQuality);
+    tobox->addWidget(new QLabel(tr("WebP Quality")));
+
+    m_scrollAreaLayout->addLayout(tobox);
+    connect(m_webpQuality,
+            static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged),
+            this,
+            &GeneralConf::setWebPQuality);
+}
+
 void GeneralConf::setSelGeoHideTime(int v)
 {
     ConfigHandler().setValue("showSelectionGeometryHideTime", v);
@@ -807,6 +828,11 @@ void GeneralConf::setSelGeoHideTime(int v)
 void GeneralConf::setJpegQuality(int v)
 {
     ConfigHandler().setJpegQuality(v);
+}
+
+void GeneralConf::setWebPQuality(int v)
+{
+    ConfigHandler().setWebPQuality(v);
 }
 
 void GeneralConf::setGeometryLocation(int index)

--- a/src/config/generalconf.h
+++ b/src/config/generalconf.h
@@ -58,6 +58,7 @@ private slots:
     void setGeometryLocation(int index);
     void setSelGeoHideTime(int v);
     void setJpegQuality(int v);
+    void setWebPQuality(int v);
 
 private:
     const QString chooseFolder(const QString& currentPath = "");
@@ -92,6 +93,7 @@ private:
     void initSaveLastRegion();
     void initShowSelectionGeometry();
     void initJpegQuality();
+    void initWebPQuality();
 
     void _updateComponents(bool allowEmptySavePath);
 
@@ -136,4 +138,5 @@ private:
     QComboBox* m_selectGeometryLocation;
     QSpinBox* m_xywhTimeout;
     QSpinBox* m_jpegQuality;
+    QSpinBox* m_webpQuality;
 };

--- a/src/utils/confighandler.cpp
+++ b/src/utils/confighandler.cpp
@@ -127,7 +127,7 @@ static QMap<class QString, QSharedPointer<ValueHandler>>
     OPTION("showSelectionGeometry"  , BoundedInt               (0,5,4)),
     OPTION("showSelectionGeometryHideTime", LowerBoundedInt       (0, 3000)),
     OPTION("jpegQuality", BoundedInt     (0,100,75)),
-    OPTION("webpQuality", BoundedInt     (0,100,95))
+    OPTION("webpQuality", BoundedInt     (0,100,90))
 };
 
 static QMap<QString, QSharedPointer<KeySequence>> recognizedShortcuts = {

--- a/src/utils/confighandler.cpp
+++ b/src/utils/confighandler.cpp
@@ -126,7 +126,8 @@ static QMap<class QString, QSharedPointer<ValueHandler>>
     OPTION("uploadClientSecret"          ,String             ( "313baf0c7b4d3ff"            )),
     OPTION("showSelectionGeometry"  , BoundedInt               (0,5,4)),
     OPTION("showSelectionGeometryHideTime", LowerBoundedInt       (0, 3000)),
-    OPTION("jpegQuality", BoundedInt     (0,100,75))
+    OPTION("jpegQuality", BoundedInt     (0,100,75)),
+    OPTION("webpQuality", BoundedInt     (0,100,95))
 };
 
 static QMap<QString, QSharedPointer<KeySequence>> recognizedShortcuts = {

--- a/src/utils/confighandler.h
+++ b/src/utils/confighandler.h
@@ -128,6 +128,7 @@ public:
     CONFIG_GETTER_SETTER(saveLastRegion, setSaveLastRegion, bool)
     CONFIG_GETTER_SETTER(showSelectionGeometry, setShowSelectionGeometry, int)
     CONFIG_GETTER_SETTER(jpegQuality, setJpegQuality, int)
+    CONFIG_GETTER_SETTER(webpQuality, setWebPQuality, int)
     CONFIG_GETTER_SETTER(showSelectionGeometryHideTime,
                          showSelectionGeometryHideTime,
                          int)

--- a/src/utils/screenshotsaver.cpp
+++ b/src/utils/screenshotsaver.cpp
@@ -41,6 +41,8 @@ bool saveToFilesystem(const QPixmap& capture,
     saveExtension = QFileInfo(completePath).suffix().toLower();
     if (saveExtension == "jpg" || saveExtension == "jpeg") {
         okay = capture.save(&file, nullptr, ConfigHandler().jpegQuality());
+    } else if (saveExtension == "webp") {
+        okay = capture.save(&file, nullptr, ConfigHandler().webpQuality());
     } else {
         okay = capture.save(&file);
     }
@@ -108,6 +110,8 @@ void saveToClipboardMime(const QPixmap& capture, const QString& imageType)
     QImageWriter imageWriter{ &buffer, imageType.toUpper().toUtf8() };
     if (imageType == "jpeg") {
         imageWriter.setQuality(ConfigHandler().jpegQuality());
+    } else if (imageType == "webp") {
+        imageWriter.setQuality(ConfigHandler().webpQuality());
     }
     imageWriter.write(capture.toImage());
 
@@ -206,6 +210,8 @@ bool saveToFilesystemGUI(const QPixmap& capture)
     saveExtension = QFileInfo(savePath).suffix().toLower();
     if (saveExtension == "jpg" || saveExtension == "jpeg") {
         okay = capture.save(&file, nullptr, ConfigHandler().jpegQuality());
+    } else if (saveExtension == "webp") {
+        okay = capture.save(&file, nullptr, ConfigHandler().webpQuality());
     } else {
         okay = capture.save(&file);
     }

--- a/src/utils/screenshotsaver.cpp
+++ b/src/utils/screenshotsaver.cpp
@@ -112,6 +112,7 @@ void saveToClipboardMime(const QPixmap& capture, const QString& imageType)
         imageWriter.setQuality(ConfigHandler().jpegQuality());
     } else if (imageType == "webp") {
         imageWriter.setQuality(ConfigHandler().webpQuality());
+        imageWriter.setOptimizedWrite(true);
     }
     imageWriter.write(capture.toImage());
 


### PR DESCRIPTION
Like #3285, this PR aims at introducing a quality config into Flameshot, allowing users to customize the quality of the WebP image emitted by Flameshot.

However during the testing of this PR, I've noticed that the output of the final WebP image appears to be far inferior than that emitted by `cwebp` with the same quality setting, and `cwebp` can excel at customizing other parameters like effort, increasing the final quality without increasing the final file size. So perhaps there should be a config option, allowing Flameshot to automatically execute a command to optimize the final image from PNG.