### PR TITLE
Qt 6 - DEB/RPM Linux packaging

### DIFF
--- a/.github/workflows/Linux-arm-pack.yml
+++ b/.github/workflows/Linux-arm-pack.yml
@@ -30,12 +30,12 @@ jobs:
       fail-fast: false
       matrix:
         dist:
-          - {
-              name: debian-11,
-              os: debian,
-              symbol: bullseye,
-              arch: armhf
-            }
+#          - {
+#              name: debian-11,
+#              os: debian,
+#              symbol: bullseye,
+#              arch: armhf
+#            }
           - {
               name: debian-12,
               os: debian,
@@ -52,25 +52,42 @@ jobs:
               name: ubuntu-22.04,
               os: ubuntu,
               symbol: jammy,
-              arch: amd64
+              arch: arm64
             }
+          - {
+              name: ubuntu-24.04,
+              os: ubuntu,
+              symbol: noble,
+              arch: arm64
+            }
+
     steps:
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Checkout Source code
         if: github.event_name == 'push'
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: master
+#          ref: master
+
       - name: Checkout Source code
         if: github.event_name == 'pull_request'
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Checkout Source code
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+
       - name: Set env & Print flameshot version
         shell: bash
         run: |
@@ -82,8 +99,11 @@ jobs:
           echo ${last_committed_tag:1}
           echo "Details: ${ver_info}"
           echo "================================"
-          echo "VERSION=${last_committed_tag:1}" >> $GITHUB_ENV
+          # This will allow to build pre-preleases without git tag
+          # echo "VERSION=${last_committed_tag:1}" >> $GITHUB_ENV
+          echo "VERSION=$(cat CMakeLists.txt |grep 'set.*(.*FLAMESHOT_VERSION' | sed 's/[^0-9.]*//' |sed 's/)//g')" >> $GITHUB_ENV
           echo "VER_INFO=${ver_info}" >> $GITHUB_ENV
+
       - name: Get packpack tool
         uses: actions/checkout@v4
         with:
@@ -91,6 +111,7 @@ jobs:
           path: tools
           ref: multiarch
           set-safe-directory: $GITHUB_WORKSPACE/tools
+
       - name: Packaging on ${{ matrix.dist.name }} ${{ matrix.dist.arch }}
         env:
           OS: ${{ matrix.dist.os }}
@@ -114,10 +135,12 @@ jobs:
           cp -r $GITHUB_WORKSPACE/packaging/debian $GITHUB_WORKSPACE
           bash $GITHUB_WORKSPACE/tools/packpack
           mv $GITHUB_WORKSPACE/build/${PRODUCT}_${VERSION}-${RELEASE}_${{ matrix.dist.arch }}.deb $GITHUB_WORKSPACE/build/${PRODUCT}-${VERSION}-${RELEASE}.${{ matrix.dist.name }}.${{ matrix.dist.arch }}.deb
+
       - name: SHA256Sum of ${{ matrix.dist.name }} ${{ matrix.dist.arch }} package
         run: |
           cd "$GITHUB_WORKSPACE/build/" || { >&2 echo "Cannot cd to '$GITHUB_WORKSPACE/build/'!"; exit 11 ; }
           sha256sum ${PRODUCT}-${VERSION}-${RELEASE}.${{ matrix.dist.name }}.${{ matrix.dist.arch }}.deb | tee ${PRODUCT}-${VERSION}-${RELEASE}.${{ matrix.dist.name }}.${{ matrix.dist.arch }}.deb.sha256sum
+
       - name: Artifact Upload
         uses: actions/upload-artifact@v4
         with:
@@ -126,5 +149,3 @@ jobs:
             ${{ github.workspace }}/build/${{ env.PRODUCT }}-*-${{ env.RELEASE }}.${{ matrix.dist.name }}.${{ matrix.dist.arch }}.deb
             ${{ github.workspace }}/build/${{ env.PRODUCT }}-*-${{ env.RELEASE }}.${{ matrix.dist.name }}.${{ matrix.dist.arch }}.deb.sha256sum
           overwrite: true
-
-  

--- a/.github/workflows/Linux-pack.yml
+++ b/.github/workflows/Linux-pack.yml
@@ -64,20 +64,30 @@ jobs:
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+
       - name: Checkout Source code
         if: github.event_name == 'push'
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: master
+#          ref: master
+
       - name: Checkout Source code
         if: github.event_name == 'pull_request'
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Checkout Source code
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+
       - name: Set env & Print flameshot version
         shell: bash
         run: |
@@ -93,6 +103,7 @@ jobs:
           # echo "VERSION=${last_committed_tag:1}" >> $GITHUB_ENV
           echo "VERSION=$(cat CMakeLists.txt |grep 'set.*(.*FLAMESHOT_VERSION' | sed 's/[^0-9.]*//' |sed 's/)//g')" >> $GITHUB_ENV
           echo "VER_INFO=${ver_info}" >> $GITHUB_ENV
+
       - name: Get packpack tool
         uses: actions/checkout@v4
         with:
@@ -100,6 +111,7 @@ jobs:
           path: tools
           ref: multiarch
           set-safe-directory: $GITHUB_WORKSPACE/tools
