### PR TITLE
Fix English translations not used despite being preferred

### DIFF
--- a/data/translations/Internationalization_en.ts
+++ b/data/translations/Internationalization_en.ts
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<!--
+    An empty translation file is required for the base language, or it will only be used as a
+    fallback if the user prefers other supported languages. E.g.
+    $ LANGUAGE=en:nl flameshot
+    will result in Dutch translations being used despite English being higher priority.
+    See https://bugreports.qt.io/browse/QTBUG-69196
+-->
+<TS version="2.1" language="en">
+</TS>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -103,6 +103,7 @@ set(FLAMESHOT_TS_FILES
       ${CMAKE_SOURCE_DIR}/data/translations/Internationalization_cs.ts
       ${CMAKE_SOURCE_DIR}/data/translations/Internationalization_de_DE.ts
       ${CMAKE_SOURCE_DIR}/data/translations/Internationalization_el.ts
+      ${CMAKE_SOURCE_DIR}/data/translations/Internationalization_en.ts
       ${CMAKE_SOURCE_DIR}/data/translations/Internationalization_es.ts
       ${CMAKE_SOURCE_DIR}/data/translations/Internationalization_eu.ts
       ${CMAKE_SOURCE_DIR}/data/translations/Internationalization_fa.ts


### PR DESCRIPTION
When specifying the preferred language on Linux, the `$LANGUAGE` env var is used. See <https://www.gnu.org/software/gettext/manual/html_node/The-LANGUAGE-variable.html>.

**Example:**
`$ LANGUAGE=en:nl flameshot`

**Expected:**
flameshot should be in English as this is a localization that flameshot provides. If English would not be supported, it should fall back to using Dutch (nl).

**Actual:**
flameshot uses Dutch translations.

**Cause:**
If an empty translation file for the base language (here "en") is not provided, the base language is only used as a fallback.
See <https://bugreports.qt.io/browse/QTBUG-69196>

Additional search keywords:
- $LANGUAGE not respected
- Wrong language used