### PR TITLE
Added river support

### DIFF
--- a/docs/Sway and wlroots support.md
+++ b/docs/Sway and wlroots support.md
@@ -4,7 +4,7 @@ Flameshot currently supports Sway and other wlroots based Wayland compositors th
 ## Basic steps
 The following packages need to be installed: `xdg-desktop-portal xdg-desktop-portal-wlr grim`. Please ensure your distro packages these, or install them manually.
 
-Ensure that environment variables are set properly. If your distro does not set them automatically, use a launch script to export `XDG_CURRENT_DESKTOP=sway` **before** Sway is launched.
+Ensure that environment variables are set properly. If your distro does not set them automatically, use a launch script to export `XDG_CURRENT_DESKTOP=sway` or `XDG_CURRENT_DESKTOP=river` **before** Sway or River is launched.
 ```sh
 #!/bin/bash
 export SDL_VIDEODRIVER=wayland
@@ -15,7 +15,20 @@ export XDG_SESSION_DESKTOP=sway
 exec sway
 ```
 
-You will also need to ensure that systemd/dbus is aware of these environment variables; this should be done **in your sway config** so that the DISPLAY and WAYLAND_DISPLAY variables are defined.
+or
+
+
+```sh
+#!/bin/bash
+export SDL_VIDEODRIVER=wayland
+export _JAVA_AWT_WM_NONREPARENTING=1
+export QT_QPA_PLATFORM=wayland
+export XDG_CURRENT_DESKTOP=river
+export XDG_SESSION_DESKTOP=river
+exec river
+```
+
+You will also need to ensure that systemd/dbus is aware of these environment variables; this should be done **in your sway or river config** so that the DISPLAY and WAYLAND_DISPLAY variables are defined.
 
 (taken from [Sway wiki](https://github.com/swaywm/sway/wiki#gtk-applications-take-20-seconds-to-start)):
 ```sh
@@ -29,6 +42,13 @@ To ensure that Flameshot is correctly positioned on multiple outputs (monitors) 
 for_window [app_id="flameshot"] border pixel 0, floating enable, fullscreen disable, move absolute position 0 0
 ```
 
+and add the following on your River config:
+
+```
+riverctl float-filter-add "flameshot"
+```
+
+Otherwise, flameshot will not take all of the screen and tiles its window instead like a normal application. Note however, that some clipboard stuff is broken so it might be good to save your screenshot as a file while having it copied to a clipboard in case if clipboard does some weird stuff like not pasting the overall screenshot.
 
 
 Starting from 0.17.0 xdg-desktop-portal requires a configuration file (e.g. in ~/.config/xdg-desktop-portal/sway-portals.conf):
@@ -54,21 +74,6 @@ Q) Flameshot takes one screenshot, then won't take anymore!
 
 A) There is a bug in xdg-desktop-portal-wlr and Flameshot causing calls with the same token to fail. If you see a sdbus vtable error in the xdpw logs, either used the [patched version](https://github.com/nullobsi/xdg-desktop-portal-wlr/tree/improve-screenshot) or update Flameshot to the latest master.
 
-# River wlroots support
-
-Like mentioned above, flameshot now works on wlroots based Wayland compositors, however, there is a weird problem with river and that is when setting `XDG_CURRENT_DESKTOP=river`, flameshot won't work. The fix is you need to trick flameshot that you are on `sway`. Hence, you need to run river like so:
-
-```sh
-XDG_CURRENT_DESKTOP=sway dbus-run-session river
-```
-
-and add the following on your config such as in `$HOME/.config/river/init`
-
-```
-riverctl float-filter-add "flameshot"
-```
-
-Otherwise, flameshot will not take all of the screen and tiles its window instead like a normal application. Note however, that some clipboard stuff is broken so it might be good to save your screenshot as a file while having it copied to a clipboard in case if clipboard does some weird stuff like not pasting the overall screenshot.
 
 #### For more information, please refer to https://github.com/emersion/xdg-desktop-portal-wlr/wiki/%22It-doesn't-work%22-Troubleshooting-Checklist
 

--- a/src/utils/desktopinfo.cpp
+++ b/src/utils/desktopinfo.cpp
@@ -34,8 +34,8 @@ DesktopInfo::WM DesktopInfo::windowManager()
         if (desktop.contains(QLatin1String("qtile"), Qt::CaseInsensitive)) {
             return DesktopInfo::QTILE;
         }
-        if (desktop.contains(QLatin1String("sway"), Qt::CaseInsensitive)) {
-            return DesktopInfo::SWAY;
+        if (desktop.contains(QLatin1String("sway"), Qt::CaseInsensitive) || desktop.contains(QLatin1String("river"), Qt::CaseInsensitive)) {
+            return DesktopInfo::WLROOTS;
         }
         if (desktop.contains(QLatin1String("Hyprland"), Qt::CaseInsensitive)) {
             return DesktopInfo::HYPRLAND;

--- a/src/utils/desktopinfo.h
+++ b/src/utils/desktopinfo.h
@@ -16,7 +16,7 @@ public:
         KDE,
         OTHER,
         QTILE,
-        SWAY,
+        WLROOTS,
         HYPRLAND
     };
 

--- a/src/utils/screengrabber.cpp
+++ b/src/utils/screengrabber.cpp
@@ -130,7 +130,7 @@ QPixmap ScreenGrabber::grabEntireDesktop(bool& ok)
                 freeDesktopPortal(ok, res);
                 break;
             case DesktopInfo::QTILE:
-            case DesktopInfo::SWAY:
+            case DesktopInfo::WLROOTS:
             case DesktopInfo::HYPRLAND:
             case DesktopInfo::OTHER: {
 #ifndef USE_WAYLAND_GRIM


### PR DESCRIPTION
This attempts to generalize wlroots compositors by checking against the proper desktop name instead of only sway. This fixes the problem of only supporting sway. Any additional desktop will just have to be added to the source to check for the correct string.