### PR TITLE
Improve README Tested PrtScr install procedure on Ubuntu 24.04 with Wayland

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ Steps for using the configuration:
     ln -s /var/lib/flatpak/exports/bin/org.flameshot.Flameshot ~/.local/bin/flameshot
     ```
 
-#### On Ubuntu (Tested on 18.04, 20.04, 22.04)
+#### On Ubuntu (Tested on 18.04, 20.04, 22.04, 24.04)
 
 To use Flameshot instead of the default screenshot application in Ubuntu we need to remove the binding on <kbd>Prt Sc</kbd> key, and then create a new binding for `/usr/bin/flameshot gui` ([adapted](https://askubuntu.com/posts/1039949/revisions) from [Pavel's answer on AskUbuntu](https://askubuntu.com/revisions/1036473/1)).
 
@@ -281,7 +281,7 @@ To use Flameshot instead of the default screenshot application in Ubuntu we need
     gsettings set org.gnome.settings-daemon.plugins.media-keys screenshot '[]'
     ```
 
-   Ubuntu 22.04: Go to _Settings_ > _Keyboard_ > _View and Customise Shortcuts_ > _Screenshots_ > _Take a screenshot interactively_ and press `backspace`
+   Ubuntu 22.04 & 24.04: Go to _Settings_ > _Keyboard_ > _View and Customise Shortcuts_ > _Screenshots_ > _Take a screenshot interactively_ and press `backspace`
 
 2. Add custom binding on <kbd>Prt Sc</kbd>:
 
@@ -289,11 +289,14 @@ To use Flameshot instead of the default screenshot application in Ubuntu we need
 
    Ubuntu 20.04: Go to _Settings_ > _Keyboard Shortcuts_ and press the '+' button at the bottom.
 
-   Ubuntu 22.04: Go to _Settings_ > _Keyboard_ > _View and Customise Shortcuts_ > _Custom shortcuts_ and press the '+' button at the bottom.
+   Ubuntu 22.04 & 24.04: Go to _Settings_ > _Keyboard_ > _View and Customise Shortcuts_ > _Custom shortcuts_ and press the '+' button at the bottom.
 
-3. Name the command as you like it, e.g. `flameshot`. And in the command insert `/usr/bin/flameshot gui`.
+3. Name the command as you like it, e.g. `flameshot`. And in the command insert.
+   
+  * On Ubuntu up to 22.04: `/usr/bin/flameshot gui`.
+  * If that doesn't work, or on Ubuntu 24.04: `/bin/sh -c '/usr/bin/flameshot gui'`
 
-4. Then click "_Set Shortcut.._" and press <kbd>Prt Sc</kbd>. This will show as "_print_".
+5. Then click "_Set Shortcut.._" and press <kbd>Prt Sc</kbd>. This will show as "_print_".
 
 Now every time you press <kbd>Prt Sc</kbd>, it will start the Flameshot GUI instead of the default application.
 


### PR DESCRIPTION
I tested the installation procedure. Instead of `/usr/bin/flameshot gui`, you  need to use `/bin/sh -c '/usr/bin/flameshot gui'`, else flameshot will fail to acquire the Wayland permissions to capture a screenshot. Besides that, no changes are required compared to the Ubuntu 22.04 procedure.