### PR TITLE
Fix issue #564, that in wayland fractional scaling situtation, screenshot preview size is wrong.

### DIFF
--- a/src/utils/screengrabber.cpp
+++ b/src/utils/screengrabber.cpp
@@ -80,7 +80,16 @@ void ScreenGrabber::freeDesktopPortal(bool& ok, QPixmap& res)
             QUrl uri = map.value("uri").toString();
             QString uriString = uri.toLocalFile();
             res = QPixmap(uriString);
-            res.setDevicePixelRatio(qApp->devicePixelRatio());
+            QScreen* screen = QGuiAppCurrentScreen().currentScreen();
+            if (screen)
+            {
+                const auto screenRect = screen->geometry();
+                res.setDevicePixelRatio(res.height() * 1.0f / screenRect.height());
+            }
+            else
+            {
+                res.setDevicePixelRatio(qApp->devicePixelRatio());
+            }
             QFile imgFile(uriString);
             imgFile.remove();
         }

--- a/src/utils/screengrabber.cpp
+++ b/src/utils/screengrabber.cpp
@@ -74,29 +74,35 @@ void ScreenGrabber::freeDesktopPortal(bool& ok, QPixmap& res)
       this);
 
     QEventLoop loop;
-    const auto gotSignal = [&res, &loop, this](uint status, const QVariantMap& map) {
+    const auto gotSignal = [&res, &loop, this](uint status,
+                                               const QVariantMap& map) {
         if (status == 0) {
             // Parse this as URI to handle unicode properly
             QUrl uri = map.value("uri").toString();
             QString uriString = uri.toLocalFile();
             res = QPixmap(uriString);
 
-            // we calculate an approximated physical desktop geometry based on dpr(provided by qt)
-            // we calculate the logical desktop geometry later, this is the accurate size
-            // more info: https://bugreports.qt.io/browse/QTBUG-135612
+            // we calculate an approximated physical desktop geometry based on
+            // dpr(provided by qt), we calculate the logical desktop geometry
+            // later, this is the accurate size, more info:
+            // https://bugreports.qt.io/browse/QTBUG-135612
             QRect approxPhysGeo = desktopGeometry();
             QRect logicalGeo = logicalDesktopGeometry();
-            if (res.size() == approxPhysGeo.size()) // which means the res is physcal size and the dpr is correct.
+            if (res.size() ==
+                approxPhysGeo.size()) // which means the res is physical size
+                                      // and the dpr is correct.
             {
                 res.setDevicePixelRatio(qApp->devicePixelRatio());
-            }
-            else if (res.size() == logicalGeo.size()) // which means the res is logical size and we need to do nothing.
+            } else if (res.size() ==
+                       logicalGeo.size()) // which means the res is logical size
+                                          // and we need to do nothing.
             {
-                ;
-            }
-            else // which means the res is physical size and the dpr is not correct.
+                // No action needed
+            } else // which means the res is physical size and the dpr is not
+                   // correct.
             {
-                res.setDevicePixelRatio(res.height() * 1.0f / logicalGeo.height());
+                res.setDevicePixelRatio(res.height() * 1.0f /
+                                        logicalGeo.height());
             }
             QFile imgFile(uriString);
             imgFile.remove();
@@ -262,8 +268,7 @@ QRect ScreenGrabber::logicalDesktopGeometry()
     QRect geometry;
     for (QScreen* const screen : QGuiApplication::screens()) {
         QRect scrRect = screen->geometry();
-        scrRect.moveTo(scrRect.x(),
-                       scrRect.y());
+        scrRect.moveTo(scrRect.x(), scrRect.y());
         geometry = geometry.united(scrRect);
     }
     return geometry;

--- a/src/utils/screengrabber.cpp
+++ b/src/utils/screengrabber.cpp
@@ -80,19 +80,23 @@ void ScreenGrabber::freeDesktopPortal(bool& ok, QPixmap& res)
             QUrl uri = map.value("uri").toString();
             QString uriString = uri.toLocalFile();
             res = QPixmap(uriString);
-            QRect approximatedPhysicalDesktopGeometryBasedOnDevicePixelRatio = desktopGeometry();
-            QRect accurateLogicalDesktopGeometry = logicalDesktopGeometry();
-            if (res.size() == approximatedPhysicalDesktopGeometryBasedOnDevicePixelRatio.size()) // which means the res is physcal size and the dpr is correct.
+
+            // we calculate an approximated physical desktop geometry based on dpr(provided by qt)
+            // we calculate the logical desktop geometry later, this is the accurate size
+            // more info: https://bugreports.qt.io/browse/QTBUG-135612
+            QRect approxPhysGeo = desktopGeometry();
+            QRect logicalGeo = logicalDesktopGeometry();
+            if (res.size() == approxPhysGeo.size()) // which means the res is physcal size and the dpr is correct.
             {
                 res.setDevicePixelRatio(qApp->devicePixelRatio());
             }
-            else if (res.size() == accurateLogicalDesktopGeometry.size()) // which means the res is logical size and we need to do nothing.
+            else if (res.size() == logicalGeo.size()) // which means the res is logical size and we need to do nothing.
             {
                 ;
             }
             else // which means the res is physical size and the dpr is not correct.
             {
-                res.setDevicePixelRatio(res.height() * 1.0f / accurateLogicalDesktopGeometry.height());
+                res.setDevicePixelRatio(res.height() * 1.0f / logicalGeo.height());
             }
             QFile imgFile(uriString);
             imgFile.remove();

--- a/src/utils/screengrabber.h
+++ b/src/utils/screengrabber.h
@@ -18,6 +18,7 @@ public:
     void freeDesktopPortal(bool& ok, QPixmap& res);
     void generalGrimScreenshot(bool& ok, QPixmap& res);
     QRect desktopGeometry();
+    QRect logicalDesktopGeometry();
 
 private:
     DesktopInfo m_info;


### PR DESCRIPTION
Fixing screenshot preview size is not correct because wayland dpr is not correct when using fractional scaling. This fix supports the idea that we will use dpr in the xcb platform because it is correct in that case.

Tested on Manjaro wayland session with fractional scaling of 125%, both QT_QPA_PLATFORM=xcb and QT_QPA_PLATFORM=wayland work as expected.

Multi-monitor environment is not tested because I don't have one.