### PR TITLE
Fix documentations

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,17 +480,17 @@ brew install cmake
 
 ### Build
 
-After installing all the dependencies, flameshot can be built.
+After installing all the dependencies, Flameshot can be built.
 
 #### Installation/build dir
 For the translations to be loaded correctly, the build process needs to be aware of where you want
-to install flameshot.
+to install Flameshot.
 
 ```shell
 # Directory where build files will be placed, may be relative
 export BUILD_DIR=build
 
-# Directory prefix where flameshot will be installed. If you are just building and don't want to
+# Directory prefix where Flameshot will be installed. If you are just building and don't want to
 # install, comment this environment variable.
 # This excludes the bin/flameshot part of the install,
 # e.g. in /opt/flameshot/bin/flameshot, the CMAKE_INSTALL_PREFIX is /opt/flameshot
@@ -507,14 +507,14 @@ cmake -S . -B "$BUILD_DIR" \
     && cmake --build "$BUILD_DIR"
 ```
 
-When the `cmake --build` command has completed you can launch flameshot from the `project_folder/build/src` folder.
+When the `cmake --build` command has completed you can launch Flameshot from the `project_folder/build/src` folder.
 
 ### Install
 
 Note that if you install from source, there _is no_ uninstaller, so consider installing to a custom directory.
 
 #### To install into a custom directory
-Make sure you are using cmake `>= 3.29` and build flameshot with `$CMAKE_INSTALL_PREFIX` set to the
+Make sure you are using cmake `>= 3.29` and build Flameshot with `$CMAKE_INSTALL_PREFIX` set to the
 installation directory. If this is not done, the translations won't be found when using a custom directory.
 Then, run the following:
 

--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ Now every time you press <kbd>Prt Sc</kbd>, it will start the Flameshot GUI inst
     ```text
     Command                        Shortcut
     xfce4-screenshooter -fd 1      Print
-    ````
+    ```
 4. Replace `xfce4-screenshooter -fd 1` with `flameshot gui`
 
 Now every time you press <kbd>Prt Sc</kbd> it will start Flameshot GUI instead of the default application.
@@ -319,7 +319,7 @@ Now every time you press <kbd>Prt Sc</kbd> it will start Flameshot GUI instead o
 
     ```text
     Print :Exec flameshot gui
-    ````
+    ```
 3. Refresh Fluxbox configuration with **Reconfigure** option from the menu.
 
 ## Considerations

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -44,4 +44,4 @@ After reporting you should aim to answer questions or clarifications as this hel
 
 ## Donations
 
-The best way to fund flameshot is to create a bounty here: https://rysolv.com/issues
+The best way to fund Flameshot is to create a bounty here: https://rysolv.com/issues

--- a/docs/RFC.md
+++ b/docs/RFC.md
@@ -33,7 +33,7 @@ project is evolving in.
 [When you need to follow this process]: #when-you-need-to-follow-this-process
 
 You need to follow this process if you intend to make "substantial" changes to
-flameshot or the RFC process itself. What constitutes a
+Flameshot or the RFC process itself. What constitutes a
 "substantial" change is evolving based on community norms and varies depending
 on what part of the ecosystem you are proposing to change, but may include the
 following.
@@ -178,7 +178,7 @@ as a "very minor change" is up to the development team.
 
 [Reviewing RFCs]: #reviewing-rfcs
 
-The preferred method of discussing RFC's is the github issue. However, the development team may schedule meetings with the
+The preferred method of discussing RFC's is the Github issue. However, the development team may schedule meetings with the
 author and/or relevant stakeholders to discuss the issues in greater detail. In either
 case a summary from the meeting will be posted back to the RFC pull request.
 

--- a/docs/Releasing.md
+++ b/docs/Releasing.md
@@ -1,17 +1,17 @@
 # Checklist for making a new release
 
-These are the code changes that need to take place
-- [ ] Update version in CMakeLists.txt
-- [ ] Update version and changelog at packaging/debian/changelog
-- [ ] Update version and changelog at packaging/rpm/flameshot.spec
-- [ ] Update data/appdata/flameshot.metainfo.xml
-- [ ] Update MacOs version in cmake/modules/MacOSXBundleInfo.plist.in 
+These are the code changes that need to take place:
+- [ ] Update version in `CMakeLists.txt`
+- [ ] Update version and changelog at `packaging/debian/changelog`
+- [ ] Update version and changelog at `packaging/rpm/flameshot.spec`
+- [ ] Update `data/appdata/flameshot.metainfo.xml`
+- [ ] Update macOS version in `cmake/modules/MacOSXBundleInfo.plist.in` 
 - [ ] Commit and push to a PR
 - [ ] Merge PR to main
 - [ ] Create and push git tag on main
 - [ ] Manually retrigger the Github actions so it uses the latest git tag 
 
-These are the steps for actually making the release
+These are the steps for actually making the release:
 - [ ] Download all binaries from CI run started from PR related to code changes shown above
 - [ ] Create sha256 for each binary and compare against sha256 shown in the CI to verify there was no corruption or inserted malware
 - [ ] Create a new "New Release" in Github and explain changes in release notes
