### PR TITLE
[security] replace pixelation by pseudo-pixelation 

### DIFF
--- a/src/tools/pixelate/pixelatetool.cpp
+++ b/src/tools/pixelate/pixelatetool.cpp
@@ -8,6 +8,7 @@
 #include <QGraphicsScene>
 #include <QImage>
 #include <QPainter>
+#include <random>
 
 PixelateTool::PixelateTool(QObject* parent)
   : AbstractTwoPointTool(parent)
@@ -46,6 +47,16 @@ CaptureTool* PixelateTool::copy(QObject* parent)
     return tool;
 }
 
+/**
+ * Since pixelation does not protect the contents of the pixelated area
+ * (see e.g. https://github.com/bishopfox/unredacter),
+ * _pseudo-pixelation_ is used:
+ *
+ * Only colors from the fringe of the selected area are used to generate
+ * a pixelation-like effect. The interior of the selected area is not used
+ * as an input at all and hence can not be recovered.
+ *
+ */
 void PixelateTool::process(QPainter& painter, const QPixmap& pixmap)
 {
     QRect selection = boundingRect().intersected(pixmap.rect());
@@ -53,33 +64,118 @@ void PixelateTool::process(QPainter& painter, const QPixmap& pixmap)
     QRect selectionScaled = QRect(selection.topLeft() * pixelRatio,
                                   selection.bottomRight() * pixelRatio);
 
-    // If thickness is less than 1, use old blur process
-    if (size() <= 1) {
-        auto* blur = new QGraphicsBlurEffect;
-        blur->setBlurRadius(10);
-        auto* item = new QGraphicsPixmapItem(pixmap.copy(selectionScaled));
-        item->setGraphicsEffect(blur);
 
-        QGraphicsScene scene;
-        scene.addItem(item);
+    // calculate the size of the pixelation effect using the tool size
+    int width = qMax(1,
+      static_cast<int>(selection.width() * (0.5 / qMax(1, size() + 1))));
+    int height = qMax(1,
+      static_cast<int>(selection.height() * (0.5 / qMax(1, size() + 1))));
 
-        scene.render(&painter, selection, QRectF());
-        blur->setBlurRadius(12);
-        // multiple repeat for make blur effect stronger
-        scene.render(&painter, selection, QRectF());
+    QSize effect_size = QSize(width, height);
 
-    } else {
-        int width =
-          static_cast<int>(selection.width() * (0.5 / qMax(1, size() + 1)));
-        int height =
-          static_cast<int>(selection.height() * (0.5 / qMax(1, size() + 1)));
-        QSize size = QSize(qMax(width, 1), qMax(height, 1));
 
-        QPixmap t = pixmap.copy(selectionScaled);
-        t = t.scaled(size, Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
-        t = t.scaled(selection.width(), selection.height());
-        painter.drawImage(selection, t.toImage());
+    // the PRNG is only used for visual effects and NOT part of the security
+    // boundary
+    std::mt19937 prng(42);
+
+    // noise for the sampling process to avoid only sampling from a small
+    // subset of the fringe
+    std::normal_distribution<float> sampling_noise(0, 5 * size() + 1);
+
+    // additional noise that will be added on top of the effect to avoid
+    // generating a monochromatic box when the fringe is monochromatic
+    std::normal_distribution<float> noise(0, 0.1f);
+
+
+    // only values from the fringe will be used to compute the pseudo-pixelation
+    std::array<QImage, 4> fringe = {
+        // top fringe
+        pixmap.copy(QRect(selectionScaled.topLeft(),
+                    selectionScaled.topRight()))
+            .toImage(),
+        // bottom fringe
+        pixmap.copy(QRect(selectionScaled.bottomLeft(),
+                    selectionScaled.bottomRight()))
+            .toImage(),
+        // left fringe
+        pixmap.copy(QRect(selectionScaled.topLeft(),
+                    selectionScaled.bottomLeft()))
+            .toImage(),
+        // right fringe
+        pixmap.copy(QRect(selectionScaled.topRight(),
+                    selectionScaled.bottomRight()))
+            .toImage()
+    };
+
+
+    // Image where the pseudo-pixelation is calculated.
+    // This will later be scaled to cover the selected area.
+    QImage pixelated = QImage(effect_size, QImage::Format_RGB32);
+
+
+    // For every pixel of the effect, we consider four projections
+    // to the fringe and sample a pixel from there.
+    // Then a horizontal and vertical interpolation are calculated.
+    std::array<std::array<float, 3>, 4> samples;
+
+    for (int x = 0; x < width; ++x) {
+        for (int y = 0; y < height; ++y) {
+            float n = noise(prng);
+
+            // relative horizontal resp. vertical position
+            float horizontal = x / (float) width;
+            float vertical = y / (float) height;
+
+            for (int i = 0; i < 4; ++i) {
+                QColor c = fringe[i].pixel(
+                    std::clamp(
+                        static_cast<int>(
+                            horizontal * fringe[i].width()
+                            + sampling_noise(prng)),
+                        0, fringe[i].width()-1),
+                    std::clamp(
+                        static_cast<int>(
+                            vertical * fringe[i].height()
+                            + sampling_noise(prng)),
+                        0, fringe[i].height()-1));
+                samples[i][0] = c.redF();
+                samples[i][1] = c.greenF();
+                samples[i][2] = c.blueF();
+            }
+
+            // weights of the horizontal resp. vertical interpolation
+            float weight_h = (qMin(x, width - x) / width)
+                     - (qMin(y, height - y) / height)
+                     + 0.5;
+
+            float weight_v = 1 - weight_h;
+
+            // compute the weighted sum of the vertical and horizontal
+            // interpolations
+            std::array<int, 3> rgb = {0, 0, 0};
+            for (int i = 0; i < 3; ++i) {
+                float c =
+                    // horizontal interpolation
+                    weight_h * ((1-horizontal) * samples[2][i] + horizontal * samples[3][i])
+
+                    // vertical interpolation
+                  + weight_v * ((1-vertical) * samples[0][i] + vertical * samples[1][i])
+
+                    // additional noise
+                  + n;
+
+                rgb[i] = static_cast<int>(0xff * c);
+                rgb[i] = std::clamp(rgb[i], 0, 0xff);
+            }
+            QRgb value = qRgb(rgb[0], rgb[1], rgb[2]);
+            pixelated.setPixel(x,y, value);
+        }
     }
+
+    pixelated = pixelated.scaled(selection.width(), selection.height(),
+            Qt::IgnoreAspectRatio, Qt::FastTransformation);
+
+    painter.drawImage(selection, pixelated);
 }
 
 void PixelateTool::drawSearchArea(QPainter& painter, const QPixmap& pixmap)


### PR DESCRIPTION
Fixes #3289
Fixes #3763

Conflicts with PR #3368

# Changes

Replaces pixelation by pseudo-pixelation to make recovering information with tools like unredactor impossible.
Only the fringe of the selected area is used to calculate a pixelation-like effect; the interior does not effect the output and hence can not be recovered.

# Concerns
* The fringe of the selection can still be recovered (i.e. drawing a black box is still more secure)
* The look of the pixelation effect changes (as the interior of the image is no longer used as input)
* It might be better to use HSV-interpolation instead of RGB
* One might want to add an option to switch between pseudo-pixelation and (insecure) true pixelation.

# Examples of the new effect

![image](https://github.com/user-attachments/assets/40ef4781-6635-44e4-b6bc-8ef37eddd164)
![flameshot_test1](https://github.com/user-attachments/assets/4f0a6ef4-fab3-4b79-948c-621b551a3512)
![image](https://github.com/user-attachments/assets/5adfb8a7-f67a-483e-8234-1fad4bf1f32b)

