### PR TITLE
Remove Ubuntu 20.04 as build target due to EOL and ongoing maintance …

### DIFF
--- a/.github/workflows/Linux-pack.yml
+++ b/.github/workflows/Linux-pack.yml
@@ -70,12 +70,6 @@ jobs:
               arch: armhf
             }
           - {
-              name: ubuntu-20.04,
-              os: ubuntu,
-              symbol: focal,
-              arch: amd64
-            }
-          - {
               name: ubuntu-22.04,
               os: ubuntu,
               symbol: jammy,


### PR DESCRIPTION
…required