### PR TITLE
Qt 6 - Fix app launcher filter

### DIFF
--- a/src/tools/launcher/applauncherwidget.cpp
+++ b/src/tools/launcher/applauncherwidget.cpp
@@ -177,7 +177,7 @@ void AppLauncherWidget::searchChanged(const QString& text)
         m_filterList->show();
         m_filterList->clear();
         const QRegularExpression regexp(
-          QRegularExpression::wildcardToRegularExpression(text),
+          QRegularExpression::wildcardToRegularExpression("*" + text + "*"),
           QRegularExpression::CaseInsensitiveOption);
         QVector<DesktopAppData> apps;
 


### PR DESCRIPTION
The QRegularExpression replacement from PR #3962 didn't include necessary wildcards, which are needed to have the same filter behavior as with Qt 5.