### PR TITLE
Make CIs to ignore .ts translation files in PullRequests

### DIFF
--- a/.github/workflows/Linux-pack.yml
+++ b/.github/workflows/Linux-pack.yml
@@ -15,6 +15,7 @@ on:
       - 'README.md'
       - 'LICENSE'
       - 'docs/**'
+      - 'data/translations/*.ts'
 
   workflow_dispatch:
 

--- a/.github/workflows/MacOS-pack.yml
+++ b/.github/workflows/MacOS-pack.yml
@@ -15,6 +15,7 @@ on:
       - 'README.md'
       - 'LICENSE'
       - 'docs/**'
+      - 'data/translations/*.ts'
 
   workflow_dispatch:
 

--- a/.github/workflows/Windows-pack.yml
+++ b/.github/workflows/Windows-pack.yml
@@ -15,6 +15,7 @@ on:
       - 'README.md'
       - 'LICENSE'
       - 'docs/**'
+      - 'data/translations/*.ts'
   
   workflow_dispatch:
 

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -13,6 +13,7 @@ on:
       - 'README.md'
       - 'LICENSE'
       - 'docs/**'
+      - 'data/translations/*.ts'
 
   workflow_dispatch:
 

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -6,11 +6,13 @@ on:
       - 'README.md'
       - 'LICENSE'
       - 'docs/**'
+      - 'data/translations/*.ts'
   pull_request:
     paths-ignore:
       - 'README.md'
       - 'LICENSE'
       - 'docs/**'
+      - 'data/translations/*.ts'
 
   workflow_dispatch:
 


### PR DESCRIPTION
Addresses #4003

In all relevant CIs the .ts files are ignored during the PR step. The only exception was the `clang-format.yml` in which I though it should also be unnecessary to run it on master HEAD when a translation file is changed. If that is wrong or ano further modification is needed, let me know and I will add more commits.