### PR TITLE
Update build/install instructions for custom install dir translations to work

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,7 +401,7 @@ Also you can open and build/debug the project in a C++ IDE. For example, in Qt C
 - Qt >= 5.9
   + Development tools
 - GCC >= 7.4
-- CMake >= 3.13
+- CMake >= 3.21
 
 #### Run-time
 
@@ -461,7 +461,7 @@ nix-shell
 
 #### macOS
 
-First of all you need to install [brew](https://brew.sh) and than install the dependencies
+First of all you need to install [brew](https://brew.sh) and then install the dependencies
 ```shell
 brew install qt5
 brew install cmake
@@ -469,42 +469,52 @@ brew install cmake
 
 ### Build
 
-After installing all the dependencies, finally run the following commands in the sources root directory:
+After installing all the dependencies, flameshot can be built.
+
+#### Installation/build dir
+For the translations to be loaded correctly, the build process needs to be aware of where you want
+to install flameshot.
 
 ```shell
-cmake -S . -B build && cmake --build build
+# Directory where build files will be placed, may be relative
+export BUILD_DIR=build
+
+# Directory prefix where flameshot will be installed. If you are just building and don't want to
+# install, this environment variable will not have an effect.
+# This excludes the bin/flameshot part of the install,
+# e.g. in /opt/flameshot/bin/flameshot, the INSTALL_PREFIX is /opt/flameshot
+# This must be an absolute path. Requires CMAKE 3.21.
+export INSTALL_PREFIX=$(realpath install)
+
+# Linux
+cmake -S . -B "$BUILD_DIR" --install-prefix "$INSTALL_PREFIX" \
+    && cmake --build "$BUILD_DIR"
+
+#MacOS
+cmake -S . -B "$BUILD_DIR" --install-prefix  "$INSTALL_PREFIX" \
+    -DQt5_DIR=$(brew --prefix qt5)/lib/cmake/Qt5 \
+    && cmake --build "$BUILD_DIR"
 ```
 
-NOTE: For macOS you should replace the command
-
-```shell
-cmake -S . -B build
-```
-
-with
-
-```shell
-cmake -S . -B build -DQt5_DIR=$(brew --prefix qt5)/lib/cmake/Qt5
-```
-
-When the `cmake --build build` command has completed you can launch flameshot from the `project_folder/build/src` folder.
+When the `cmake --build` command has completed you can launch flameshot from the `project_folder/build/src` folder.
 
 ### Install
 
 Note that if you install from source, there _is no_ uninstaller, so consider installing to a custom directory.
 
 #### To install into a custom directory
+For translations to work when installing in a custom directory, make sure you built flameshot with
+the `$INSTALL_PREFIX` set to the installation directory.
+
 ```bash
-# Best to use an absolute path here
-INST_DIR=/opt/flameshot
 # You may need to run this with privileges
-cmake --install build --prefix "$INST_DIR"
+cmake --install "$BUILD_DIR" --prefix "$INSTALL_PREFIX"
 ```
 
 #### To install to the default install directory
 ```bash
 # You may need to run this with privileges
-cmake --install build
+cmake --install "$BUILD_DIR"
 ```
 
 ### FAQ

--- a/README.md
+++ b/README.md
@@ -401,7 +401,7 @@ Also you can open and build/debug the project in a C++ IDE. For example, in Qt C
 - Qt >= 5.9
   + Development tools
 - GCC >= 7.4
-- CMake >= 3.21
+- CMake >= 3.29
 
 #### Run-time
 
@@ -480,18 +480,18 @@ to install flameshot.
 export BUILD_DIR=build
 
 # Directory prefix where flameshot will be installed. If you are just building and don't want to
-# install, this environment variable will not have an effect.
+# install, comment this environment variable.
 # This excludes the bin/flameshot part of the install,
-# e.g. in /opt/flameshot/bin/flameshot, the INSTALL_PREFIX is /opt/flameshot
-# This must be an absolute path. Requires CMAKE 3.21.
-export INSTALL_PREFIX=$(realpath install)
+# e.g. in /opt/flameshot/bin/flameshot, the CMAKE_INSTALL_PREFIX is /opt/flameshot
+# This must be an absolute path. Requires CMAKE 3.29.
+export CMAKE_INSTALL_PREFIX=/opt/flameshot
 
 # Linux
-cmake -S . -B "$BUILD_DIR" --install-prefix "$INSTALL_PREFIX" \
+cmake -S . -B "$BUILD_DIR" \
     && cmake --build "$BUILD_DIR"
 
 #MacOS
-cmake -S . -B "$BUILD_DIR" --install-prefix  "$INSTALL_PREFIX" \
+cmake -S . -B "$BUILD_DIR" \
     -DQt5_DIR=$(brew --prefix qt5)/lib/cmake/Qt5 \
     && cmake --build "$BUILD_DIR"
 ```
@@ -503,12 +503,16 @@ When the `cmake --build` command has completed you can launch flameshot from the
 Note that if you install from source, there _is no_ uninstaller, so consider installing to a custom directory.
 
 #### To install into a custom directory
-For translations to work when installing in a custom directory, make sure you built flameshot with
-the `$INSTALL_PREFIX` set to the installation directory.
+Make sure you are using cmake `>= 3.29` and build flameshot with `$CMAKE_INSTALL_PREFIX` set to the
+installation directory. If this is not done, the translations won't be found when using a custom directory.
+Then, run the following:
 
 ```bash
+# !Build with CMAKE_INSTALL_PREFIX and use cmake >= 3.29! Using an older cmake will cause
+# installation into the default /usr/local dir.
+
 # You may need to run this with privileges
-cmake --install "$BUILD_DIR" --prefix "$INSTALL_PREFIX"
+cmake --install "$BUILD_DIR"
 ```
 
 #### To install to the default install directory

--- a/README.md
+++ b/README.md
@@ -492,7 +492,7 @@ cmake -S . -B "$BUILD_DIR" \
 
 #MacOS
 cmake -S . -B "$BUILD_DIR" \
-    -DQt5_DIR=$(brew --prefix qt5)/lib/cmake/Qt5 \
+    -DQt5_DIR="$(brew --prefix qt5)/lib/cmake/Qt5" \
     && cmake --build "$BUILD_DIR"
 ```
 


### PR DESCRIPTION
Flameshot uses CMAKE_INSTALL_PREFIX to set APP_PREFIX.
APP_PREFIX is used to determine one of the potential locations of the translations.
This can be observed in https://github.com/flameshot-org/flameshot/blob/10d12e0b54d59de2ac2567c540a93113672cd884/src/utils/pathinfo.cpp#L26
CMAKE_INSTALL_PREFIX defaults to /usr/local on UNIX.

The problem is that APP_PREFIX is set during the build -S step and changing this
using build --install build --prefix ... does not actually change the value of
APP_PREFIX. This leads to the translations not being found when running
from a custom install location.

To combat this, the [CMAKE_INSTALL_PREFIX](https://cmake.org/cmake/help/latest/variable/CMAKE_INSTALL_PREFIX.html) env var is used to properly set
the APP_PREFIX. This requires CMAKE 3.29.

Alternatives:
- Get rid of APP_PREFIX and try to find the translations using path traversal.
- Use --install-prefix and --prefix, this requires cmake 3.21. Also possible is to use
  -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR> which would not require a
  newer CMAKE. This requires specifying the install dir twice.
- Add a symbolic link next to the binary and use the same method used
  to make running from the build directory possible.
  `ln -s "$INST_DIR/bin/translations" ../share/flameshot/translations`