### PR TITLE
Added a config option to remove the contrast ring around the counting circle tool

### DIFF
--- a/flameshot.example.ini
+++ b/flameshot.example.ini
@@ -52,7 +52,8 @@
 ;disabledGrimWarning=true
 ;
 ;; Disable the contrast on the counting tool when it has no arrow
-;disabledCountingCircleContrast=false
+;disableCountingCircleContrast=false
+;
 ;; Automatically close daemon when it's not needed (not available on Windows)
 ;autoCloseIdleDaemon=false
 ;

--- a/flameshot.example.ini
+++ b/flameshot.example.ini
@@ -51,6 +51,8 @@
 ;; Disable Grim Warning notification
 ;disabledGrimWarning=true
 ;
+;; Disable the contrast on the counting tool when it has no arrow
+;disabledCountingCircleContrast=false
 ;; Automatically close daemon when it's not needed (not available on Windows)
 ;autoCloseIdleDaemon=false
 ;

--- a/src/config/generalconf.cpp
+++ b/src/config/generalconf.cpp
@@ -59,6 +59,7 @@ GeneralConf::GeneralConf(QWidget* parent)
     initUploadClientSecret();
     initPredefinedColorPaletteLarge();
     initShowSelectionGeometry();
+    initCountingCircleNoContrast();
 
     m_layout->addStretch();
 
@@ -82,6 +83,7 @@ void GeneralConf::_updateComponents(bool allowEmptySavePath)
     m_copyPathAfterSave->setChecked(config.copyPathAfterSave());
     m_antialiasingPinZoom->setChecked(config.antialiasingPinZoom());
     m_useJpgForClipboard->setChecked(config.useJpgForClipboard());
+    m_countingCircleNoContrast->setChecked(config.countingCircleNoContrast());
     m_copyOnDoubleClick->setChecked(config.copyOnDoubleClick());
     m_uploadWithoutConfirmation->setChecked(config.uploadWithoutConfirmation());
     m_historyConfirmationToDelete->setChecked(
@@ -150,6 +152,10 @@ void GeneralConf::allowMultipleGuiInstancesChanged(bool checked)
     ConfigHandler().setAllowMultipleGuiInstances(checked);
 }
 
+void GeneralConf::setCountingCircleNoContrast(bool checked)
+{
+    ConfigHandler().setCountingCircleNoContrast(checked);
+}
 void GeneralConf::autoCloseIdleDaemonChanged(bool checked)
 {
     ConfigHandler().setAutoCloseIdleDaemon(checked);
@@ -798,6 +804,17 @@ void GeneralConf::initJpegQuality()
             this,
             &GeneralConf::setJpegQuality);
 }
+
+void GeneralConf::initCountingCircleNoContrast()
+{
+    m_countingCircleNoContrast = new QCheckBox(tr("Disable contrast on the counting bubble"), this);
+    m_countingCircleNoContrast->setToolTip(
+      tr("Disable the contrasting circle that is around the counting circle tool when it has no arrow"));
+    m_scrollAreaLayout->addWidget(m_countingCircleNoContrast);
+    connect(m_countingCircleNoContrast,
+            &QCheckBox::clicked,
+            this,
+            &GeneralConf::setCountingCircleNoContrast);}
 
 void GeneralConf::setSelGeoHideTime(int v)
 {

--- a/src/config/generalconf.cpp
+++ b/src/config/generalconf.cpp
@@ -59,7 +59,7 @@ GeneralConf::GeneralConf(QWidget* parent)
     initUploadClientSecret();
     initPredefinedColorPaletteLarge();
     initShowSelectionGeometry();
-    initCountingCircleNoContrast();
+    initDisableCountingCircleContrast();
 
     m_layout->addStretch();
 
@@ -83,7 +83,7 @@ void GeneralConf::_updateComponents(bool allowEmptySavePath)
     m_copyPathAfterSave->setChecked(config.copyPathAfterSave());
     m_antialiasingPinZoom->setChecked(config.antialiasingPinZoom());
     m_useJpgForClipboard->setChecked(config.useJpgForClipboard());
-    m_countingCircleNoContrast->setChecked(config.countingCircleNoContrast());
+    m_disableCountingCircleContrast->setChecked(config.disableCountingCircleContrast());
     m_copyOnDoubleClick->setChecked(config.copyOnDoubleClick());
     m_uploadWithoutConfirmation->setChecked(config.uploadWithoutConfirmation());
     m_historyConfirmationToDelete->setChecked(
@@ -152,9 +152,9 @@ void GeneralConf::allowMultipleGuiInstancesChanged(bool checked)
     ConfigHandler().setAllowMultipleGuiInstances(checked);
 }
 
-void GeneralConf::setCountingCircleNoContrast(bool checked)
+void GeneralConf::setDisableCountingCircleContrast(bool checked)
 {
-    ConfigHandler().setCountingCircleNoContrast(checked);
+    ConfigHandler().setDisableCountingCircleContrast(checked);
 }
 void GeneralConf::autoCloseIdleDaemonChanged(bool checked)
 {
@@ -805,16 +805,16 @@ void GeneralConf::initJpegQuality()
             &GeneralConf::setJpegQuality);
 }
 