+
       - name: Packaging on ${{ matrix.dist.name }} ${{ matrix.dist.arch }}
         env:
           OS: ${{ matrix.dist.os }}
@@ -111,10 +123,12 @@ jobs:
           cp -r $GITHUB_WORKSPACE/packaging/debian $GITHUB_WORKSPACE
           bash $GITHUB_WORKSPACE/tools/packpack
           mv $GITHUB_WORKSPACE/build/${PRODUCT}_${VERSION}-${RELEASE}_${{ matrix.dist.arch }}.deb $GITHUB_WORKSPACE/build/${PRODUCT}-${VERSION}-${RELEASE}.${{ matrix.dist.name }}.${{ matrix.dist.arch }}.deb
+
       - name: SHA256Sum of ${{ matrix.dist.name }} ${{ matrix.dist.arch }} package
         run: |
           cd "$GITHUB_WORKSPACE/build/" || { >&2 echo "Cannot cd to '$GITHUB_WORKSPACE/build/'!"; exit 11 ; }
           sha256sum ${PRODUCT}-${VERSION}-${RELEASE}.${{ matrix.dist.name }}.${{ matrix.dist.arch }}.deb | tee ${PRODUCT}-${VERSION}-${RELEASE}.${{ matrix.dist.name }}.${{ matrix.dist.arch }}.deb.sha256sum
+
       - name: Artifact Upload
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/Linux-pack.yml
+++ b/.github/workflows/Linux-pack.yml
@@ -62,11 +62,11 @@ jobs:
             }
 
     steps:
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Checkout Source code
         if: github.event_name == 'push'

--- a/.github/workflows/Linux-pack.yml
+++ b/.github/workflows/Linux-pack.yml
@@ -89,7 +89,9 @@ jobs:
           echo ${last_committed_tag:1}
           echo "Details: ${ver_info}"
           echo "================================"
-          echo "VERSION=${last_committed_tag:1}" >> $GITHUB_ENV
+          # This will allow to build pre-preleases without git tag
+          # echo "VERSION=${last_committed_tag:1}" >> $GITHUB_ENV
+          echo "VERSION=$(cat CMakeLists.txt |grep 'set.*(.*FLAMESHOT_VERSION' | sed 's/[^0-9.]*//' |sed 's/)//g')" >> $GITHUB_ENV
           echo "VER_INFO=${ver_info}" >> $GITHUB_ENV
       - name: Get packpack tool
         uses: actions/checkout@v4

--- a/.github/workflows/Linux-pack.yml
+++ b/.github/workflows/Linux-pack.yml
@@ -138,119 +138,130 @@ jobs:
             ${{ github.workspace }}/build/${{ env.PRODUCT }}-*-${{ env.RELEASE }}.${{ matrix.dist.name }}.${{ matrix.dist.arch }}.deb.sha256sum
           overwrite: true
 
