### PR TITLE
Fix for wrong set savePath on Windows (#3990)

### DIFF
--- a/src/utils/screenshotsaver.cpp
+++ b/src/utils/screenshotsaver.cpp
@@ -260,8 +260,8 @@ bool saveToFilesystemGUI(const QPixmap& capture)
     }
 
     if (okay) {
-        QString pathNoFile =
-          savePath.left(savePath.lastIndexOf(QDir::separator()));
+        // Don't use QDir::separator() here, as Qt internally always uses '/'
+        QString pathNoFile = savePath.left(savePath.lastIndexOf('/'));
 
         ConfigHandler().setSavePath(pathNoFile);
 


### PR DESCRIPTION
Fix for wrong set savePath on Windows (#3990). As Qt is always using '/' internally, we must avoid QDir::separator() here, as it returns '\\' on Windows and because of this the correct path cannot be extracted.