-void GeneralConf::initCountingCircleNoContrast()
+void GeneralConf::initDisableCountingCircleContrast()
 {
-    m_countingCircleNoContrast = new QCheckBox(tr("Disable contrast on the counting bubble"), this);
-    m_countingCircleNoContrast->setToolTip(
+    m_disableCountingCircleContrast = new QCheckBox(tr("Disable contrast on the counting bubble"), this);
+    m_disableCountingCircleContrast->setToolTip(
       tr("Disable the contrasting circle that is around the counting circle tool when it has no arrow"));
-    m_scrollAreaLayout->addWidget(m_countingCircleNoContrast);
-    connect(m_countingCircleNoContrast,
+    m_scrollAreaLayout->addWidget(m_disableCountingCircleContrast);
+    connect(m_disableCountingCircleContrast,
             &QCheckBox::clicked,
             this,
-            &GeneralConf::setCountingCircleNoContrast);}
+            &GeneralConf::setDisableCountingCircleContrast);}
 
 void GeneralConf::setSelGeoHideTime(int v)
 {

--- a/src/config/generalconf.h
+++ b/src/config/generalconf.h
@@ -58,7 +58,7 @@ private slots:
     void setGeometryLocation(int index);
     void setSelGeoHideTime(int v);
     void setJpegQuality(int v);
-    void setCountingCircleNoContrast(bool checked);
+    void setDisableCountingCircleContrast(bool checked);
 
 private:
     const QString chooseFolder(const QString& currentPath = "");
@@ -93,7 +93,7 @@ private:
     void initSaveLastRegion();
     void initShowSelectionGeometry();
     void initJpegQuality();
-    void initCountingCircleNoContrast();
+    void initDisableCountingCircleContrast();
 
     void _updateComponents(bool allowEmptySavePath);
 
@@ -138,5 +138,5 @@ private:
     QComboBox* m_selectGeometryLocation;
     QSpinBox* m_xywhTimeout;
     QSpinBox* m_jpegQuality;
-    QCheckBox* m_countingCircleNoContrast;
+    QCheckBox* m_disableCountingCircleContrast;
 };

--- a/src/config/generalconf.h
+++ b/src/config/generalconf.h
@@ -58,6 +58,7 @@ private slots:
     void setGeometryLocation(int index);
     void setSelGeoHideTime(int v);
     void setJpegQuality(int v);
+    void setCountingCircleNoContrast(bool checked);
 
 private:
     const QString chooseFolder(const QString& currentPath = "");
@@ -92,6 +93,7 @@ private:
     void initSaveLastRegion();
     void initShowSelectionGeometry();
     void initJpegQuality();
+    void initCountingCircleNoContrast();
 
     void _updateComponents(bool allowEmptySavePath);
 
@@ -136,4 +138,5 @@ private:
     QComboBox* m_selectGeometryLocation;
     QSpinBox* m_xywhTimeout;
     QSpinBox* m_jpegQuality;
+    QCheckBox* m_countingCircleNoContrast;
 };

--- a/src/tools/circlecount/circlecounttool.cpp
+++ b/src/tools/circlecount/circlecounttool.cpp
@@ -3,8 +3,10 @@
 
 #include "circlecounttool.h"
 #include "colorutils.h"
+#include "confighandler.h"
 #include <QPainter>
 #include <QPainterPath>
+#include <qdebug.h>
 
 namespace {
 #define PADDING_VALUE 2
@@ -130,11 +132,17 @@ void CircleCountTool::process(QPainter& painter, const QPixmap& pixmap)
         path.lineTo(points().first);
         painter.drawPath(path);
     }
-
     painter.setPen(contrastColor);
     painter.setBrush(antiContrastColor);
