### PR TITLE
Another fix for wrong set savePath on Windows

### DIFF
--- a/src/utils/screenshotsaver.cpp
+++ b/src/utils/screenshotsaver.cpp
@@ -241,8 +241,7 @@ bool saveToFilesystemGUI(const QPixmap& capture)
     }
 #endif
     if (!config.savePathFixed()) {
-        savePath = QDir::toNativeSeparators(
-          ShowSaveFileDialog(QObject::tr("Save screenshot"), savePath));
+        savePath = ShowSaveFileDialog(QObject::tr("Save screenshot"), savePath);
     }
     if (savePath == "") {
         return okay;


### PR DESCRIPTION
This refers to #3990 / #3997
When I fixed the above, I was focusing on the "Use fixed path for screenshot to save" from the issue only, but when no fixed path is used, the file path returned from the save dialog was converted to 'native dir separators' and causing the same problem as reported in #3990.