### PR TITLE
Remove QEMU dummy package installation from Linux-pack.yml

### DIFF
--- a/.github/workflows/Linux-pack.yml
+++ b/.github/workflows/Linux-pack.yml
@@ -142,7 +142,7 @@ jobs:
           esac
           if [ -n "${QEMU_ARCH}" ]; then
             sudo apt-get -y -qq update
-            sudo apt-get -y install qemu binfmt-support qemu-user-static
+            sudo apt-get -y install binfmt-support qemu-user-static
             docker run --rm --privileged multiarch/qemu-user-static --reset --persistent yes --credential yes
             cat /proc/sys/fs/binfmt_misc/qemu-${QEMU_ARCH}
           fi


### PR DESCRIPTION
Motivation: I don't want the CI to fail when tests are run on ARM

![image](https://github.com/user-attachments/assets/921f5c3e-5966-4dbb-8f90-fd831e4a45e5)

Solution reasoning:
The QEMU package is now a dummy package. Installing `qemu-user-static` should keep functionality and fix the failing workflow.

See https://packages.debian.org/buster/qemu and https://packages.debian.org/bullseye/qemu for official mention of it being a dummy package.

![image](https://github.com/user-attachments/assets/944cadbb-74db-4cd7-a951-2c0e38d75d5b)

Current state CI run: https://github.com/volovikariel/flameshot/actions/runs/13458590444
With this change: https://github.com/volovikariel/flameshot/actions/runs/13458428232
