### PR TITLE
Fixes flatpak for Qt6

### DIFF
--- a/packaging/flatpak/org.flameshot.Flameshot.yml
+++ b/packaging/flatpak/org.flameshot.Flameshot.yml
@@ -1,6 +1,6 @@
 app-id: org.flameshot.Flameshot
 runtime: org.kde.Platform
-runtime-version: '5.15-21.08'
+runtime-version: '6.9'
 sdk: org.kde.Sdk
 command: flameshot
 finish-args:
@@ -32,6 +32,10 @@ modules:
       - -DCMAKE_BUILD_TYPE=Release 
       - -DUSE_WAYLAND_CLIPBOARD=1
     sources:
+    # Keep this in until qt6 is merged to master branch. Makes it easy to test flatpak dev builds
+    # Change the path to the location of the cloned flameshot repo
+      #- type: dir 
+      #  path: /path/to/repo
       - type: git
         url: https://github.com/flameshot-org/flameshot.git
         branch: master


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/b4f25a38-fabd-4535-a448-adad205c7c3b)


This now can build flameshot with Qt6 in flatpack :)