### PR TITLE
Exclude docs from CIs

### DIFF
--- a/.github/workflows/Linux-pack.yml
+++ b/.github/workflows/Linux-pack.yml
@@ -16,6 +16,8 @@ on:
       - 'LICENSE'
       - 'docs/**'
 
+  workflow_dispatch:
+
 env:
   PRODUCT: flameshot
   RELEASE: 1

--- a/.github/workflows/MacOS-pack.yml
+++ b/.github/workflows/MacOS-pack.yml
@@ -16,6 +16,8 @@ on:
       - 'LICENSE'
       - 'docs/**'
 
+  workflow_dispatch:
+
 env:
   PRODUCT: flameshot
 

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -6,11 +6,14 @@ on:
     paths-ignore:
       - 'README.md'
       - 'LICENSE'
+      - 'docs/**'
   pull_request:
     branches: [ master ]
     paths-ignore:
       - 'README.md'
       - 'LICENSE'
+      - 'docs/**'
+
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -14,6 +14,7 @@ on:
       - 'LICENSE'
       - 'docs/**'
 
+  workflow_dispatch:
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,6 +1,17 @@
 name: test-clang-format
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - 'README.md'
+      - 'LICENSE'
+      - 'docs/**'
+  pull_request:
+    paths-ignore:
+      - 'README.md'
+      - 'LICENSE'
+      - 'docs/**'
+
 
 jobs:
   build:

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -12,6 +12,7 @@ on:
       - 'LICENSE'
       - 'docs/**'
 
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
It is wasteful to run CIs for when the markdown files and documentations are modified. So the README and docs directly are now excluded in all Github Actions.

Also I thought it is a good idea to be able to manually trigger the Github Actions. This can be useful when the CI breaks because of something that is fixed in another PR. More info here:

https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/manually-running-a-workflow