-#   rpm-pack:
-#     name: Build rpm on ${{ matrix.dist.name }} ${{ matrix.dist.arch }}
-#     runs-on: ubuntu-latest
-#     strategy:
-#       fail-fast: false
-#       matrix:
-#         dist:
-#           - {
-#               name: fedora-41,
-#               os: fedora,
-#               symbol: 41,
-#               arch: x86_64
-#             }
-#           - {
-#               name: fedora-42,
-#               os: fedora,
-#               symbol: 42,
-#               arch: x86_64
-#             }
-#           - {
-#               name: opensuse-leap-15.6,
-#               os: opensuse-leap,
-#               symbol: 15.6,
-#               arch: x86_64
-#             }
-#     steps:
-#       - name: Checkout Source code
-#         if: github.event_name == 'push'
-#         uses: actions/checkout@v4
-#         with:
-#           fetch-depth: 0
-#           ref: master
-#       - name: Checkout Source code
-#         if: github.event_name == 'pull_request'
-#         uses: actions/checkout@v4
-#         with:
-#           fetch-depth: 0
-#           ref: ${{ github.event.pull_request.head.sha }}
-#       - name: Set env & Print flameshot version
-#         shell: bash
-#         run: |
-#           last_committed_tag=$(git tag -l --sort=-v:refname | head -1)
-#           git_revno=$(git rev-list $(git describe --tags --abbrev=0)..HEAD --count)
-#           git_hash=$(git rev-parse --short HEAD)
-#           ver_info=${last_committed_tag}+git${git_revno}.${git_hash}
-#           echo "=======FLAMESHOT VERSION========"
-#           echo ${last_committed_tag:1}
-#           echo "Details: ${ver_info}"
-#           echo "================================"
-#           echo "VERSION=${last_committed_tag:1}" >> $GITHUB_ENV
-#           echo "VER_INFO=${ver_info}" >> $GITHUB_ENV
-#       - name: Get packpack tool
-#         uses: actions/checkout@v4
-#         with:
-#           repository: ${{ env.PACKPACK_REPO }}
-#           path: tools
-#           ref: master
-#           set-safe-directory: $GITHUB_WORKSPACE/tools
-#       - name: Packaging on ${{ matrix.dist.name }} ${{ matrix.dist.arch }}
-#         if: matrix.dist.os == 'fedora'
-#         run: |
-#           mkdir $GITHUB_WORKSPACE/rpm
-#           cp $GITHUB_WORKSPACE/packaging/rpm/fedora/flameshot.spec $GITHUB_WORKSPACE/rpm
-#           bash $GITHUB_WORKSPACE/tools/packpack
-#         env:
-#           OS: ${{ matrix.dist.os }}
-#           DIST: ${{ matrix.dist.symbol }}
-#       - name: Packaging on ${{ matrix.dist.name }} ${{ matrix.dist.arch }}
-#         if: matrix.dist.os == 'opensuse-leap'
-#         run: |
-#           mkdir $GITHUB_WORKSPACE/rpm
-#           cp $GITHUB_WORKSPACE/packaging/rpm/opensuse/flameshot.spec $GITHUB_WORKSPACE/rpm
-#           bash $GITHUB_WORKSPACE/tools/packpack
-#         env:
-#           OS: ${{ matrix.dist.os }}
-#           DIST: ${{ matrix.dist.symbol }}
-#       - name: Package Clean
-#         if: matrix.dist.os == 'fedora'
-#         run: |
-#           rm -f ${{ github.workspace }}/build/${{ env.PRODUCT }}-debuginfo-*.rpm
-#           rm -f ${{ github.workspace }}/build/${{ env.PRODUCT }}-debugsource-*.rpm
-#           rm -f ${{ github.workspace }}/build/${{ env.PRODUCT }}-*.src.rpm
-#           rm -f ${{ github.workspace }}/build/build.log
-#       - name: SHA256Sum of ${{ matrix.dist.name }} ${{ matrix.dist.arch }} package
-#         if: matrix.dist.os == 'fedora'
-#         run: |
-#           cd "$GITHUB_WORKSPACE/build/" || { >&2 echo "Cannot cd to '$GITHUB_WORKSPACE/build/'!"; exit 11 ; }
-#           sha256sum ${PRODUCT}-${VERSION}-${RELEASE}.fc*.${{ matrix.dist.arch }}.rpm | tee ${PRODUCT}-${VERSION}-${RELEASE}.fc${{ matrix.dist.symbol }}.${{ matrix.dist.arch }}.rpm.sha256sum
-#       - name: SHA256Sum of ${{ matrix.dist.name }} ${{ matrix.dist.arch }} package
-#         if: matrix.dist.os == 'opensuse-leap'
-#         run: |
-#           mv $GITHUB_WORKSPACE/build/${PRODUCT}-${VERSION}-lp*.${{ matrix.dist.arch }}.rpm $GITHUB_WORKSPACE/build/${PRODUCT}-${VERSION}-${RELEASE}-lp${{ matrix.dist.symbol }}.${{ matrix.dist.arch }}.rpm
-#           cd "$GITHUB_WORKSPACE/build/" || { >&2 echo "Cannot cd to '$GITHUB_WORKSPACE/build/'!"; exit 11 ; }
-#           sha256sum ${PRODUCT}-${VERSION}-${RELEASE}-lp${{ matrix.dist.symbol }}.${{ matrix.dist.arch }}.rpm | tee ${PRODUCT}-${VERSION}-${RELEASE}-lp${{ matrix.dist.symbol }}.${{ matrix.dist.arch }}.rpm.sha256sum
-#       - name: Artifact Upload
-#         if: matrix.dist.os == 'fedora'
-#         uses: actions/upload-artifact@v4
-#         with:
-#           name: ${{ env.PRODUCT }}-${{ env.VER_INFO }}-artifact-${{ matrix.dist.name }}-${{ matrix.dist.arch }}
-#           path: |
-#             ${{ github.workspace }}/build/
-#           overwrite: true
-#
-#       - name: Artifact Upload
-#         if: matrix.dist.os == 'opensuse-leap'
-#         uses: actions/upload-artifact@v4
-#         with:
-#           name: ${{ env.PRODUCT }}-${{ env.VER_INFO }}-artifact-${{ matrix.dist.name }}-${{ matrix.dist.arch }}
-#           path: |
-#             ${{ github.workspace }}/build/${{ env.PRODUCT }}-*-lp${{ matrix.dist.symbol }}.${{ matrix.dist.arch }}.rpm
-#             ${{ github.workspace }}/build/${{ env.PRODUCT }}-*-lp${{ matrix.dist.symbol }}.${{ matrix.dist.arch }}.rpm.sha256sum
-#           overwrite: true
-#
+  rpm-pack:
+    name: Build rpm on ${{ matrix.dist.name }} ${{ matrix.dist.arch }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        dist:
+          - {
+              name: fedora-41,
+              os: fedora,
+              symbol: 41,
+              arch: x86_64
+            }
+          - {
+              name: fedora-42,
+              os: fedora,
+              symbol: 42,
+              arch: x86_64
+            }
+    steps:
+      - name: Checkout Source code
+        if: github.event_name == 'push'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+#          ref: master
+
+      - name: Checkout Source code
+        if: github.event_name == 'pull_request'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Checkout Source code
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Set env & Print flameshot version
+        shell: bash
+        run: |
+          last_committed_tag=$(git tag -l --sort=-v:refname | head -1)
+          git_revno=$(git rev-list $(git describe --tags --abbrev=0)..HEAD --count)
+          git_hash=$(git rev-parse --short HEAD)
+          ver_info=${last_committed_tag}+git${git_revno}.${git_hash}
+          echo "=======FLAMESHOT VERSION========"
+          echo ${last_committed_tag:1}
+          echo "Details: ${ver_info}"
+          echo "================================"
+          # This will allow to build pre-preleases without git tag
+          # echo "VERSION=${last_committed_tag:1}" >> $GITHUB_ENV
+          echo "VERSION=$(cat CMakeLists.txt |grep 'set.*(.*FLAMESHOT_VERSION' | sed 's/[^0-9.]*//' |sed 's/)//g')" >> $GITHUB_ENV
+          echo "VER_INFO=${ver_info}" >> $GITHUB_ENV
+
+      - name: Get packpack tool
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.PACKPACK_REPO }}
+          path: tools
+          ref: master
+          set-safe-directory: $GITHUB_WORKSPACE/tools
+
+      - name: Packaging on ${{ matrix.dist.name }} ${{ matrix.dist.arch }}
+        if: matrix.dist.os == 'fedora'
+        run: |
+          mkdir $GITHUB_WORKSPACE/rpm
+          cp $GITHUB_WORKSPACE/packaging/rpm/fedora/flameshot.spec $GITHUB_WORKSPACE/rpm
+          bash $GITHUB_WORKSPACE/tools/packpack
+        env:
+          OS: ${{ matrix.dist.os }}
+          DIST: ${{ matrix.dist.symbol }}
+
+      - name: Packaging on ${{ matrix.dist.name }} ${{ matrix.dist.arch }}
+        if: matrix.dist.os == 'opensuse-leap'
+        run: |
+          mkdir $GITHUB_WORKSPACE/rpm
+          cp $GITHUB_WORKSPACE/packaging/rpm/opensuse/flameshot.spec $GITHUB_WORKSPACE/rpm
+          bash $GITHUB_WORKSPACE/tools/packpack
+        env:
+          OS: ${{ matrix.dist.os }}
+          DIST: ${{ matrix.dist.symbol }}
+
+      - name: Package Clean
+        if: matrix.dist.os == 'fedora'
+        run: |
+          rm -f ${{ github.workspace }}/build/${{ env.PRODUCT }}-debuginfo-*.rpm
+          rm -f ${{ github.workspace }}/build/${{ env.PRODUCT }}-debugsource-*.rpm
+          rm -f ${{ github.workspace }}/build/${{ env.PRODUCT }}-*.src.rpm
+          rm -f ${{ github.workspace }}/build/build.log
+
+      - name: SHA256Sum of ${{ matrix.dist.name }} ${{ matrix.dist.arch }} package
+        if: matrix.dist.os == 'fedora'
+        run: |
+          cd "$GITHUB_WORKSPACE/build/" || { >&2 echo "Cannot cd to '$GITHUB_WORKSPACE/build/'!"; exit 11 ; }
+          sha256sum ${PRODUCT}-${VERSION}-${RELEASE}.fc*.${{ matrix.dist.arch }}.rpm | tee ${PRODUCT}-${VERSION}-${RELEASE}.fc${{ matrix.dist.symbol }}.${{ matrix.dist.arch }}.rpm.sha256sum
+
+      - name: SHA256Sum of ${{ matrix.dist.name }} ${{ matrix.dist.arch }} package
+        if: matrix.dist.os == 'opensuse-leap'
+        run: |
+          mv $GITHUB_WORKSPACE/build/${PRODUCT}-${VERSION}-lp*.${{ matrix.dist.arch }}.rpm $GITHUB_WORKSPACE/build/${PRODUCT}-${VERSION}-${RELEASE}-lp${{ matrix.dist.symbol }}.${{ matrix.dist.arch }}.rpm
+          cd "$GITHUB_WORKSPACE/build/" || { >&2 echo "Cannot cd to '$GITHUB_WORKSPACE/build/'!"; exit 11 ; }
+          sha256sum ${PRODUCT}-${VERSION}-${RELEASE}-lp${{ matrix.dist.symbol }}.${{ matrix.dist.arch }}.rpm | tee ${PRODUCT}-${VERSION}-${RELEASE}-lp${{ matrix.dist.symbol }}.${{ matrix.dist.arch }}.rpm.sha256sum
+
+      - name: Artifact Upload
+        if: matrix.dist.os == 'fedora'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.PRODUCT }}-${{ env.VER_INFO }}-artifact-${{ matrix.dist.name }}-${{ matrix.dist.arch }}
+          path: |
+            ${{ github.workspace }}/build/
+          overwrite: true
+
+      - name: Artifact Upload
+        if: matrix.dist.os == 'opensuse-leap'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.PRODUCT }}-${{ env.VER_INFO }}-artifact-${{ matrix.dist.name }}-${{ matrix.dist.arch }}
+          path: |
+            ${{ github.workspace }}/build/${{ env.PRODUCT }}-*-lp${{ matrix.dist.symbol }}.${{ matrix.dist.arch }}.rpm
+            ${{ github.workspace }}/build/${{ env.PRODUCT }}-*-lp${{ matrix.dist.symbol }}.${{ matrix.dist.arch }}.rpm.sha256sum
+          overwrite: true
+
 #   appimage-pack:
 #     name: Build appimage on ${{ matrix.config.name }}
 #     runs-on: ubuntu-latest

