### PR TITLE
Fix Qt caching on Windows CI

### DIFF
--- a/.github/workflows/Windows-pack.yml
+++ b/.github/workflows/Windows-pack.yml
@@ -28,9 +28,7 @@ jobs:
     name: VS 2022 ${{ matrix.config.arch }}-${{ matrix.type }}
     runs-on: windows-2025
     env:
-      VCINSTALLDIR: C:/Program Files (x86)/Microsoft Visual Studio/2022/Enterprise/VC/
-      Qt6_DIR: ${{ github.workspace }}\build\Qt\${{ matrix.qt_ver }}\${{ matrix.config.qt_arch_install }}\lib\cmake\Qt6\
-      QTDIR: ${{ github.workspace }}\build\Qt\${{ matrix.qt_ver }}\${{ matrix.config.qt_arch_install }}\
+      VCINSTALLDIR: C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC
       # 2025.02.14
       VCPKG_VERSION: d5ec528843d29e3a52d745a64b469f810b2cedbf
       VCPKG_PACKAGES: openssl-windows
@@ -101,21 +99,15 @@ jobs:
           vcpkgGitCommitId: ${{ env.VCPKG_VERSION }}
           vcpkgTriplet: ${{ matrix.config.vcpkg_triplet }}
 
-      - name: Cache Qt
-        id: cache-qt
-        uses: actions/cache@v4
-        with:
-          path: ./build/Qt/${{ matrix.qt_ver }}/${{ matrix.config.qt_arch_install }}
-          key: ${{ runner.os }}-QtCache/${{ matrix.qt_ver }}/${{ matrix.config.qt_arch }}
-
       - name: Install Qt
         uses: jurplel/install-qt-action@v4
         with:
           version: ${{ matrix.qt_ver }}
+          cache: 'true'
+          cache-key-prefix: install-qt-action-${{ matrix.qt_ver }}
           target:  ${{ matrix.qt_target }}
           arch: ${{ matrix.config.qt_arch }}
           dir: '${{ github.workspace }}/build/'
-          cached: ${{ steps.cache-qt.outputs.cache-hit }}
 
       - name: Configure
         working-directory: build

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -98,7 +98,8 @@ jobs:
             artifact: "Windows-MSVC.tar.xz",
             os: windows-2022,
             cc: "cl", cxx: "cl",
-            environment_script: "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Auxiliary/Build/vcvars64.bat"
+            environment_script: "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Auxiliary/Build/vcvars64.bat",
+            qt_ver: '6.9.1'
           }
 
     steps:
@@ -109,20 +110,14 @@ jobs:
         run: |
           Remove-Item "$env:LOCALAPPDATA\Microsoft\WindowsApps\python*.exe" -Force -ErrorAction SilentlyContinue
 
-      - name: Cache Qt
-        id: cache-qt
-        uses: actions/cache@v4
-        with:
-          path: ./build/Qt/6.9.1
-          key: ${{ runner.os }}-QtCache-6.9.1
-
       - name: Install Qt
         uses: jurplel/install-qt-action@v4
         with:
-          version: 6.9.1
+          version: ${{ matrix.config.qt_ver }}
+          cache: 'true'
+          cache-key-prefix: install-qt-action-${{ matrix.config.qt_ver }}
           target:  desktop
           dir: '${{ github.workspace }}/build/'
-          cached: ${{ steps.cache-qt.outputs.cache-hit }}
 
       - name: Configure
         working-directory: build


### PR DESCRIPTION
Since install-qt-action@**v3**, the action provides its own caching. Separate "actions/cache" is not needed anymore and with the built-in cache, the and install-qt-action 'cached' options was replaced.

Environment variables 'Qt6_DIR' and 'QTDIR' are not needed anymore neither (see [install-qt-action Upgrade guide](https://github.com/jurplel/install-qt-action/blob/master/README_upgrade_guide.md)).

The actions are running fine in my branch see [Building(CMake)](https://github.com/ElTh0r0/flameshot/actions/runs/15664442622/job/44126691517) and [Packaging(Windows)](https://github.com/ElTh0r0/flameshot/actions/runs/15664399518/job/44126591005).

I executed "Building(CMake)" twice and with the second run, I see the caching worked:
![grafik](https://github.com/user-attachments/assets/05ca7ab9-61e5-4839-bf54-a724b5c0a96c)


There is still an issue with the vcpkg step and because of that OpenSSL is not installed, but as mentioned in #3972 we most likely won't need separate OpenSSL anymore, but I cannot fully verify it due to missing imgur account.