### PR TITLE
Qt6 - Fix applauncher performance on Windows

### DIFF
--- a/src/utils/winlnkfileparse.cpp
+++ b/src/utils/winlnkfileparse.cpp
@@ -4,7 +4,7 @@
 #include "winlnkfileparse.h"
 #include <QDir>
 #include <QDirIterator>
-#include <QFileSystemModel>
+#include <QFileIconProvider>
 #include <QImageWriter>
 #include <QRegularExpression>
 #include <QSettings>
@@ -36,11 +36,8 @@ DesktopAppData WinLnkFileParser::parseLnkFile(const QFileInfo& fiLnk,
 
     res.name = fiLnk.baseName();
     res.exec = fiSymlink.absoluteFilePath();
-
-    // Get icon from exe
-    QFileSystemModel* model = new QFileSystemModel;
-    model->setRootPath(fiSymlink.path());
-    res.icon = model->fileIcon(model->index(fiSymlink.filePath()));
+    static QFileIconProvider provider;
+    res.icon = provider.icon(QFileInfo(fiSymlink.filePath()));
 
     if (m_GraphicAppsList.contains(fiSymlink.fileName())) {
         res.categories = QStringList() << "Graphics";

--- a/src/utils/winlnkfileparse.h
+++ b/src/utils/winlnkfileparse.h
@@ -25,7 +25,7 @@ struct WinLnkFileParser
     WinLnkFileParser();
     DesktopAppData parseLnkFile(const QFileInfo& fiLnk, bool& ok) const;
     int processDirectory(const QDir& dir);
-    QString getAllUsersStartMenuPath();
+    static QString getAllUsersStartMenuPath();
 
     QVector<DesktopAppData> getAppsByCategory(const QString& category);
     QMap<QString, QVector<DesktopAppData>> getAppsByCategory(


### PR DESCRIPTION
The initial implementation for fetching the app icons for the AppLauncherWidget on Windows was using QFileSystemModel. With Qt 5 this worked well, but with Qt 6 there is a big performance issue, not sure what was changed in Qt 6 internally (on my system it takes >20 sec for showing the AppLauncherWidget which is unusable!).

Using QFileIconProvider instead brings back the old performance and opening the Widget quickly again in ~1-2 sec.