--- a/.github/workflows/Linux-pack.yml
+++ b/.github/workflows/Linux-pack.yml
@@ -29,99 +29,99 @@ env:
   PACKPACK_REPO: flameshot-org/packpack
 
 jobs:
-#   deb-pack:
-#     name: Build deb on ${{ matrix.dist.name }} ${{ matrix.dist.arch }}
-#     runs-on: ubuntu-latest
-#     strategy:
-#       fail-fast: false
-#       matrix:
-#         dist:
-#           - {
-#               name: debian-11,
-#               os: debian,
-#               symbol: bullseye,
-#               arch: amd64
-#             }
-#           - {
-#               name: debian-12,
-#               os: debian,
-#               symbol: bookworm,
-#               arch: amd64
-#             }
-#           - {
-#               name: ubuntu-22.04,
-#               os: ubuntu,
-#               symbol: jammy,
-#               arch: amd64
-#             }
-#           - {
-#               name: ubuntu-24.04,
-#               os: ubuntu,
-#               symbol: noble,
-#               arch: amd64
-#             }
-#
-#     steps:
-#       - name: Set up Docker Buildx
-#         uses: docker/setup-buildx-action@v3
-#       - name: Set up QEMU
-#         uses: docker/setup-qemu-action@v3
-#       - name: Checkout Source code
-#         if: github.event_name == 'push'
-#         uses: actions/checkout@v4
-#         with:
-#           fetch-depth: 0
-#           ref: master
-#       - name: Checkout Source code
-#         if: github.event_name == 'pull_request'
-#         uses: actions/checkout@v4
-#         with:
-#           fetch-depth: 0
-#           ref: ${{ github.event.pull_request.head.sha }}
-#       - name: Set env & Print flameshot version
-#         shell: bash
-#         run: |
-#           last_committed_tag=$(git tag -l --sort=-v:refname | head -1)
-#           git_revno=$(git rev-list $(git describe --tags --abbrev=0)..HEAD --count)
-#           git_hash=$(git rev-parse --short HEAD)
-#           ver_info=${last_committed_tag}+git${git_revno}.${git_hash}
-#           echo "=======FLAMESHOT VERSION========"
-#           echo ${last_committed_tag:1}
-#           echo "Details: ${ver_info}"
-#           echo "================================"
-#           echo "VERSION=${last_committed_tag:1}" >> $GITHUB_ENV
-#           echo "VER_INFO=${ver_info}" >> $GITHUB_ENV
-#       - name: Get packpack tool
-#         uses: actions/checkout@v4
-#         with:
-#           repository: ${{ env.PACKPACK_REPO }}
-#           path: tools
-#           ref: multiarch
-#           set-safe-directory: $GITHUB_WORKSPACE/tools
-#       - name: Packaging on ${{ matrix.dist.name }} ${{ matrix.dist.arch }}
-#         env:
-#           OS: ${{ matrix.dist.os }}
-#           DIST: ${{ matrix.dist.symbol }}
-#           #DOCKER_ARCH: ${{ matrix.dist.arch }}
-#           ## I cannot see if ARCH is used anywhere. Should we remove it?
-#           #ARCH: ${{ matrix.dist.arch }}
-#         run: |
-#           cp -r $GITHUB_WORKSPACE/packaging/debian $GITHUB_WORKSPACE
-#           bash $GITHUB_WORKSPACE/tools/packpack
-#           mv $GITHUB_WORKSPACE/build/${PRODUCT}_${VERSION}-${RELEASE}_${{ matrix.dist.arch }}.deb $GITHUB_WORKSPACE/build/${PRODUCT}-${VERSION}-${RELEASE}.${{ matrix.dist.name }}.${{ matrix.dist.arch }}.deb
-#       - name: SHA256Sum of ${{ matrix.dist.name }} ${{ matrix.dist.arch }} package
-#         run: |
-#           cd "$GITHUB_WORKSPACE/build/" || { >&2 echo "Cannot cd to '$GITHUB_WORKSPACE/build/'!"; exit 11 ; }
-#           sha256sum ${PRODUCT}-${VERSION}-${RELEASE}.${{ matrix.dist.name }}.${{ matrix.dist.arch }}.deb | tee ${PRODUCT}-${VERSION}-${RELEASE}.${{ matrix.dist.name }}.${{ matrix.dist.arch }}.deb.sha256sum
-#       - name: Artifact Upload
-#         uses: actions/upload-artifact@v4
-#         with:
-#           name: ${{ env.PRODUCT }}-${{ env.VER_INFO }}-artifact-${{ matrix.dist.name }}-${{ matrix.dist.arch }}
-#           path: |
-#             ${{ github.workspace }}/build/${{ env.PRODUCT }}-*-${{ env.RELEASE }}.${{ matrix.dist.name }}.${{ matrix.dist.arch }}.deb
-#             ${{ github.workspace }}/build/${{ env.PRODUCT }}-*-${{ env.RELEASE }}.${{ matrix.dist.name }}.${{ matrix.dist.arch }}.deb.sha256sum
-#           overwrite: true
-#
+  deb-pack:
+    name: Build deb on ${{ matrix.dist.name }} ${{ matrix.dist.arch }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        dist:
+#          - {
+#              name: debian-11,
+#              os: debian,
+#              symbol: bullseye,
+#              arch: amd64
+#            }
+          - {
+              name: debian-12,
+              os: debian,
+              symbol: bookworm,
+              arch: amd64
+            }
+          - {
+              name: ubuntu-22.04,
+              os: ubuntu,
+              symbol: jammy,
+              arch: amd64
+            }
+          - {
+              name: ubuntu-24.04,
+              os: ubuntu,
+              symbol: noble,
+              arch: amd64
+            }
+
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Checkout Source code
+        if: github.event_name == 'push'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: master
+      - name: Checkout Source code
+        if: github.event_name == 'pull_request'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Set env & Print flameshot version
+        shell: bash
+        run: |
+          last_committed_tag=$(git tag -l --sort=-v:refname | head -1)
+          git_revno=$(git rev-list $(git describe --tags --abbrev=0)..HEAD --count)
+          git_hash=$(git rev-parse --short HEAD)
+          ver_info=${last_committed_tag}+git${git_revno}.${git_hash}
+          echo "=======FLAMESHOT VERSION========"
+          echo ${last_committed_tag:1}
+          echo "Details: ${ver_info}"
+          echo "================================"
+          echo "VERSION=${last_committed_tag:1}" >> $GITHUB_ENV
+          echo "VER_INFO=${ver_info}" >> $GITHUB_ENV
+      - name: Get packpack tool
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.PACKPACK_REPO }}
+          path: tools
+          ref: multiarch
+          set-safe-directory: $GITHUB_WORKSPACE/tools
+      - name: Packaging on ${{ matrix.dist.name }} ${{ matrix.dist.arch }}
+        env:
+          OS: ${{ matrix.dist.os }}
+          DIST: ${{ matrix.dist.symbol }}
+          #DOCKER_ARCH: ${{ matrix.dist.arch }}
+          ## I cannot see if ARCH is used anywhere. Should we remove it?
+          #ARCH: ${{ matrix.dist.arch }}
+        run: |
+          cp -r $GITHUB_WORKSPACE/packaging/debian $GITHUB_WORKSPACE
+          bash $GITHUB_WORKSPACE/tools/packpack
+          mv $GITHUB_WORKSPACE/build/${PRODUCT}_${VERSION}-${RELEASE}_${{ matrix.dist.arch }}.deb $GITHUB_WORKSPACE/build/${PRODUCT}-${VERSION}-${RELEASE}.${{ matrix.dist.name }}.${{ matrix.dist.arch }}.deb
+      - name: SHA256Sum of ${{ matrix.dist.name }} ${{ matrix.dist.arch }} package
+        run: |
+          cd "$GITHUB_WORKSPACE/build/" || { >&2 echo "Cannot cd to '$GITHUB_WORKSPACE/build/'!"; exit 11 ; }
+          sha256sum ${PRODUCT}-${VERSION}-${RELEASE}.${{ matrix.dist.name }}.${{ matrix.dist.arch }}.deb | tee ${PRODUCT}-${VERSION}-${RELEASE}.${{ matrix.dist.name }}.${{ matrix.dist.arch }}.deb.sha256sum
+      - name: Artifact Upload
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.PRODUCT }}-${{ env.VER_INFO }}-artifact-${{ matrix.dist.name }}-${{ matrix.dist.arch }}
+          path: |
+            ${{ github.workspace }}/build/${{ env.PRODUCT }}-*-${{ env.RELEASE }}.${{ matrix.dist.name }}.${{ matrix.dist.arch }}.deb
+            ${{ github.workspace }}/build/${{ env.PRODUCT }}-*-${{ env.RELEASE }}.${{ matrix.dist.name }}.${{ matrix.dist.arch }}.deb.sha256sum
+          overwrite: true
+
 #   rpm-pack:
 #     name: Build rpm on ${{ matrix.dist.name }} ${{ matrix.dist.arch }}
 #     runs-on: ubuntu-latest
