### PR TITLE
Add useGrimAdapter option to the config window

### DIFF
--- a/src/config/generalconf.cpp
+++ b/src/config/generalconf.cpp
@@ -19,6 +19,7 @@
 #include <QStandardPaths>
 #include <QTextCodec>
 #include <QVBoxLayout>
+#include <qcheckbox.h>
 
 GeneralConf::GeneralConf(QWidget* parent)
   : QWidget(parent)
@@ -37,6 +38,7 @@ GeneralConf::GeneralConf(QWidget* parent)
     initAutoCloseIdleDaemon();
 #endif
     initShowTrayIcon();
+    initUseGrimAdapter();
     initShowDesktopNotification();
     initShowAbortNotification();
 #if !defined(DISABLE_UPDATE_CHECKER)
@@ -117,6 +119,10 @@ void GeneralConf::_updateComponents(bool allowEmptySavePath)
 #if defined(Q_OS_LINUX) || defined(Q_OS_UNIX)
     m_showTray->setChecked(!config.disabledTrayIcon());
 #endif
+
+#if defined(Q_OS_LINUX)
+    m_useGrimAdapter->setChecked(config.useGrimAdapter());
+#endif
 }
 
 void GeneralConf::updateComponents()
@@ -147,6 +153,11 @@ void GeneralConf::showDesktopNotificationChanged(bool checked)
 void GeneralConf::showAbortNotificationChanged(bool checked)
 {
     ConfigHandler().setShowAbortNotification(checked);
+}
+
+void GeneralConf::useGrimAdapter(bool checked)
+{
+    ConfigHandler().useGrimAdapter(checked);
 }
 
 #if !defined(DISABLE_UPDATE_CHECKER)
@@ -323,6 +334,21 @@ void GeneralConf::initShowTrayIcon()
     connect(m_showTray, &QCheckBox::clicked, this, [](bool checked) {
         ConfigHandler().setDisabledTrayIcon(!checked);
     });
+#endif
+}
+
+void GeneralConf::initUseGrimAdapter()
+{
+#if defined(Q_OS_LINUX)
+    m_useGrimAdapter = new QCheckBox(tr("Use grim adapter"), this);
+    m_useGrimAdapter->setToolTip(
+      tr("Use grim adapter for capturing screenshots"));
+    m_scrollAreaLayout->addWidget(m_useGrimAdapter);
+
+    connect(m_useGrimAdapter,
+            &QCheckBox::clicked,
+            this,
+            &GeneralConf::useGrimAdapter);
 #endif
 }
 

--- a/src/config/generalconf.cpp
+++ b/src/config/generalconf.cpp
@@ -19,7 +19,6 @@
 #include <QStandardPaths>
 #include <QTextCodec>
 #include <QVBoxLayout>
-#include <qcheckbox.h>
 
 GeneralConf::GeneralConf(QWidget* parent)
   : QWidget(parent)

--- a/src/config/generalconf.cpp
+++ b/src/config/generalconf.cpp
@@ -339,9 +339,12 @@ void GeneralConf::initShowTrayIcon()
 void GeneralConf::initUseGrimAdapter()
 {
 #if defined(Q_OS_LINUX)
-    m_useGrimAdapter = new QCheckBox(tr("Use grim adapter"), this);
+    m_useGrimAdapter =
+      new QCheckBox(tr("Use grim to capture screenshots"), this);
     m_useGrimAdapter->setToolTip(
-      tr("Use grim adapter for capturing screenshots"));
+      tr("Grim is a wayland only utility to capture screens based on the "
+         "screencopy protocol. Generally only enable on minimal wayland window "
+         "managers like sway, hyprland, etc."));
     m_scrollAreaLayout->addWidget(m_useGrimAdapter);
 
     connect(m_useGrimAdapter,

--- a/src/config/generalconf.h
+++ b/src/config/generalconf.h
@@ -38,6 +38,7 @@ private slots:
     void showSidePanelButtonChanged(bool checked);
     void showDesktopNotificationChanged(bool checked);
     void showAbortNotificationChanged(bool checked);
+    void useGrimAdapter(bool checked);
 #if !defined(DISABLE_UPDATE_CHECKER)
     void checkForUpdatesChanged(bool checked);
 #endif
@@ -87,6 +88,7 @@ private:
     void initShowSidePanelButton();
     void initShowStartupLaunchMessage();
     void initShowTrayIcon();
+    void initUseGrimAdapter();
     void initSquareMagnifier();
     void initUndoLimit();
     void initUploadWithoutConfirmation();
@@ -107,6 +109,7 @@ private:
     QCheckBox* m_sysNotifications;
     QCheckBox* m_abortNotifications;
     QCheckBox* m_showTray;
+    QCheckBox* m_useGrimAdapter;
     QCheckBox* m_helpMessage;
     QCheckBox* m_sidePanelButton;
 #if !defined(DISABLE_UPDATE_CHECKER)


### PR DESCRIPTION
As stated in [this](https://github.com/flameshot-org/flameshot/issues/3941) issue, #3919 added an option to use grim adapter, but it was not added to the config UI window.

This PR adds this option (`useGrimAdapter`) to the config UI.

Option name: `Use grim to capture screenshots`
Description: `Grim is a wayland only utility to capture screens based on the screencopy protocol. Generally only enable on minimal wayland window managers like sway, hyprland, etc.`

Tested, works!

EDIT: old screenshot, see comments [below](https://github.com/flameshot-org/flameshot/pull/3943#issuecomment-2896459996)
![image](https://github.com/user-attachments/assets/74ef0627-85a4-4b2f-bc01-763674d2d98f)

(PS: screenshot taken with flameshot)


Closes #3941
