### PR TITLE
Replace USE_WAYLAND_GRIM build option with useGrimAdapter setting

### DIFF
--- a/flameshot.example.ini
+++ b/flameshot.example.ini
@@ -51,6 +51,9 @@
 ;; Whether the tray icon is disabled (bool)
 ;disabledTrayIcon=false
 ;
+;; Use grim-based wayland universal screenshot adapter
+;useGrimAdapter=false
+;
 ;; Disable Grim Warning notification
 ;disabledGrimWarning=true
 ;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -220,15 +220,8 @@ target_link_libraries(
 )
 
 if (USE_WAYLAND_CLIPBOARD)
-  if(!USE_WAYLAND_GRIM)
-    message(WARNING "You activated the USE_WAYLAND_CLIPBOARD option, but did not activate the USE_WAYLAND_GRIM option. Flameshot will use the dbus protocol to support wayland. If you use wlroots-based wayland, it is recommended to enable USE_WAYLAND_GRIM")
-  endif()
   target_compile_definitions(flameshot PRIVATE USE_WAYLAND_CLIPBOARD=1)
   target_link_libraries(flameshot KF5::GuiAddons)
-endif()
-
-if (USE_WAYLAND_GRIM)
-    target_compile_definitions(flameshot PRIVATE USE_WAYLAND_GRIM=1)
 endif()
 
 if (APPLE)

--- a/src/utils/confighandler.cpp
+++ b/src/utils/confighandler.cpp
@@ -79,6 +79,7 @@ static QMap<class QString, QSharedPointer<ValueHandler>>
     OPTION("showDesktopNotification"     ,Bool               ( true          )),
     OPTION("showAbortNotification"       ,Bool               ( true          )),
     OPTION("disabledTrayIcon"            ,Bool               ( false         )),
+    OPTION("useGrimAdapter"              ,Bool               ( false         )),
     OPTION("disabledGrimWarning"         ,Bool               ( false         )),
     OPTION("historyConfirmationToDelete" ,Bool               ( true          )),
 #if !defined(DISABLE_UPDATE_CHECKER)

--- a/src/utils/confighandler.h
+++ b/src/utils/confighandler.h
@@ -89,6 +89,7 @@ public:
     CONFIG_GETTER_SETTER(showAbortNotification, setShowAbortNotification, bool)
     CONFIG_GETTER_SETTER(filenamePattern, setFilenamePattern, QString)
     CONFIG_GETTER_SETTER(disabledTrayIcon, setDisabledTrayIcon, bool)
+    CONFIG_GETTER_SETTER(useGrimAdapter, useGrimAdapter, bool)
     CONFIG_GETTER_SETTER(disabledGrimWarning, disabledGrimWarning, bool)
     CONFIG_GETTER_SETTER(drawThickness, setDrawThickness, int)
     CONFIG_GETTER_SETTER(drawFontSize, setDrawFontSize, int)


### PR DESCRIPTION
Since there is already the `disabledGrimWarning` setting, I suggest to replace USE_WAYLAND_GRIM build option with `useGrimAdapter` setting.
People that uses wlroots based Wayland compositors (labwc in my case) will be able to use grim without rebuild flameshot, but just adding line `useGrimAdapter=true` to `~/.config/flameshot/flameshot.ini`.
I don't see any significant negative effects:
- the current behavior does not changed
- grim is still optional
- even if `useGrimAdapter=true`, but grim is not installed, there is message:
`The universal wayland screen capture adapter requires Grim as the screen capture component of wayland. If the screen capture component is missing, please install it!`

The only thing - you will get new setting insted of new build option, but this will lead to more flexibility.
It will also be possible to close this issue: https://github.com/flameshot-org/flameshot/issues/3399
- option `USE_WAYLAND_CLIPBOARD` was added in this commit: https://github.com/flameshot-org/flameshot/commit/00685369a0e0e7f438e051e42119e0360ab84a76
- `USE_WAYLAND_GRIM` was removed in this RP.