### PR TITLE
Qt 6 - Fix http status response

### DIFF
--- a/src/tools/imgupload/storages/imgur/imguruploader.cpp
+++ b/src/tools/imgupload/storages/imgur/imguruploader.cpp
@@ -9,6 +9,7 @@
 #include "src/widgets/notificationwidget.h"
 #include <QBuffer>
 #include <QDesktopServices>
+#include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QNetworkAccessManager>
@@ -31,9 +32,9 @@ void ImgurUploader::handleReply(QNetworkReply* reply)
 {
     spinner()->deleteLater();
     m_currentImageName.clear();
+    QJsonDocument response = QJsonDocument::fromJson(reply->readAll());
+    QJsonObject json = response.object();
     if (reply->error() == QNetworkReply::NoError) {
-        QJsonDocument response = QJsonDocument::fromJson(reply->readAll());
-        QJsonObject json = response.object();
         QJsonObject data = json[QStringLiteral("data")].toObject();
         setImageURL(data[QStringLiteral("link")].toString());
 
@@ -54,7 +55,17 @@ void ImgurUploader::handleReply(QNetworkReply* reply)
 
         emit uploadOk(imageURL());
     } else {
-        setInfoLabelText(reply->errorString());
+        QString status;
+        if (json.contains("errors") && json.value("errors").isArray()) {
+            QJsonArray errorsArray = json.value("errors").toArray();
+            if (!errorsArray.isEmpty() && errorsArray.at(0).isObject()) {
+                QJsonObject errorObj = errorsArray.at(0).toObject();
+                status = errorObj.value("code").toString() + " - " +
+                         errorObj.value("status").toString();
+            }
+        }
+
+        setInfoLabelText(reply->errorString() + "\n" + status);
     }
     new QShortcut(Qt::Key_Escape, this, SLOT(close()));
 }

--- a/src/tools/imgupload/storages/imgur/imguruploader.cpp
+++ b/src/tools/imgupload/storages/imgur/imguruploader.cpp
@@ -56,12 +56,15 @@ void ImgurUploader::handleReply(QNetworkReply* reply)
         emit uploadOk(imageURL());
     } else {
         QString status;
-        if (json.contains("errors") && json.value("errors").isArray()) {
-            QJsonArray errorsArray = json.value("errors").toArray();
+        if (json.contains(QStringLiteral("errors")) &&
+            json.value(QStringLiteral("errors")).isArray()) {
+            QJsonArray errorsArray =
+              json.value(QStringLiteral("errors")).toArray();
             if (!errorsArray.isEmpty() && errorsArray.at(0).isObject()) {
                 QJsonObject errorObj = errorsArray.at(0).toObject();
-                status = errorObj.value("code").toString() + " - " +
-                         errorObj.value("status").toString();
+                status = errorObj.value(QStringLiteral("code")).toString() +
+                         " - " +
+                         errorObj.value(QStringLiteral("status")).toString();
             }
         }
 


### PR DESCRIPTION
As mentioned in #3972, it seems that Qt 6 handles network replies differently, and an error string is no longer set in certain cases. From what I understand, Qt 6 does not treat 429 as an error because the request was successfully sent (from a technical point of view).
This pull request parses the JSON response to print a human-readable status/error message.

```json
{
  "errors": [
    {
      "id": "[...]",
      "code": "429",
      "status": "Too Many Requests",
      "detail": "Too Many Requests"
    }
  ]
}
```
![grafik](https://github.com/user-attachments/assets/d9b7b68e-c426-4efb-bd4e-6de1bc3b8fd1)
