### PR TITLE
Add config option to open grabber instead of panel from color picker

### DIFF
--- a/flameshot.example.ini
+++ b/flameshot.example.ini
@@ -87,6 +87,9 @@
 ;; Upload to imgur without confirmation (bool)
 ;uploadWithoutConfirmation=false
 ;
+;; The "picker" option in the color picker opens starts the color grabber instead of opening the side panel
+; pickerOpensGrabber=false
+;
 ;; Use larger color palette as the default one
 ; predefinedColorPaletteLarge=false
 ;

--- a/src/config/generalconf.cpp
+++ b/src/config/generalconf.cpp
@@ -52,6 +52,7 @@ GeneralConf::GeneralConf(QWidget* parent)
     initCopyPathAfterSave();
     initCopyAndCloseAfterUpload();
     initUploadWithoutConfirmation();
+    initPickerOpensGrabber();
     initHistoryConfirmationToDelete();
     initAntialiasingPinZoom();
     initUploadHistoryMax();
@@ -84,6 +85,7 @@ void GeneralConf::_updateComponents(bool allowEmptySavePath)
     m_useJpgForClipboard->setChecked(config.useJpgForClipboard());
     m_copyOnDoubleClick->setChecked(config.copyOnDoubleClick());
     m_uploadWithoutConfirmation->setChecked(config.uploadWithoutConfirmation());
+    m_pickerOpensGrabber->setChecked(config.pickerOpensGrabber());
     m_historyConfirmationToDelete->setChecked(
       config.historyConfirmationToDelete());
 #if !defined(DISABLE_UPDATE_CHECKER)
@@ -672,6 +674,19 @@ void GeneralConf::initUploadWithoutConfirmation()
     m_scrollAreaLayout->addWidget(m_uploadWithoutConfirmation);
     connect(m_uploadWithoutConfirmation, &QCheckBox::clicked, [](bool checked) {
         ConfigHandler().setUploadWithoutConfirmation(checked);
+    });
+}
+
+void GeneralConf::initPickerOpensGrabber()
+{
+    m_pickerOpensGrabber =
+      new QCheckBox(tr("Custom color picker opens grabber"), this);
+    m_pickerOpensGrabber->setToolTip(
+      tr("Custom option in the color picker opens grabber instead of the "
+         "side panel"));
+    m_scrollAreaLayout->addWidget(m_pickerOpensGrabber);
+    connect(m_pickerOpensGrabber, &QCheckBox::clicked, [](bool checked) {
+        ConfigHandler().setPickerOpensGrabber(checked);
     });
 }
 

--- a/src/config/generalconf.h
+++ b/src/config/generalconf.h
@@ -86,6 +86,7 @@ private:
     void initSquareMagnifier();
     void initUndoLimit();
     void initUploadWithoutConfirmation();
+    void initPickerOpensGrabber();
     void initUseJpgForClipboard();
     void initUploadHistoryMax();
     void initUploadClientSecret();
@@ -115,6 +116,7 @@ private:
     QCheckBox* m_antialiasingPinZoom;
     QCheckBox* m_saveLastRegion;
     QCheckBox* m_uploadWithoutConfirmation;
+    QCheckBox* m_pickerOpensGrabber;
     QPushButton* m_importButton;
     QPushButton* m_exportButton;
     QPushButton* m_resetButton;

--- a/src/utils/confighandler.cpp
+++ b/src/utils/confighandler.cpp
@@ -96,6 +96,7 @@ static QMap<class QString, QSharedPointer<ValueHandler>>
     OPTION("antialiasingPinZoom"         ,Bool               ( true          )),
     OPTION("useJpgForClipboard"          ,Bool               ( false         )),
     OPTION("uploadWithoutConfirmation"   ,Bool               ( false         )),
+    OPTION("pickerOpensGrabber"          ,Bool               ( false         )),
     OPTION("saveAfterCopy"               ,Bool               ( false         )),
     OPTION("savePath"                    ,ExistingDir        (                   )),
     OPTION("savePathFixed"               ,Bool               ( false         )),

