### PR TITLE
fix(ci): correct macos build

### DIFF
--- a/.github/workflows/MacOS-pack.yml
+++ b/.github/workflows/MacOS-pack.yml
@@ -20,10 +20,21 @@ env:
   PRODUCT: flameshot
 
 jobs:
-  x86_64:
-    name: macOS Sonoma 14
-    runs-on: macos-14
-
+  dmg-pack:
+    name: Build dmg on ${{ matrix.dist.os }} ${{ matrix.dist.arch }}
+    strategy:
+      fail-fast: false
+      matrix:
+        dist:
+          - {
+              os: macos-13,
+              arch: x86_64
+            }
+          - {
+              os: macos-14,
+              arch: arm64
+            }
+    runs-on: ${{ matrix.dist.os }}
     env:
       APP_NAME: flameshot
       DIR_BULD: build
@@ -46,6 +57,28 @@ jobs:
       NOTARIZATION_CHECK: false
 
     steps:
+      - name: Check architecture
+        if: matrix.dist.arch == 'x86_64'
+        shell: bash
+        run: |
+          platform_arch=$(uname -m)
+          if [[ $platform_arch != "x86_64" ]]; then
+            echo "$platform_arch detected. This build must be run on x86_64."
+            exit -1
+          fi
+          echo "$platform_arch detected."
+
+      - name: Check architecture
+        if: matrix.dist.arch == 'arm64'
+        shell: bash
+        run: |
+          platform_arch=$(uname -m)
+          if [[ $platform_arch != "arm64" ]]; then
+            echo "$platform_arch detected. This build must be run on arm64."
+            exit -1
+          fi
+          echo "$platform_arch detected."
+
       - name: Checkout Source code
         uses: actions/checkout@v4
 
@@ -87,7 +120,7 @@ jobs:
       - name: Artifact Upload
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.PRODUCT }}-${{ env.VER_INFO }}-artifact-macos-x86_64
+          name: ${{ env.PRODUCT }}-${{ env.VER_INFO }}-artifact-macos-${{ matrix.dist.arch }}
           path: ${{ github.workspace }}/build/src/flameshot.dmg
           overwrite: true
 


### PR DESCRIPTION
- add arm64 build, macos-14 (is latest now) in GitHub Actions is only available for arm64. See here https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source.
- update x86_64 build on maocos-13, macos-13 will be the last image to support Intel x86_64. We have to rewrite Intel x86_64 pipeline once macos-13 image is removed in GitHub Actions or drop macos x86_64 support in the future.
![](https://github.com/user-attachments/assets/4e89c0a0-ae32-49c9-96ea-3d8b33101955)

NOTE. I'm not macos user, so didn't test them on macos arm64/x86_64, just builds pass.


