### PR TITLE
Add qtimageformats to Windows CI for adding webp support

### DIFF
--- a/.github/workflows/Windows-pack.yml
+++ b/.github/workflows/Windows-pack.yml
@@ -107,6 +107,7 @@ jobs:
           cache-key-prefix: install-qt-action-${{ matrix.qt_ver }}
           target:  ${{ matrix.qt_target }}
           arch: ${{ matrix.config.qt_arch }}
+          modules: 'qtimageformats'
           dir: '${{ github.workspace }}/build/'
 
       - name: Configure


### PR DESCRIPTION
When qtimageformats module is installed on a Windows system, the windeployqt tool adds the WebP DLL (among others) to the 'imageformats' output folder. This makes WebP available for saving screenshots on Windows.
Related to #3672 

(requires #4022 to be merged to work)