### PR TITLE
CI: migrate all upload-artifact actions from v3 to v4

### DIFF
--- a/.github/workflows/Linux-pack.yml
+++ b/.github/workflows/Linux-pack.yml
@@ -229,7 +229,7 @@ jobs:
           echo $(sh $GITHUB_WORKSPACE/scripts/upload_services/${UPLOAD_SERVICE}.sh $GITHUB_WORKSPACE/build/${PRODUCT}-${VERSION}-${RELEASE}.${{ matrix.dist.name }}.${{ matrix.dist.arch }}.deb)
           echo "======no operation for you can see link in the log console====="
       - name: Artifact Upload
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Linux-distribution-artifact
           path: |
@@ -336,7 +336,7 @@ jobs:
           echo "======no operation for you can see link in the log console====="
       - name: Artifact Upload
         if: matrix.dist.os == 'fedora'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Linux-distribution-artifact
           path: |
@@ -344,7 +344,7 @@ jobs:
 
       - name: Artifact Upload
         if: matrix.dist.os == 'opensuse-leap'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Linux-distribution-artifact
           path: |
@@ -478,7 +478,7 @@ jobs:
           echo $(sh $GITHUB_WORKSPACE/scripts/upload_services/${UPLOAD_SERVICE}.sh $GITHUB_WORKSPACE/Flameshot-${VERSION}.x86_64.AppImage)
           echo "======no operation for you can see link in the log console====="
       - name: Artifact Upload
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Linux-distribution-artifact
           path: |
@@ -544,7 +544,7 @@ jobs:
           echo $(sh $GITHUB_WORKSPACE/scripts/upload_services/${UPLOAD_SERVICE}.sh $GITHUB_WORKSPACE/org.flameshot.Flameshot-${VERSION}.x86_64.flatpak)
           echo "======no operation for you can see link in the log console====="
       - name: Artifact Upload
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Linux-distribution-artifact
           path: |
@@ -601,7 +601,7 @@ jobs:
           echo $(sh $GITHUB_WORKSPACE/scripts/upload_services/${UPLOAD_SERVICE}.sh $GITHUB_WORKSPACE/build/${PRODUCT}-${VERSION}-${RELEASE}.amd64.snap)
           echo "======no operation for you can see link in the log console====="
       - name: Artifact Upload
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Linux-distribution-artifact
           path: |

--- a/.github/workflows/Linux-pack.yml
+++ b/.github/workflows/Linux-pack.yml
@@ -235,6 +235,7 @@ jobs:
           path: |
             ${{ github.workspace }}/build/${{ env.PRODUCT }}-*-${{ env.RELEASE }}.${{ matrix.dist.name }}.${{ matrix.dist.arch }}.deb
             ${{ github.workspace }}/build/${{ env.PRODUCT }}-*-${{ env.RELEASE }}.${{ matrix.dist.name }}.${{ matrix.dist.arch }}.deb.sha256sum
+          overwrite: true
 
   rpm-pack:
     name: Build rpm on ${{ matrix.dist.name }} ${{ matrix.dist.arch }}
@@ -341,6 +342,7 @@ jobs:
           name: Linux-distribution-artifact
           path: |
             ${{ github.workspace }}/build/
+          overwrite: true
 
       - name: Artifact Upload
         if: matrix.dist.os == 'opensuse-leap'
@@ -350,6 +352,8 @@ jobs:
           path: |
             ${{ github.workspace }}/build/${{ env.PRODUCT }}-*-lp${{ matrix.dist.symbol }}.${{ matrix.dist.arch }}.rpm
             ${{ github.workspace }}/build/${{ env.PRODUCT }}-*-lp${{ matrix.dist.symbol }}.${{ matrix.dist.arch }}.rpm.sha256sum
+          overwrite: true
+  
   appimage-pack:
     name: Build appimage on ${{ matrix.config.name }}
     runs-on: ubuntu-22.04
@@ -484,6 +488,7 @@ jobs:
           path: |
             ${{ github.workspace }}/Flameshot-*.x86_64.AppImage
             ${{ github.workspace }}/Flameshot-*.x86_64.AppImage.sha256sum
+          overwrite: true
 
   flatpak-pack:
     name: Build flatpak on ubuntu-20.04
@@ -550,6 +555,7 @@ jobs:
           path: |
             ${{ github.workspace }}/org.flameshot.Flameshot-*.x86_64.flatpak
             ${{ github.workspace }}/org.flameshot.Flameshot-*.x86_64.flatpak.sha256sum
+          overwrite: true
 
   snap-pack:
     name: Build snap on ubuntu-20.04
@@ -607,3 +613,4 @@ jobs:
           path: |
             ${{ github.workspace }}/build/${{ env.PRODUCT }}-*-${{ env.RELEASE }}.amd64.snap
             ${{ github.workspace }}/build/${{ env.PRODUCT }}-*-${{ env.RELEASE }}.amd64.snap.sha256sum
+          overwrite: true

--- a/.github/workflows/MacOS-pack.yml
+++ b/.github/workflows/MacOS-pack.yml
@@ -78,7 +78,7 @@ jobs:
           echo "=====no operation for you can see link in the log console====="
 
       - name: Artifact Upload
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS-artifact
           path: ${{ github.workspace }}/build/src/flameshot.dmg

--- a/.github/workflows/MacOS-pack.yml
+++ b/.github/workflows/MacOS-pack.yml
@@ -82,6 +82,7 @@ jobs:
         with:
           name: MacOS-artifact
           path: ${{ github.workspace }}/build/src/flameshot.dmg
+          overwrite: true
 
       - name: Notarization status
         shell: bash

--- a/.github/workflows/Windows-pack.yml
+++ b/.github/workflows/Windows-pack.yml
@@ -204,3 +204,4 @@ jobs:
         with:
           name: Windows-${{ matrix.config.arch }}-${{ matrix.type }}-artifact
           path: ${{ github.workspace }}/build/Package/*
+          overwrite: true


### PR DESCRIPTION
The 4 failed CIs are irrelevant to this PR. The RPM CIs fail because this PR should be merged: #3685, and the Windows CI fails because of a python package which is not used by us. I think we should update the action there too, but that needs it's own PR.