-    painter.drawEllipse(
-      points().first, bubble_size + PADDING_VALUE, bubble_size + PADDING_VALUE);
+    if(ConfigHandler().countingCircleNoContrast())
+    {
+        if(line.length() < bubble_size)
+        {
+            painter.setBrush(color());
+            painter.setPen(color());
+        }
+    }
+    painter.drawEllipse(points().first, bubble_size + PADDING_VALUE, bubble_size + PADDING_VALUE);
     painter.setBrush(color());
     painter.drawEllipse(points().first, bubble_size, bubble_size);
     QRect textRect = QRect(points().first.x() - bubble_size / 2,

--- a/src/tools/circlecount/circlecounttool.cpp
+++ b/src/tools/circlecount/circlecounttool.cpp
@@ -134,7 +134,7 @@ void CircleCountTool::process(QPainter& painter, const QPixmap& pixmap)
     }
     painter.setPen(contrastColor);
     painter.setBrush(antiContrastColor);
-    if(ConfigHandler().countingCircleNoContrast())
+    if(ConfigHandler().disableCountingCircleContrast())
     {
         if(line.length() < bubble_size)
         {

--- a/src/utils/confighandler.cpp
+++ b/src/utils/confighandler.cpp
@@ -79,6 +79,7 @@ static QMap<class QString, QSharedPointer<ValueHandler>>
     OPTION("showDesktopNotification"     ,Bool               ( true          )),
     OPTION("disabledTrayIcon"            ,Bool               ( false         )),
     OPTION("disabledGrimWarning"         ,Bool               ( false         )),
+    OPTION("countingCircleNoContrast"    ,Bool               ( false         )),
     OPTION("historyConfirmationToDelete" ,Bool               ( true          )),
 #if !defined(DISABLE_UPDATE_CHECKER)
     OPTION("checkForUpdates"             ,Bool               ( true          )),

--- a/src/utils/confighandler.cpp
+++ b/src/utils/confighandler.cpp
@@ -79,7 +79,7 @@ static QMap<class QString, QSharedPointer<ValueHandler>>
     OPTION("showDesktopNotification"     ,Bool               ( true          )),
     OPTION("disabledTrayIcon"            ,Bool               ( false         )),
     OPTION("disabledGrimWarning"         ,Bool               ( false         )),
-    OPTION("countingCircleNoContrast"    ,Bool               ( false         )),
+    OPTION("disableCountingCircleContrast"    ,Bool               ( false         )),
     OPTION("historyConfirmationToDelete" ,Bool               ( true          )),
 #if !defined(DISABLE_UPDATE_CHECKER)
     OPTION("checkForUpdates"             ,Bool               ( true          )),

--- a/src/utils/confighandler.h
+++ b/src/utils/confighandler.h
@@ -89,6 +89,7 @@ public:
     CONFIG_GETTER_SETTER(filenamePattern, setFilenamePattern, QString)
     CONFIG_GETTER_SETTER(disabledTrayIcon, setDisabledTrayIcon, bool)
     CONFIG_GETTER_SETTER(disabledGrimWarning, disabledGrimWarning, bool)
+    CONFIG_GETTER_SETTER(countingCircleNoContrast, setCountingCircleNoContrast, bool)
     CONFIG_GETTER_SETTER(drawThickness, setDrawThickness, int)
     CONFIG_GETTER_SETTER(drawFontSize, setDrawFontSize, int)
     CONFIG_GETTER_SETTER(keepOpenAppLauncher, setKeepOpenAppLauncher, bool)

--- a/src/utils/confighandler.h
+++ b/src/utils/confighandler.h
@@ -89,7 +89,7 @@ public:
     CONFIG_GETTER_SETTER(filenamePattern, setFilenamePattern, QString)
     CONFIG_GETTER_SETTER(disabledTrayIcon, setDisabledTrayIcon, bool)
     CONFIG_GETTER_SETTER(disabledGrimWarning, disabledGrimWarning, bool)
-    CONFIG_GETTER_SETTER(countingCircleNoContrast, setCountingCircleNoContrast, bool)
+    CONFIG_GETTER_SETTER(disableCountingCircleContrast, setDisableCountingCircleContrast, bool)
     CONFIG_GETTER_SETTER(drawThickness, setDrawThickness, int)
     CONFIG_GETTER_SETTER(drawFontSize, setDrawFontSize, int)
     CONFIG_GETTER_SETTER(keepOpenAppLauncher, setKeepOpenAppLauncher, bool)


### PR DESCRIPTION
This config option removes the contrasting ring around the counting circle tool but enables it again when the user adds an arrow to the circle. I tested it with removing the circle there as well but it looks really unnatural.

I saw someone made a request for the enhancement in #3720 and I already ran it in my own fork of flameshot so decided to give it an actual config option.
![2024-10-07_06-11](https://github.com/user-attachments/assets/8615f005-1eeb-49fb-ab14-f09273c570d3)
