### PR TITLE
make pin moving compatible with Wayland on Qt6

### DIFF
--- a/src/tools/pin/pinwidget.cpp
+++ b/src/tools/pin/pinwidget.cpp
@@ -148,9 +148,6 @@ void PinWidget::mouseDoubleClickEvent(QMouseEvent*)
 
 void PinWidget::mousePressEvent(QMouseEvent* e)
 {
-    m_dragStart = e->globalPosition();
-    m_offsetX = e->position().x() / width();
-    m_offsetY = e->position().y() / height();
     if (QWindow* window = windowHandle(); window != nullptr) {
         window->startSystemMove();
         return;

--- a/src/tools/pin/pinwidget.h
+++ b/src/tools/pin/pinwidget.h
@@ -45,8 +45,6 @@ private:
     QPixmap m_pixmap;
     QVBoxLayout* m_layout;
     QLabel* m_label;
-    QPointF m_dragStart;
-    qreal m_offsetX{}, m_offsetY{};
     QGraphicsDropShadowEffect* m_shadowEffect;
     QColor m_baseColor, m_hoverColor;
 


### PR DESCRIPTION
First step in fixing #3979. 

Simply fixing the opacity looked terrible with the border added on Wayland. When I first fixed the border on wayland the window became unmovable. This is because on wayland DE's Qt is not able to move non child widgets. So we now request the DE to move for us.

I've only tested on arch with Gnome and KDE. I want to test this on MacOs, and some X11 desktops before merging. If required we can add some if statements to restore the old behavior if the new implementation does not work on all platforms.

See here for more details:

https://doc.qt.io/qt-6/qwindow.html#startSystemMove
https://doc.qt.io/qt-6/qwindow.html#setPosition
https://stackoverflow.com/questions/76665812/qwindow-startsystemmove-stops-hover-events-on-child-widgets

When this is merged I can then add the real opacity fix. 


Tested:
- [x] Wayland KDE
- [x] Wayland Gnome
- [x] X11 KDE
- [x] MacOS
- [x] windows