@@ -403,7 +403,7 @@ jobs:
       - name: Setup Flathub
         run: |
           flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
-          flatpak install -y --noninteractive flathub org.kde.Sdk//5.15 org.kde.Platform//5.15
+          flatpak install -y --noninteractive flathub org.kde.Sdk//6.9 org.kde.Platform//6.9
       - name: Packaging flatpak
         run: |
           BUNDLE="org.flameshot.Flameshot_${VERSION}_x86_64.flatpak"

--- a/README.md
+++ b/README.md
@@ -443,13 +443,13 @@ apt install git openssl ca-certificates qt6-image-formats-plugins
 
 ```shell
 # Compile-time
-dnf install gcc-c++ cmake qt5-qtbase-devel qt5-linguist
+dnf install gcc-c++ cmake qt6-qtbase-devel qt6-qtsvg-devel qt6-qttools qt6-linguist
 
 # Run-time
-dnf install qt5-qtbase qt5-qtsvg-devel
+dnf install qt6-qtbase qt6-qtsvg
 
 # Optional
-dnf install git openssl ca-certificates
+dnf install git openssl ca-certificates qt6-qtimageformats
 ```
 
 #### Arch

--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ Also you can open and build/debug the project in a C++ IDE. For example, in Qt C
 
 #### Compile-time
 
