### PR TITLE
Remove link to Snap in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,6 @@
       <img src="https://img.shields.io/github/release/flameshot-org/flameshot.svg?label=docs" alt="Docs" />
     </a>
     <br>
-    <a href="https://snapcraft.io/flameshot">
-      <img alt="Get it from the Snap Store" src="https://snapcraft.io/static/images/badges/en/snap-store-black.svg" />
-    </a>
     <a href="https://flathub.org/apps/details/org.flameshot.Flameshot">
       <img height="60" alt="Download on Flathub" src="https://flathub.org/assets/badges/flathub-badge-en.svg"/>
     </a>


### PR DESCRIPTION
https://github.com/flameshot-org/flameshot/issues/3471 `snap install flameshot` has been failing for some time on some distributions, e.g. possibly at least since Ubuntu 22.04 and possibly earlier. `apt install flameshot` does work and is the method listed at [Flameshot's website](https://flameshot.org/docs/installation/installation-linux/) for various Linux distributions, and it also notes that Flameshot isn't on Snap yet. 

Maybe easiest is to stop directing people towards snap via the first thing you see on the README if it doesn't work consistently/isn't actively being supported. It seems to work maybe on some other distros, but the users of those distros are probably more tech-savvy and will know how to actually figure out install failures.

Recommending that https://github.com/flameshot-org/flameshot/issues/3471 gets closed if this gets merged. 