### PR TITLE
Add Shortcut to Cancel current selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ These shortcuts are available in GUI mode:
 | <kbd>Ctrl</kbd> + <kbd>Q</kbd>                                            | Leave the capture screen                                         |
 | <kbd>Ctrl</kbd> + <kbd>O</kbd>                                            | Choose an app to open the capture                                |
 | <kbd>Ctrl</kbd> + <kbd>Return</kbd>                                            | Commit text in text area|
+| <kbd>Ctrl</kbd> + <kbd>Backspace</kbd>                                    | Cancel current selection                                       | 
 | <kbd>Return</kbd>                                             | Upload the selection to Imgur                                      |
 | <kbd>Spacebar</kbd>                                                       | Toggle visibility of sidebar with options of the selected tool, color picker for the drawing color and history menu |
 | Right Click                                                               | Show the color wheel                                              |

--- a/flameshot.example.ini
+++ b/flameshot.example.ini
@@ -99,6 +99,7 @@
 ;; Shortcut Settings for all tools
 ;[Shortcuts]
 ;TYPE_ARROW=A
+;TYPE_CANCEL=Ctrl+Backspace
 ;TYPE_CIRCLE=C
 ;TYPE_CIRCLECOUNT=
 ;TYPE_COMMIT_CURRENT_TOOL=Ctrl+Return

--- a/src/config/shortcutswidget.cpp
+++ b/src/config/shortcutswidget.cpp
@@ -192,6 +192,7 @@ void ShortcutsWidget::loadShortcuts()
     appendShortcut("TYPE_COMMIT_CURRENT_TOOL", tr("Commit text in text area"));
     appendShortcut("TYPE_DELETE_CURRENT_TOOL",
                    tr("Delete selected drawn object"));
+    appendShortcut("TYPE_CANCEL", tr("Cancel current selection"));
 
     // non-editable shortcuts have an empty shortcut name
 

--- a/src/tools/capturetool.h
+++ b/src/tools/capturetool.h
@@ -48,6 +48,7 @@ public:
         TYPE_SIZEDECREASE = 21,
         TYPE_INVERT = 22,
         TYPE_ACCEPT = 23,
+        TYPE_CANCEL = 24,
     };
     Q_ENUM(Type);
 

--- a/src/utils/confighandler.cpp
+++ b/src/utils/confighandler.cpp
@@ -145,6 +145,7 @@ static QMap<QString, QSharedPointer<KeySequence>> recognizedShortcuts = {
     SHORTCUT("TYPE_SAVE"                ,   "Ctrl+S"                ),
     SHORTCUT("TYPE_ACCEPT"              ,   "Return"                ),
     SHORTCUT("TYPE_EXIT"                ,   "Ctrl+Q"                ),
+	SHORTCUT("TYPE_CANCEL" 				,	"Ctrl+Backspace"		),
     SHORTCUT("TYPE_IMAGEUPLOADER"       ,                           ),
 #if !defined(Q_OS_MACOS)
     SHORTCUT("TYPE_OPEN_APP"            ,   "Ctrl+O"                ),

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -796,7 +796,6 @@ void CaptureWidget::mousePressEvent(QMouseEvent* e)
     if (m_selection->getMouseSide(e->pos()) != SelectionWidget::CENTER) {
         m_panel->setActiveLayer(-1);
     }
-
     if (e->button() == Qt::RightButton) {
         if (m_activeTool && m_activeTool->editMode()) {
             return;
@@ -1603,6 +1602,10 @@ void CaptureWidget::initShortcuts()
                 m_selection,
                 SLOT(moveDown()));
 
+    newShortcut(QKeySequence(ConfigHandler().shortcut("TYPE_CANCEL")),
+                this,
+                SLOT(cancel()));
+
     newShortcut(
       QKeySequence(ConfigHandler().shortcut("TYPE_DELETE_CURRENT_TOOL")),
       this,
@@ -1912,6 +1915,23 @@ void CaptureWidget::redo()
     updateLayersPanel();
 
     restoreCircleCountState();
+}
+
+void CaptureWidget::cancel()
+{
+    if (m_activeButton != nullptr) {
+        uncheckActiveTool();
+    }
+    if (m_panel) {
+        m_panel->setActiveLayer(-1);
+    }
+    if (m_toolWidget) {
+        m_toolWidget->hide();
+        delete m_toolWidget;
+        m_toolWidget = nullptr;
+    }
+    m_selection->hide();
+    emit m_selection->geometrySettled();
 }
 
 QRect CaptureWidget::extendedSelection() const

--- a/src/widgets/capture/capturewidget.h
+++ b/src/widgets/capture/capturewidget.h
@@ -70,6 +70,7 @@ signals:
 private slots:
     void undo();
     void redo();
+    void cancel();
     void togglePanel();
     void childEnter();
     void childLeave();


### PR DESCRIPTION
This PR adds the ability to close the selection using the Ctrl + Backspace key combination, addressing issue #3319 . The new shortcut allows users to quickly exit the selection mode without relying on mouse interactions. All the relevant files and documentation are updated to reflect this.

Thanks!