--- a/src/utils/confighandler.h
+++ b/src/utils/confighandler.h
@@ -83,6 +83,7 @@ public:
     CONFIG_GETTER_SETTER(fontFamily, setFontFamily, QString)
     CONFIG_GETTER_SETTER(showHelp, setShowHelp, bool)
     CONFIG_GETTER_SETTER(showSidePanelButton, setShowSidePanelButton, bool)
+    CONFIG_GETTER_SETTER(pickerOpensGrabber, setPickerOpensGrabber, bool)
     CONFIG_GETTER_SETTER(showDesktopNotification,
                          setShowDesktopNotification,
                          bool)

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -203,7 +203,7 @@ CaptureWidget::CaptureWidget(const CaptureRequest& req,
     }
 
     // Init color picker
-    m_colorPicker = new ColorPicker(this);
+    m_colorPicker = new ColorPicker(&m_context.screenshot, this);
     connect(m_colorPicker,
             &ColorPicker::colorSelected,
             this,

--- a/src/widgets/capture/colorpicker.cpp
+++ b/src/widgets/capture/colorpicker.cpp
@@ -7,8 +7,9 @@
 #include <QMouseEvent>
 #include <QPainter>
 
-ColorPicker::ColorPicker(QWidget* parent)
+ColorPicker::ColorPicker(QPixmap* p, QWidget* parent)
   : ColorPickerWidget(parent)
+  , m_pixmap(p)
 {
     setMouseTracking(true);
 
@@ -36,6 +37,22 @@ void ColorPicker::mouseMoveEvent(QMouseEvent* e)
     }
 }
 
+void ColorPicker::startColorGrab()
+{
+    m_colorGrabber = new ColorGrabWidget(m_pixmap);
+    connect(m_colorGrabber,
+            &ColorGrabWidget::colorGrabbed,
+            this,
+            &ColorPicker::onColorGrabFinished);
+
+    m_colorGrabber->startGrabbing();
+}
+
+void ColorPicker::onColorGrabFinished()
+{
+    emit colorSelected(m_colorGrabber->color());
+}
+
 void ColorPicker::showEvent(QShowEvent* event)
 {
     grabMouse();
@@ -44,5 +61,10 @@ void ColorPicker::showEvent(QShowEvent* event)
 void ColorPicker::hideEvent(QHideEvent* event)
 {
     releaseMouse();
-    emit colorSelected(m_colorList.at(m_selectedIndex));
+
+    if (ConfigHandler().pickerOpensGrabber() && m_selectedIndex == 0) {
+        startColorGrab();
+    } else {
+        emit colorSelected(m_colorList.at(m_selectedIndex));
+    }
 }

--- a/src/widgets/capture/colorpicker.h
+++ b/src/widgets/capture/colorpicker.h
@@ -4,12 +4,13 @@
 #pragma once
 
 #include "src/widgets/colorpickerwidget.h"
+#include "src/widgets/panel/colorgrabwidget.h"
 
 class ColorPicker : public ColorPickerWidget
 {
     Q_OBJECT
 public:
-    explicit ColorPicker(QWidget* parent = nullptr);
+    explicit ColorPicker(QPixmap* p, QWidget* parent = nullptr);
 
 signals:
     void colorSelected(QColor c);
@@ -18,4 +19,11 @@ protected:
     void showEvent(QShowEvent* event) override;
     void hideEvent(QHideEvent* event) override;
     void mouseMoveEvent(QMouseEvent* e) override;
+
+    void startColorGrab();
+    void onColorGrabFinished();
+
+private:
+    ColorGrabWidget* m_colorGrabber{};
+    QPixmap* m_pixmap;
 };


### PR DESCRIPTION
This adds a checkbox to have the custom "picker" option in the colour picker immediately open and use the colour grabber instead of the side panel.

I find myself quite often wanting to use on-screen colours when editing in flameshot, and using the side panel for it is a bit more cumbersome than necessary, this option alleviates that by allowing use of the grabber directly, while the side panel remains available through usual means.