### PR TITLE
Search windeployqt

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -391,7 +391,19 @@ endif ()
 
 # windeployqt
 if (WIN32)
-    if (EXISTS $ENV{QTDIR}/bin/windeployqt.exe)
+    # Add CMAKE_PREFIX_PATH to search paths
+    foreach(prefix ${CMAKE_PREFIX_PATH})
+        list(APPEND WINDEPLOYQT_SEARCH_PATHS "${prefix}/bin")
+    endforeach()
+    list(APPEND WINDEPLOYQT_SEARCH_PATHS "$ENV{QTDIR}/bin")
+    
+    find_program(WINDEPLOYQT_EXE windeployqt.exe
+        PATHS ${WINDEPLOYQT_SEARCH_PATHS}
+    )
+
+    if(WINDEPLOYQT_EXE)
+        message(STATUS "windeployqt found: ${WINDEPLOYQT_EXE}")
+
         if (CMAKE_BUILD_TYPE MATCHES Release)
             set(BINARIES_TYPE --release)
         else ()
@@ -403,7 +415,7 @@ if (WIN32)
                 POST_BUILD
                 COMMAND ${CMAKE_COMMAND} -E remove_directory ${CMAKE_BINARY_DIR}/windeployqt_stuff
                 COMMAND
-                $ENV{QTDIR}/bin/windeployqt.exe ${BINARIES_TYPE} --no-translations --compiler-runtime --no-system-d3d-compiler
+                ${WINDEPLOYQT_EXE} ${BINARIES_TYPE} --no-translations --compiler-runtime --no-system-d3d-compiler
                 --no-quick-import --dir ${CMAKE_BINARY_DIR}/windeployqt_stuff $<TARGET_FILE:flameshot>
                 # copy translations manually QM_FILES
                 COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/windeployqt_stuff/translations
@@ -429,7 +441,7 @@ if (WIN32)
         endif ()
 
     else ()
-        message("Unable to find executable QTDIR/bin/windeployqt.")
+        message(WARNING "Unable to find executable windeployqt.")
     endif ()
 endif ()
 


### PR DESCRIPTION
As mentioned in https://github.com/flameshot-org/flameshot/discussions/4012#discussioncomment-13504609, windeployqt wasn't found anymore and because of this the Windows artifacts were missing the Qt DLLs.
Now cmake searches in CMAKE_PREFIX_PATH first and (as fallback / for backward compatibility) in environment variable QTDIR for the windeployqt.exe