### PR TITLE
Correct the exit value on abort (#3321)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -45,7 +45,7 @@ void wayland_hacks()
 }
 #endif
 
-void requestCaptureAndWait(const CaptureRequest& req)
+int requestCaptureAndWait(const CaptureRequest& req)
 {
     Flameshot* flameshot = Flameshot::instance();
     flameshot->requestCapture(req);
@@ -66,7 +66,7 @@ void requestCaptureAndWait(const CaptureRequest& req)
         AbstractLogger::info() << "Screenshot aborted.";
         qApp->exit(1);
     });
-    qApp->exec();
+    return qApp->exec();
 }
 
 QSharedMemory* guiMutexLock()
@@ -428,7 +428,7 @@ int main(int argc, char* argv[])
                 req.addSaveTask();
             }
         }
-        requestCaptureAndWait(req);
+        return requestCaptureAndWait(req);
     } else if (parser.isSet(fullArgument)) { // FULL
         reinitializeAsQApplication(argc, argv);
 
@@ -463,7 +463,7 @@ int main(int argc, char* argv[])
         if (!clipboard && path.isEmpty() && !raw && !upload) {
             req.addSaveTask();
         }
-        requestCaptureAndWait(req);
+        return requestCaptureAndWait(req);
     } else if (parser.isSet(screenArgument)) { // SCREEN
         reinitializeAsQApplication(argc, argv);
 
@@ -513,7 +513,7 @@ int main(int argc, char* argv[])
             req.addSaveTask();
         }
 
-        requestCaptureAndWait(req);
+        return requestCaptureAndWait(req);
     } else if (parser.isSet(configArgument)) { // CONFIG
         bool autostart = parser.isSet(autostartOption);
         bool filename = parser.isSet(filenameOption);


### PR DESCRIPTION
`flameshot gui` exits with 0 on abort, we can use the return value of `qApp->exec()` in `requestCaptureAndWait` in main.cpp.

![图片](https://github.com/user-attachments/assets/965e2542-55f9-4250-bb5b-0cb3b336e8af)