@@ -19,5 +19,5 @@ These are the steps for actually making the release
 - [ ] Update flatpak manifest for Flathub: https://github.com/flathub/org.flameshot.Flameshot
 - [ ] Push snapcraft edge release to stable
 - [ ] If this is a major release coordinate with sign path on signed windows binaries
-- [ ] Update change log on [website](https://github.com/flameshot-org/flameshot-org.github.io/) data/changelog.md
+- [ ] Update change log on [website](https://github.com/flameshot-org/flameshot-org.github.io/) `data/changelog.md`
 - [ ] Update version on [website](https://github.com/flameshot-org/flameshot-org.github.io/blob/master/_coverpage.md)

--- a/docs/Releasing.md
+++ b/docs/Releasing.md
@@ -9,14 +9,14 @@ These are the code changes that need to take place
 - [ ] Commit and push to a PR
 - [ ] Merge PR to main
 - [ ] Create and push git tag on main
-- [ ] Manually retrigger the github actions so it uses the latest git tag 
+- [ ] Manually retrigger the Github actions so it uses the latest git tag 
 
 These are the steps for actually making the release
 - [ ] Download all binaries from CI run started from PR related to code changes shown above
-- [ ] Create sha256 for each binary and compare against sha256 shown in the CI to verify there was no corruption or inserted malware.
-- [ ] Create a new "New Release" in github and explain changes in release notes
+- [ ] Create sha256 for each binary and compare against sha256 shown in the CI to verify there was no corruption or inserted malware
+- [ ] Create a new "New Release" in Github and explain changes in release notes
 - [ ] Upload all binaries and sha's
-- [ ] Update flatpak manifest for flathub: https://github.com/flathub/org.flameshot.Flameshot
+- [ ] Update flatpak manifest for Flathub: https://github.com/flathub/org.flameshot.Flameshot
 - [ ] Push snapcraft edge release to stable
 - [ ] If this is a major release coordinate with sign path on signed windows binaries
 - [ ] Update change log on [website](https://github.com/flameshot-org/flameshot-org.github.io/) data/changelog.md

--- a/docs/Sway and wlroots support.md
+++ b/docs/Sway and wlroots support.md
@@ -48,7 +48,7 @@ org.freedesktop.impl.portal.Screenshot=wlr
 Q) Flameshot doesn't take a screenshot, it just hangs!
 
 A) Please ensure that the packages are installed, and that the variables are exported.
-This is usually caused by flameshot receiving no response from the desktop portal. This can be verified by running `dbus-monitor --session sender=org.freedesktop.portal.Desktop destination=org.freedesktop.portal.Desktop`.
+This is usually caused by Flameshot receiving no response from the desktop portal. This can be verified by running `dbus-monitor --session sender=org.freedesktop.portal.Desktop destination=org.freedesktop.portal.Desktop`.
 
 Q) Flameshot takes one screenshot, then won't take anymore!
 
@@ -56,7 +56,7 @@ A) There is a bug in xdg-desktop-portal-wlr and Flameshot causing calls with the
 
 # River wlroots support
 
-Like mentioned above, flameshot now works on wlroots based Wayland compositors, however, there is a weird problem with river and that is when setting `XDG_CURRENT_DESKTOP=river`, flameshot won't work. The fix is you need to trick flameshot that you are on `sway`. Hence, you need to run river like so:
+Like mentioned above, Flameshot now works on wlroots based Wayland compositors, however, there is a weird problem with river and that is when setting `XDG_CURRENT_DESKTOP=river`, Flameshot won't work. The fix is you need to trick Flameshot that you are on `sway`. Hence, you need to run river like so:
 
 ```sh
 XDG_CURRENT_DESKTOP=sway dbus-run-session river
@@ -68,7 +68,7 @@ and add the following on your config such as in `$HOME/.config/river/init`
 riverctl float-filter-add "flameshot"
 ```
 
-Otherwise, flameshot will not take all of the screen and tiles its window instead like a normal application. Note however, that some clipboard stuff is broken so it might be good to save your screenshot as a file while having it copied to a clipboard in case if clipboard does some weird stuff like not pasting the overall screenshot.
+Otherwise, Flameshot will not take all of the screen and tiles its window instead like a normal application. Note however, that some clipboard stuff is broken so it might be good to save your screenshot as a file while having it copied to a clipboard in case if clipboard does some weird stuff like not pasting the overall screenshot.
 
 #### For more information, please refer to https://github.com/emersion/xdg-desktop-portal-wlr/wiki/%22It-doesn't-work%22-Troubleshooting-Checklist
 


### PR DESCRIPTION
The following were addressed:
- fixing code fence issue in README partly cause by #3796 according to markdown specs and Github flavoured markdown [[1](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)]
- spell checking all markdown files
- capitalizing special names (e.g., Flameshot, and Github)
- added markdown styling to improve readability of `docs/Releasing.md`
