### PR TITLE
Qt 6 - Support dark mode in Windows

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -83,7 +83,11 @@ QTranslator translator, qtTranslator;
 void configureApp(bool gui)
 {
     if (gui) {
+#if defined(Q_OS_WIN) && QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+        QApplication::setStyle("Fusion"); // Supports dark scheme on Win 10/11
+#else
         QApplication::setStyle(new StyleOverride);
+#endif
     }
 
     // Configure translations


### PR DESCRIPTION
When the "Fusion" style is selected, the application will automatically switch to light / dark mode according to the setting chosen in Windows. This is supported [since Qt 6.5](https://www.qt.io/blog/dark-mode-on-windows-11-with-qt-6.5).

![dark](https://github.com/user-attachments/assets/5a15044e-7893-4a0b-962f-5d70b402d80c)
