### PR TITLE
Add last-region option to manpage and shell completions

### DIFF
--- a/data/man/man1/flameshot.1
+++ b/data/man/man1/flameshot.1
@@ -147,6 +147,14 @@ Valid for subcommands: config
 .RE
 .
 .PP
+\-\-last-region
+.RS 4
+Repeat screenshot with previously selected region
+.br
+Valid for subcommands: full, gui, screen
+.RE
+.
+.PP
 \-m, \-\-maincolor <color-code>
 .RS 4
 Define the main UI color

--- a/data/shell-completion/flameshot.bash
+++ b/data/shell-completion/flameshot.bash
@@ -11,9 +11,9 @@ _flameshot() {
 	prev="${COMP_WORDS[COMP_CWORD-1]}"
 	cur="${COMP_WORDS[COMP_CWORD]}"
 	cmd="gui full config launcher screen"
-	screen_opts="--number --path --delay --raw -p -d -r -n"
-	gui_opts="--path --delay --raw -p -d -r"
-	full_opts="--path --delay --clipboard --raw -p -d -c -r"
+	screen_opts="--number --path --delay --raw --last-region -p -d -r -n"
+	gui_opts="--path --delay --raw --last-region -p -d -r"
+	full_opts="--path --delay --clipboard --raw --last-region -p -d -c -r"
 	config_opts="--contrastcolor --filename --maincolor --showhelp --trayicon --autostart -k -f -m -s -t -a"
 
 	case "${prev}" in

--- a/data/shell-completion/flameshot.fish
+++ b/data/shell-completion/flameshot.fish
@@ -78,6 +78,7 @@ __flameshot_complete gui -l "path"              -s "p"  -rk  -d "Output file or 
 __flameshot_complete gui -l "clipboard"         -s "c"  -f   -d "Copy screenshot to the clipboard"
 __flameshot_complete gui -l "delay"             -s "d"  -frk -d "Delay time in milliseconds"
 __flameshot_complete gui -l "region"                    -frk -d "Screenshot region to select (WxH+X+Y)" -a "(__flameshot_complete_region gui)"
+__flameshot_complete gui -l "last-region"               -f   -d "Repeat screenshot with previously selected region"
 __flameshot_complete gui -l "raw"               -s "r"  -f   -d "Print raw PNG capture"
 __flameshot_complete gui -l "print-geometry"    -s "g"  -f   -d "Print geometry of the selection"
 __flameshot_complete gui -l "upload"            -s "u"  -f   -d "Upload the screenshot"
@@ -91,6 +92,7 @@ __flameshot_complete screen -l "path"           -s "p"  -rk  -d "Output file or 
 __flameshot_complete screen -l "clipboard"      -s "c"  -f   -d "Copy screenshot to the clipboard"
 __flameshot_complete screen -l "delay"          -s "d"  -frk -d "Delay time in milliseconds"
 __flameshot_complete screen -l "region"                 -frk -d "Screenshot region to select (WxH+X+Y)" -a "(__flameshot_complete_region screen)"
+__flameshot_complete screen -l "last-region"            -f   -d "Repeat screenshot with previously selected region"
 __flameshot_complete screen -l "raw"            -s "r"  -f   -d "Print raw PNG capture"
 __flameshot_complete screen -l "upload"         -s "u"  -f   -d "Upload the screenshot"
 __flameshot_complete screen -l "pin"                    -f   -d "Pin the screenshot to the screen"
@@ -101,6 +103,7 @@ __flameshot_complete full   -l "path"           -s "p"  -rk  -d "Output file or 
 __flameshot_complete full   -l "clipboard"      -s "c"  -f   -d "Copy screenshot to the clipboard"
 __flameshot_complete full   -l "delay"          -s "d"  -frk -d "Delay time in milliseconds"
 __flameshot_complete full   -l "region"                 -frk -d "Screenshot region to select (WxH+X+Y)" -a "(__flameshot_complete_region full)"
+__flameshot_complete full   -l "last-region"            -f   -d "Repeat screenshot with previously selected region"
 __flameshot_complete full   -l "raw"            -s "r"  -f   -d "Print raw PNG capture"
 __flameshot_complete full   -l "upload"         -s "u"  -f   -d "Upload the screenshot"
 

--- a/data/shell-completion/flameshot.zsh
+++ b/data/shell-completion/flameshot.zsh
@@ -21,6 +21,7 @@ _flameshot_gui_opts=(
     {-c,--clipboard}'[Save the capture to the clipboard]'
     {-d,--delay}'[Delay time in milliseconds]'
     "--region[Screenshot region to select <WxH+X+Y or string>]"
+    "--last-region[Repeat screenshot with previously selected region]"
     {-r,--raw}'[Print raw PNG capture]'
     {-g,--print-geometry}'[Print geometry of the selection in the format WxH+X+Y. Does nothing if raw is specified]'
     {-u,--upload}'[Upload screenshot]'
@@ -42,6 +43,7 @@ _flameshot_screen_opts=(
     {-c,--clipboard}'[Save the capture to the clipboard]'
     {-d,--delay}'[Delay time in milliseconds]'
     "--region[Screenshot region to select <WxH+X+Y or string>]"
+    "--last-region[Repeat screenshot with previously selected region]"
     {-r,--raw}'[Print raw PNG capture]'
     {-u,--upload}'[Upload screenshot]'
     "--pin[Pin the capture to the screen]"
@@ -60,6 +62,7 @@ _flameshot_full_opts=(
     {-c,--clipboard}'[Save the capture to the clipboard]'
     {-d,--delay}'[Delay time in milliseconds]'
     "--region[Screenshot region to select <WxH+X+Y or string>]"
+    "--last-region[Repeat screenshot with previously selected region]"
     {-r,--raw}'[Print raw PNG capture]'
     {-u,--upload}'[Upload screenshot]'
 )


### PR DESCRIPTION
The `--last-region` was hard to find out about, as it isn't documented in the manpage and not available in the shell completions. This PR fixes that.