### PR TITLE
Give pins a different window title

### DIFF
--- a/src/tools/pin/pinwidget.cpp
+++ b/src/tools/pin/pinwidget.cpp
@@ -39,7 +39,7 @@ PinWidget::PinWidget(const QPixmap& pixmap,
     // set the bottom widget background transparent
     setAttribute(Qt::WA_TranslucentBackground);
     setAttribute(Qt::WA_DeleteOnClose);
-    setWindowTitle("Flameshot Pin");
+    setWindowTitle("flameshot-pin");
     ConfigHandler conf;
     m_baseColor = conf.uiColor();
     m_hoverColor = conf.contrastUiColor();

--- a/src/tools/pin/pinwidget.cpp
+++ b/src/tools/pin/pinwidget.cpp
@@ -39,6 +39,7 @@ PinWidget::PinWidget(const QPixmap& pixmap,
     // set the bottom widget background transparent
     setAttribute(Qt::WA_TranslucentBackground);
     setAttribute(Qt::WA_DeleteOnClose);
+    setWindowTitle("Flameshot Pin");
     ConfigHandler conf;
     m_baseColor = conf.uiColor();
     m_hoverColor = conf.contrastUiColor();


### PR DESCRIPTION
Workaround for a KDE issue where the capture window can't be differentiated from the pin window in any way, making the multi-monitor workaround in #3073 also break pins.