### PR TITLE
Fix issue when config subcommand toggles autostart

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -544,8 +544,8 @@ int main(int argc, char* argv[])
         bool mainColor = parser.isSet(mainColorOption);
         bool contrastColor = parser.isSet(contrastColorOption);
         bool check = parser.isSet(checkOption);
-        bool someFlagSet =
-          (filename || tray || mainColor || contrastColor || check);
+        bool someFlagSet = (autostart || filename || tray || mainColor ||
+                            contrastColor || check);
         if (check) {
             AbstractLogger err = AbstractLogger::error(AbstractLogger::Stderr);
             bool ok = ConfigHandler().checkForErrors(&err);


### PR DESCRIPTION
when autostart was passed as an option to the `config` subcommand it was not properly recognized. This area of code is in need of some refactoring to prevent these types of mistakes, but for now this fixes the bug. 