### PR TITLE
add loadMore button in Upload History widget (issue #3208)

### DIFF
--- a/src/config/generalconf.cpp
+++ b/src/config/generalconf.cpp
@@ -535,7 +535,7 @@ void GeneralConf::initUploadHistoryMax()
     box->setLayout(vboxLayout);
 
     m_uploadHistoryMax = new QSpinBox(this);
-    m_uploadHistoryMax->setMaximum(50);
+    m_uploadHistoryMax->setMaximum(100); // Allow up to 100
     QString foreground = this->palette().windowText().color().name();
     m_uploadHistoryMax->setStyleSheet(
       QStringLiteral("color: %1").arg(foreground));

--- a/src/utils/history.cpp
+++ b/src/utils/history.cpp
@@ -58,7 +58,7 @@ const QList<QString>& History::history()
                                              QDir::Files,
                                              QDir::Time);
     int cnt = 0;
-    int max = ConfigHandler().uploadHistoryMax();
+    int max = 500; // the total amount of images stored is 500
     m_thumbs.clear();
     foreach (QString fileName, images) {
         if (++cnt <= max) {

--- a/src/widgets/uploadhistory.h
+++ b/src/widgets/uploadhistory.h
@@ -1,7 +1,9 @@
 #ifndef UPLOADHISTORY_H
 #define UPLOADHISTORY_H
 
+#include "history.h"
 #include <QWidget>
+#include <qpushbutton.h>
 
 QT_BEGIN_NAMESPACE
 namespace Ui {
@@ -20,13 +22,17 @@ public:
     ~UploadHistory();
 
     void loadHistory();
-
+    void loadNextBatch(); // Load the next batch of images
 public slots:
 
 private:
+    QList<QString> secondaryStorage; // Secondary storage for older screenshots
     void setEmptyMessage();
+    QPushButton* loadMoreButton; // Attribute for the "Load More" button
     void addLine(QString const&, QString const&);
-
+    QList<QString> historyFiles; // Store all history file paths
+    int currentBatchStartIndex;  // Track the starting index for the next batch
     Ui::UploadHistory* ui;
+    History history;
 };
 #endif // UPLOADHISTORY_H

--- a/src/widgets/uploadhistory.ui
+++ b/src/widgets/uploadhistory.ui
@@ -44,6 +44,19 @@
     </widget>
    </item>
   </layout>
+<layout class="QGridLayout" name="gridLayout">
+<item row="0" column="0">
+ <layout class="QVBoxLayout" name="historyContainer">
+  <item>
+   <widget class="QPushButton" name="loadMoreButton">
+    <property name="text">
+     <string>Load More</string>
+    </property>
+   </widget>
+  </item>
+ </layout>
+</item>
+</layout>
  </widget>
  <resources>
   <include location="../../data/graphics.qrc"/>


### PR DESCRIPTION

- fixes issue #3208 : https://github.com/flameshot-org/flameshot/issues/3208
- I created a new storage called secondaryStorage, which keeps in memory the excess images.
- the total number of images stored is 500 (as defined in src/utils/history.cpp and proposed in the issue).
- the loadMore button is always at the bottom of the UI, except when there aren't anymore images to load, then it disappears.