-- Qt >= 5.9
+- Qt >= 6.0
   + Development tools
 - GCC >= 7.4
 - CMake >= 3.29
@@ -424,18 +424,19 @@ Also you can open and build/debug the project in a C++ IDE. For example, in Qt C
 - Git
 - OpenSSL
 - CA Certificates
+- Qt Image Formats - for additional export image formats (e.g. tiff, webp, and more)
 
 #### Debian
 
 ```shell
 # Compile-time
-apt install g++ cmake build-essential qtbase5-dev qttools5-dev-tools libqt5svg5-dev qttools5-dev
+apt install g++ cmake build-essential qt6-base-dev qt6-tools-dev-tools qt6-svg-dev qt6-tools-dev
 
 # Run-time
-apt install libqt5dbus5 libqt5network5 libqt5core5a libqt5widgets5 libqt5gui5 libqt5svg5
+apt install libqt6dbus6 libqt6network6 libqt6core6 libqt6widgets6 libqt6gui6 libqt6svg6
 
 # Optional
-apt install git openssl ca-certificates
+apt install git openssl ca-certificates qt6-image-formats-plugins
 ```
 
 #### Fedora
@@ -455,13 +456,13 @@ dnf install git openssl ca-certificates
 
 ```shell
 # Compile-time
-pacman -S cmake base-devel git qt5-base qt5-tools
+pacman -S cmake base-devel git qt6-base qt6-tools
 
 # Run-time
-pacman -S qt5-svg
+pacman -S qt6-svg
 
 # Optional
-pacman -S openssl ca-certificates
+pacman -S openssl ca-certificates qt6-imageformats
 ```
 
 #### NixOS
