### PR TITLE
fix: add missing appstream data for flatpak builder

### DIFF
--- a/data/appdata/org.flameshot.Flameshot.metainfo.xml
+++ b/data/appdata/org.flameshot.Flameshot.metainfo.xml
@@ -8,6 +8,9 @@ SPDX-License-Identifier: CC0-1.0
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-3.0-or-later</project_license>
   <name>Flameshot</name>
+  <developer id="org.flameshot">
+    <name>Flameshot Developers</name>
+  </developer>
   <releases>
     <release version="12.1.0" date="2022-07-03"/>
     <release version="12.0.0" date="2022-06-21"/>
@@ -33,9 +36,11 @@ SPDX-License-Identifier: CC0-1.0
   <screenshots>
     <screenshot type="default">
       <image>https://raw.githubusercontent.com/flameshot-org/flameshot/master/data/img/preview/usageStatic.png</image>
+      <caption>Flameshot Usage</caption>
     </screenshot>
     <screenshot>
       <image>https://raw.githubusercontent.com/flameshot-org/flameshot/master/data/img/preview/animatedUsage.gif</image>
+      <caption>Animated Flameshot Usage</caption>
     </screenshot>
   </screenshots>
   <url type="homepage">https://github.com/flameshot-org/flameshot</url>


### PR DESCRIPTION
Commit updates appstream data to pass strict validation, which is necessary to build new Flatpak versions.

Flatpak builder added strict validation and requires "developer" information [1] to be provided.

Build error:

```
Run docker run --rm --privileged \
+ flatpak-builder-lint --exceptions repo repo
{
    "errors": [
        "appstream-missing-developer-name"
    ],
    "warnings": [
        "appstream-screenshot-missing-caption"
    ],
    "info": [
        "appstream-screenshot-missing-caption: One or more screenshots
are missing captions in the Metainfo file",
        "appstream-missing-developer-name: No developer tag found in
Metainfo file"
    ],
    "message": "Please consult the documentation at
https://docs.flathub.org/docs/for-app-authors/linter"
}
error: Recipe `validate-build` failed with exit code 1
```

For good measure, captions for the provided screenshots are added.

After changes made, `appstreamcli validate` only mentions issue with uppercase cid component which should be kept as is:

```sh
$ appstreamcli validate --pedantic data/appdata/org.flameshot.Flameshot.metainfo.xml
P: org.flameshot.Flameshot:7: cid-contains-uppercase-letter org.flameshot.Flameshot

✔ Validation was successful: pedantic: 1
```

[1]: https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines#developer-name
