### PR TITLE
allow networking during build phase so cmake can clone dependencies

### DIFF
--- a/packaging/flatpak/org.flameshot.Flameshot.yml
+++ b/packaging/flatpak/org.flameshot.Flameshot.yml
@@ -25,6 +25,9 @@ finish-args:
 modules:
   - name: flameshot
     buildsystem: cmake-ninja
+    build-options:
+      build-args:
+        - --share=network
     config-opts:
       - -DCMAKE_BUILD_TYPE=Release 
       - -DUSE_WAYLAND_CLIPBOARD=1


### PR DESCRIPTION
This bug was introduced because the CI builds from master branch. So if a commit breaks flatpak, it wont be detected until after its merged to master branch. 