@@ -474,7 +475,7 @@ nix-shell
 
 First of all you need to install [brew](https://brew.sh) and then install the dependencies
 ```shell
-brew install qt5
+brew install qt6
 brew install cmake
 ```
 
@@ -503,7 +504,7 @@ cmake -S . -B "$BUILD_DIR" \
 
 #MacOS
 cmake -S . -B "$BUILD_DIR" \
-    -DQt5_DIR="$(brew --prefix qt5)/lib/cmake/Qt5" \
+    -DQt6_DIR="$(brew --prefix qt6)/lib/cmake/Qt6" \
     && cmake --build "$BUILD_DIR"
 ```
 

--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -5,10 +5,10 @@ Maintainer: Boyuan Yang <byang@debian.org>
 Build-Depends:
  cmake (>= 3.13~),
  debhelper (>= 11),
- qt6-base-dev (>= 6.4.0~),
- qt6-tools-dev (>= 6.4.0~),
- qt6-tools-dev-tools (>= 6.4.0~),
- qt6-svg-dev (>= 6.4.0~),
+ qt6-base-dev (>= 6.2.0~),
+ qt6-tools-dev (>= 6.2.0~),
+ qt6-tools-dev-tools (>= 6.2.0~),
+ qt6-svg-dev (>= 6.2.0~),
 Standards-Version: 4.5.0
 Homepage: https://github.com/flameshot-org/flameshot
 Vcs-Browser: https://github.com/flameshot-org/flameshot
@@ -18,7 +18,7 @@ Package: flameshot
 Architecture: any
 Depends:
  hicolor-icon-theme,
- libqt6svg6 (>= 6.4.0~),
+ libqt6svg6 (>= 6.2.0~),
  ${shlibs:Depends},
  ${misc:Depends},
 Recommends:

--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -27,6 +27,7 @@ Recommends:
 Suggests:
  ca-certificates,
  openssl,
+ qt6-image-formats-plugins,
 Description: Powerful yet simple-to-use screenshot software
  Flameshot is a powerful yet simple-to-use screenshot software.
  Notable features include customizable appearance, in-app screenshot editing,

--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -5,10 +5,10 @@ Maintainer: Boyuan Yang <byang@debian.org>
 Build-Depends:
  cmake (>= 3.13~),
  debhelper (>= 11),
- qtbase5-dev (>= 5.9.0~),
- qttools5-dev (>= 5.9.0~),
- qttools5-dev-tools (>= 5.9.0~),
- libqt5svg5-dev (>= 5.9.0~),
+ qt6-base-dev (>= 6.4.0~),
+ qt6-tools-dev (>= 6.4.0~),
+ qt6-tools-dev-tools (>= 6.4.0~),
+ qt6-svg-dev (>= 6.4.0~),
 Standards-Version: 4.5.0
 Homepage: https://github.com/flameshot-org/flameshot
 Vcs-Browser: https://github.com/flameshot-org/flameshot
@@ -18,7 +18,7 @@ Package: flameshot
 Architecture: any
 Depends:
  hicolor-icon-theme,
- libqt5svg5 (>= 5.9.0~),
+ libqt6svg6 (>= 6.4.0~),
  ${shlibs:Depends},
  ${misc:Depends},
 Recommends:

--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -13,8 +13,6 @@ export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 # package maintainers to append LDFLAGS
 export DEB_LDFLAGS_MAINT_APPEND = -Wl,--as-needed
 
-export QT_SELECT := 5
-
 %:
 	dh $@ 
 

--- a/packaging/rpm/fedora/flameshot.spec
+++ b/packaging/rpm/fedora/flameshot.spec
@@ -16,21 +16,22 @@ BuildRequires: libappstream-glib
 BuildRequires: ninja-build
 BuildRequires: desktop-file-utils
 
-BuildRequires: cmake(Qt5Core) >= 5.9.0
-BuildRequires: cmake(KF5GuiAddons) >= 5.89.0
-BuildRequires: cmake(Qt5DBus) >= 5.9.0
-BuildRequires: cmake(Qt5Gui) >= 5.9.0
-BuildRequires: cmake(Qt5LinguistTools) >= 5.9.0
-BuildRequires: cmake(Qt5Network) >= 5.9.0
-BuildRequires: cmake(Qt5Svg) >= 5.9.0
-BuildRequires: cmake(Qt5Widgets) >= 5.9.0
+BuildRequires: cmake(Qt6Core) >= 6.0.0
+BuildRequires: cmake(KF6GuiAddons) >= 6.7.0
+BuildRequires: cmake(Qt6DBus) >= 6.0.0
+BuildRequires: cmake(Qt6Gui) >= 6.0.0
+BuildRequires: cmake(Qt6LinguistTools) >= 6.0.0
+BuildRequires: cmake(Qt6Network) >= 6.0.0
+BuildRequires: cmake(Qt6Svg) >= 6.0.0
+BuildRequires: cmake(Qt6Widgets) >= 6.0.0
 
 
 Requires: hicolor-icon-theme
-Requires: qt5-qtbase >= 5.9.0
-Requires: qt5-qttools >= 5.9.0
-Requires: qt5-qtsvg%{?_isa} >= 5.9.0
+Requires: qt6-qtbase >= 6.0.0
+Requires: qt6-qttools >= 6.0.0
+Requires: qt6-qtsvg >= 6.0.0
 
+Recommends: qt6-qtimageformats
 Recommends: xdg-desktop-portal%{?_isa}
 Recommends: (xdg-desktop-portal-gnome%{?_isa} if gnome-shell%{?_isa})
 Recommends: (xdg-desktop-portal-kde%{?_isa} if plasma-workspace-wayland%{?_isa})

--- a/packaging/rpm/opensuse/flameshot.spec
+++ b/packaging/rpm/opensuse/flameshot.spec
@@ -16,20 +16,21 @@ BuildRequires: update-desktop-files
 BuildRequires: appstream-glib
 BuildRequires: desktop-file-utils
 
-BuildRequires: cmake(Qt5Core) >= 5.9.0
-BuildRequires: cmake(Qt5DBus) >= 5.9.0
-BuildRequires: cmake(Qt5Gui) >= 5.9.0
-BuildRequires: cmake(Qt5LinguistTools) >= 5.9.0
-BuildRequires: cmake(Qt5Network) >= 5.9.0
-BuildRequires: cmake(Qt5Svg) >= 5.9.0
-BuildRequires: cmake(Qt5Widgets) >= 5.9.0
+BuildRequires: cmake(Qt6Core) >= 6.0.0
+BuildRequires: cmake(Qt6DBus) >= 6.0.0
+BuildRequires: cmake(Qt6Gui) >= 6.0.0
+BuildRequires: cmake(Qt6LinguistTools) >= 6.0.0
+BuildRequires: cmake(Qt6Network) >= 6.0.0
+BuildRequires: cmake(Qt6Svg) >= 6.0.0
+BuildRequires: cmake(Qt6Widgets) >= 6.0.0
 
 
 Requires: hicolor-icon-theme
-Requires: libQt5Core5 >= 5.9.0
-Requires: libqt5-qttools >= 5.9.0
-Requires: libQt5Svg5 >= 5.9.0
+Requires: qt6-base >= 6.0.0
+Requires: qt6-tools >= 6.0.0
+Requires: qt6-svg >= 6.0.0
 
+Recommends: qt6-imageformats
 Recommends: xdg-desktop-portal%{?_isa}
 Recommends: (xdg-desktop-portal-gnome%{?_isa} if gnome-shell%{?_isa})
 Recommends: (xdg-desktop-portal-kde%{?_isa} if plasma-workspace-wayland%{?_isa})


### PR DESCRIPTION
My changes so far:
- Removed Debian 11 and opensuse-leap-15.6, as they don't support Qt 6 - if I am not wrong.
- According to the [setup-qemu-action manual](https://github.com/docker/setup-qemu-action) the qemu action must be before Buildx, otherwise Buildx may not use the correct platform architecture.
- Add 'Qt Image Formats' package as optional/recommended
- Update README to Qt 6 (please somebody review it!)

The packages are successfully built except for Ubuntu 22.04 (same for the ARM builds) - I have no idea yet, why it fails for 22.04. If anybody has an idea, would be great! Is there any possibility to get more debug output why the build fails? It seems something is wrong with dependencies, but what?

I tested the Fedora 42 and Ubuntu 24.04 package in a VirtualBox VM. On Ubunut 24.04, the installation and taking screenshots works (after providing screenshot permission).
When trying to install the package in Fedora, I get the following:
```
Failed to resolve the transaction:
Problem: conflicting requirements
  - nothing provides libQtColorWidgets.so.2()(64bit), this is required by flameshot-12.1.0-1.fc42.x86_64 from @commandline
You can try adding the following to the command line:
  --skip-broken to skip uninstallable packages
```

Support is highly welcome 🙂