### PR TITLE
Respect `disabledGrimWarning` config all notifications

### DIFF
--- a/src/utils/screengrabber.cpp
+++ b/src/utils/screengrabber.cpp
@@ -140,12 +140,15 @@ QPixmap ScreenGrabber::grabEntireDesktop(bool& ok)
             case DesktopInfo::HYPRLAND:
             case DesktopInfo::OTHER: {
 #ifndef USE_WAYLAND_GRIM
-                AbstractLogger::warning() << tr(
-                  "If the USE_WAYLAND_GRIM option is not activated, the dbus "
-                  "protocol will be used. It should be noted that using the "
-                  "dbus protocol under wayland is not recommended. It is "
-                  "recommended to recompile with the USE_WAYLAND_GRIM flag to "
-                  "activate the grim-based general wayland screenshot adapter");
+                if (!ConfigHandler().disabledGrimWarning()) {
+                    AbstractLogger::warning() << tr(
+                      "If the USE_WAYLAND_GRIM option is not activated, the "
+                      "dbus protocol will be used. It should be noted that "
+                      "using the dbus protocol under wayland is not "
+                      "recommended. It is recommended to recompile with the "
+                      "USE_WAYLAND_GRIM flag to activate the grim-based "
+                      "general wayland screenshot adapter");
+                }
                 freeDesktopPortal(ok, res);
 #else
                 if (!ConfigHandler().disabledGrimWarning()) {


### PR DESCRIPTION
This change extends #3456 that missed this notification (which is kinda annoying for people who do not use grim intentionally).