### PR TITLE
Remove QT+GNOME+Wayland 'xcb' hack on fixed Qt versions

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -37,10 +37,23 @@
 // source: https://github.com/ksnip/ksnip/issues/416
 void wayland_hacks()
 {
-    // Workaround to https://github.com/ksnip/ksnip/issues/416
+    int suffixIndex;
     DesktopInfo info;
-    if (info.windowManager() == DesktopInfo::GNOME) {
-        qputenv("QT_QPA_PLATFORM", "xcb");
+
+    const char *qt_version = qVersion();
+
+    QVersionNumber targetVersion(5, 15, 2);
+    QString string(qt_version);
+    QVersionNumber currentVersion = QVersionNumber::fromString(string, &suffixIndex);
+
+    if (currentVersion < targetVersion) {
+        if (info.windowManager() == DesktopInfo::GNOME) {
+            qWarning() << "Qt versions lower than" << targetVersion.toString() << 
+                "on GNOME using Wayland have a bug when accessing the clipboard." <<
+                "Your version is" << currentVersion.toString() << "so we're forcing QT_QPA_PLATFORM to 'xcb'." << 
+                "To use native Wayland, please upgrade your Qt version to" << targetVersion.toString() << "or higher";
+            qputenv("QT_QPA_PLATFORM", "xcb");
+        }
     }
 }
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -40,18 +40,23 @@ void wayland_hacks()
     int suffixIndex;
     DesktopInfo info;
 
-    const char *qt_version = qVersion();
+    const char* qt_version = qVersion();
 
     QVersionNumber targetVersion(5, 15, 2);
     QString string(qt_version);
-    QVersionNumber currentVersion = QVersionNumber::fromString(string, &suffixIndex);
+    QVersionNumber currentVersion =
+      QVersionNumber::fromString(string, &suffixIndex);
 
     if (currentVersion < targetVersion) {
         if (info.windowManager() == DesktopInfo::GNOME) {
-            qWarning() << "Qt versions lower than" << targetVersion.toString() << 
-                "on GNOME using Wayland have a bug when accessing the clipboard." <<
-                "Your version is" << currentVersion.toString() << "so we're forcing QT_QPA_PLATFORM to 'xcb'." << 
-                "To use native Wayland, please upgrade your Qt version to" << targetVersion.toString() << "or higher";
+            qWarning()
+              << "Qt versions lower than" << targetVersion.toString()
+              << "on GNOME using Wayland have a bug when accessing the "
+                 "clipboard."
+              << "Your version is" << currentVersion.toString()
+              << "so we're forcing QT_QPA_PLATFORM to 'xcb'."
+              << "To use native Wayland, please upgrade your Qt version to"
+              << targetVersion.toString() << "or higher";
             qputenv("QT_QPA_PLATFORM", "xcb");
         }
     }


### PR DESCRIPTION
We implement code on GNOME desktops to force `QT_QPA_PLATFORM` to `xcb`; this works around a clipboard-related bug on GNOME+Wayland+Qt.

This bug was fixed (or worked around) in Qt 5.15.2, so we implement a version check; if the runtime Qt version is < 5.15.2, still force the workaround; otherwise, we don't need the workaround so we skip it.

We also add logging output so that users attempting to force the app not to use xcb won't get confused (as I did).

Note that the original discussion on this issue was in ksnip/ksnip#416, which indicates when this issue was fixed in Qt.