### PR TITLE
Fix the known issue of saving JPEG to clipboard on macOS

### DIFF
--- a/src/config/generalconf.cpp
+++ b/src/config/generalconf.cpp
@@ -629,10 +629,6 @@ void GeneralConf::initUseJpgForClipboard()
       tr("Use lossy JPG format for clipboard (lossless PNG default)"));
     m_scrollAreaLayout->addWidget(m_useJpgForClipboard);
 
-#if defined(Q_OS_MACOS)
-    // FIXME - temporary fix to disable option for MacOS
-    m_useJpgForClipboard->hide();
-#endif
     connect(m_useJpgForClipboard,
             &QCheckBox::clicked,
             this,

--- a/src/utils/screenshotsaver.cpp
+++ b/src/utils/screenshotsaver.cpp
@@ -10,6 +10,13 @@
 #include "src/utils/globalvalues.h"
 #include "utils/desktopinfo.h"
 
+#include <QTemporaryFile>
+#include <QImageWriter>
+#include <QPixmap>
+#include <QByteArray>
+#include <QProcess>
+#include <QDebug>
+
 #if USE_WAYLAND_CLIPBOARD
 #include <KSystemClipboard>
 #endif
@@ -101,6 +108,42 @@ QString ShowSaveFileDialog(const QString& title, const QString& directory)
     }
 }
 
+void saveJpegToClipboardMacOS(const QPixmap& capture) {
+    // Convert QPixmap to JPEG data
+    QByteArray jpegData;
+    QBuffer buffer(&jpegData);
+    buffer.open(QIODevice::WriteOnly);
+
+    QImageWriter imageWriter(&buffer, "jpeg");
+    imageWriter.setQuality(ConfigHandler().jpegQuality()); // Set JPEG quality to whatever is in settings
+    if (!imageWriter.write(capture.toImage())) {
+        qWarning() << "Failed to write image to JPEG format.";
+        return;
+    }
+
+    // Save JPEG data to a temporary file
+    QTemporaryFile tempFile;
+    if (!tempFile.open()) {
+        qWarning() << "Failed to open temporary file for writing.";
+        return;
+    }
+    tempFile.write(jpegData);
+    tempFile.close();
+
+    // Use osascript to copy the contents of the file to clipboard
+    QProcess process;
+    QString script = QString(
+        "set the clipboard to (read (POSIX file \"%1\") as «class PNGf»)"
+    ).arg(tempFile.fileName());
+    process.start("osascript", QStringList() << "-e" << script);
+    if (!process.waitForFinished()) {
+        qWarning() << "Failed to execute AppleScript.";
+    }
+
+    // Clean up
+    tempFile.remove();
+}
+
 void saveToClipboardMime(const QPixmap& capture, const QString& imageType)
 {
     QByteArray array;
@@ -152,8 +195,11 @@ void saveToClipboard(const QPixmap& capture)
         AbstractLogger() << QObject::tr("Capture saved to clipboard.");
     }
     if (ConfigHandler().useJpgForClipboard()) {
-        // FIXME - it doesn't work on MacOS
+#ifdef Q_OS_MAC
+        saveJpegToClipboardMacOS(capture);
+#else
         saveToClipboardMime(capture, "jpeg");
+#endif
     } else {
         // Need to send message before copying to clipboard
 #if defined(Q_OS_LINUX) || defined(Q_OS_UNIX)

--- a/src/utils/screenshotsaver.cpp
+++ b/src/utils/screenshotsaver.cpp
@@ -135,7 +135,7 @@ void saveJpegToClipboardMacOS(const QPixmap& capture)
 
     // Use osascript to copy the contents of the file to clipboard
     QProcess process;
-    QString script = 
+    QString script =
       QString("set the clipboard to (read (POSIX file \"%1\") as «class PNGf»)")
         .arg(tempFile.fileName());
     process.start("osascript", QStringList() << "-e" << script);

--- a/src/utils/screenshotsaver.cpp
+++ b/src/utils/screenshotsaver.cpp
@@ -10,12 +10,12 @@
 #include "src/utils/globalvalues.h"
 #include "utils/desktopinfo.h"
 
-#include <QTemporaryFile>
+#include <QByteArray>
+#include <QDebug>
 #include <QImageWriter>
 #include <QPixmap>
-#include <QByteArray>
 #include <QProcess>
-#include <QDebug>
+#include <QTemporaryFile>
 
 #if USE_WAYLAND_CLIPBOARD
 #include <KSystemClipboard>
@@ -108,14 +108,17 @@ QString ShowSaveFileDialog(const QString& title, const QString& directory)
     }
 }
 
-void saveJpegToClipboardMacOS(const QPixmap& capture) {
+void saveJpegToClipboardMacOS(const QPixmap& capture)
+{
     // Convert QPixmap to JPEG data
     QByteArray jpegData;
     QBuffer buffer(&jpegData);
     buffer.open(QIODevice::WriteOnly);
 
     QImageWriter imageWriter(&buffer, "jpeg");
-    imageWriter.setQuality(ConfigHandler().jpegQuality()); // Set JPEG quality to whatever is in settings
+
+    // Set JPEG quality to whatever is in settings
+    imageWriter.setQuality(ConfigHandler().jpegQuality());
     if (!imageWriter.write(capture.toImage())) {
         qWarning() << "Failed to write image to JPEG format.";
         return;
@@ -132,9 +135,9 @@ void saveJpegToClipboardMacOS(const QPixmap& capture) {
 
     // Use osascript to copy the contents of the file to clipboard
     QProcess process;
-    QString script = QString(
-        "set the clipboard to (read (POSIX file \"%1\") as «class PNGf»)"
-    ).arg(tempFile.fileName());
+    QString script = 
+      QString("set the clipboard to (read (POSIX file \"%1\") as «class PNGf»)")
+        .arg(tempFile.fileName());
     process.start("osascript", QStringList() << "-e" << script);
     if (!process.waitForFinished()) {
         qWarning() << "Failed to execute AppleScript.";


### PR DESCRIPTION
I fixed the known issue while setting `useJpgForClipboard=true` on macOS.

I wrote specific macOS function for this case and re-introduced this setting to GUI.

The code is tested and I run the app on my Mac.

The initial issue is here with more context: https://github.com/flameshot-org/flameshot/issues/3722

For the quick test, you can use the built app with the fix: https://github.com/flameshot-org/flameshot/issues/3722#issuecomment-2351597224

**Results:**
The same screenshot in a `.png` is 7.6 MB in size, in a `.jpeg` it's a 850 KB with 90 compression quality.