### PR TITLE
Center dialogs on current screen

### DIFF
--- a/src/core/flameshot.cpp
+++ b/src/core/flameshot.cpp
@@ -37,8 +37,8 @@
 #endif
 
 Flameshot::Flameshot()
-  : m_captureWindow(nullptr)
-  , m_haveExternalWidget(false)
+  : m_haveExternalWidget(false)
+  , m_captureWindow(nullptr)
 #if defined(Q_OS_MACOS)
   , m_HotkeyScreenshotCapture(nullptr)
   , m_HotkeyScreenshotHistory(nullptr)
@@ -221,6 +221,12 @@ void Flameshot::config()
     if (m_configWindow == nullptr) {
         m_configWindow = new ConfigWindow();
         m_configWindow->show();
+        // Call show() first, otherwise the correct geometry cannot be fetched
+        // for centering the window on the screen
+        QRect position = m_configWindow->frameGeometry();
+        QScreen* currentScreen = QGuiAppCurrentScreen().currentScreen();
+        position.moveCenter(currentScreen->availableGeometry().center());
+        m_configWindow->move(position.topLeft());
 #if defined(Q_OS_MACOS)
         m_configWindow->activateWindow();
         m_configWindow->raise();
@@ -249,7 +255,14 @@ void Flameshot::history()
             historyWidget = nullptr;
         });
     }
+
     historyWidget->show();
+    // Call show() first, otherwise the correct geometry cannot be fetched
+    // for centering the window on the screen
+    QRect position = historyWidget->frameGeometry();
+    QScreen* currentScreen = QGuiAppCurrentScreen().currentScreen();
+    position.moveCenter(currentScreen->availableGeometry().center());
+    historyWidget->move(position.topLeft());
 
 #if defined(Q_OS_MACOS)
     historyWidget->activateWindow();

--- a/src/widgets/capturelauncher.cpp
+++ b/src/widgets/capturelauncher.cpp
@@ -5,6 +5,7 @@
 #include "./ui_capturelauncher.h"
 #include "src/config/cacheutils.h"
 #include "src/core/flameshot.h"
+#include "src/core/qguiappcurrentscreen.h"
 #include "src/utils/globalvalues.h"
 #include "src/utils/screengrabber.h"
 #include "src/utils/screenshotsaver.h"
@@ -84,7 +85,14 @@ CaptureLauncher::CaptureLauncher(QDialog* parent)
     ui->screenshotY->setText(QString::number(lastRegion.y()));
     ui->screenshotWidth->setText(QString::number(lastRegion.width()));
     ui->screenshotHeight->setText(QString::number(lastRegion.height()));
+
     show();
+    // Call show() first, otherwise the correct geometry cannot be fetched
+    // for centering the window on the screen
+    QRect position = frameGeometry();
+    QScreen* screen = QGuiAppCurrentScreen().currentScreen();
+    position.moveCenter(screen->availableGeometry().center());
+    move(position.topLeft());
 }
 
 // HACK:

--- a/src/widgets/infowindow.cpp
+++ b/src/widgets/infowindow.cpp
@@ -23,12 +23,13 @@ InfoWindow::InfoWindow(QWidget* parent)
     connect(
       ui->CopyInfoButton, &QPushButton::clicked, this, &InfoWindow::copyInfo);
 
+    show();
+    // Call show() first, otherwise the correct geometry cannot be fetched for
+    // centering the window on the screen
     QRect position = frameGeometry();
     QScreen* screen = QGuiAppCurrentScreen().currentScreen();
     position.moveCenter(screen->availableGeometry().center());
     move(position.topLeft());
-
-    show();
 }
 
 InfoWindow::~InfoWindow()


### PR DESCRIPTION
Fix for #877 
Note: On my main system (Manjaro with KDE Plasma), the dialog's had been automatically centered by Plasma (without this code change), so potentially other Linux users didn't noticed this issue. But it was an issue on Windows, which is fixed now with this PR.