### PR TITLE
Enable Singleapplication again

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,11 +119,11 @@ enable_sanitizers(project_options)
 
 # allow for static analysis options include(cmake/StaticAnalyzers.cmake)
 
-set(QAPPLICATION_CLASS
-        QApplication
-        CACHE STRING "Inheritance class for SingleApplication")
-
 if(USE_SINGLEAPPLICATION)
+  set(QAPPLICATION_CLASS
+          QApplication
+          CACHE STRING "Inheritance class for SingleApplication")
+
   FetchContent_Declare(
       singleApplication
       GIT_REPOSITORY https://github.com/itay-grudev/SingleApplication.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,7 @@ set(RUN_IN_PLACE
 option(FLAMESHOT_DEBUG_CAPTURE "Enable mode to make debugging easier" OFF)
 option(USE_MONOCHROME_ICON "Build using monochrome icon as default" OFF)
 option(GENERATE_TS "Regenerate translation source files" OFF)
-option(USE_EXTERNAL_SINGLEAPPLICATION "Use external QtSingleApplication library" OFF)
+option(USE_SINGLEAPPLICATION "Use SingleApplication library" ON)
 option(USE_LAUNCHER_ABSOLUTE_PATH "Use absolute path for the desktop launcher" ON)
 option(USE_WAYLAND_CLIPBOARD "USE KF Gui Wayland Clipboard" OFF)
 option(DISABLE_UPDATE_CHECKER "Disable check for updates" OFF)
@@ -123,20 +123,13 @@ set(QAPPLICATION_CLASS
         QApplication
         CACHE STRING "Inheritance class for SingleApplication")
 
-if(USE_EXTERNAL_SINGLEAPPLICATION)
-  # look for external QtSingleApplication
-  # package dev-qt/qtsingleapplication provides no symlink to current version
-  set(qtsingleapplication_libs libQt5Solutions_SingleApplication-2.6 Qt5Solutions_SingleApplication-2.6)
-  find_library(QTSINGLEAPPLICATION_LIBRARY NAMES ${qtsingleapplication_libs})
-  message(STATUS "Using external QtSingleApplication library")
-else()
+if(USE_SINGLEAPPLICATION)
   FetchContent_Declare(
       singleApplication
       GIT_REPOSITORY https://github.com/itay-grudev/SingleApplication.git
       GIT_TAG v3.5.2
   )
   FetchContent_MakeAvailable(SingleApplication)
-  set(QTSINGLEAPPLICATION_LIBRARY SingleApplication::SingleApplication)
 endif()
 
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -206,9 +206,7 @@ target_include_directories(
          )
 
 
-if (USE_EXTERNAL_SINGLEAPPLICATION)
-    add_compile_definitions(USE_EXTERNAL_SINGLEAPPLICATION=1)
-else ()
+if (USE_SINGLEAPPLICATION)
     target_include_directories(
         flameshot
         PUBLIC
@@ -223,9 +221,15 @@ target_link_libraries(
         Qt${QT_VERSION_MAJOR}::DBus
         Qt${QT_VERSION_MAJOR}::Network
         Qt${QT_VERSION_MAJOR}::Widgets
-        ${QTSINGLEAPPLICATION_LIBRARY}
         QtColorWidgets
 )
+
+if (USE_SINGLEAPPLICATION)
+  target_link_libraries(
+          flameshot
+          SingleApplication::SingleApplication
+  )
+endif()
 
 if (USE_WAYLAND_CLIPBOARD)
   target_compile_definitions(flameshot PRIVATE USE_WAYLAND_CLIPBOARD=1)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -153,9 +153,6 @@ endif ()
 target_sources(
         flameshot
         PRIVATE
-        # ${CMAKE_CURRENT_SOURCE_DIR}/../external/Qt-Color-Widgets/src/QtColorWidgets/color_utils.cpp
-        # ${CMAKE_CURRENT_SOURCE_DIR}/../external/Qt-Color-Widgets/src/QtColorWidgets/color_wheel.cpp
-        # ${CMAKE_CURRENT_SOURCE_DIR}/../external/Qt-Color-Widgets/include/QtColorWidgets/color_wheel.hpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../data/graphics.qrc
         ${CMAKE_CURRENT_SOURCE_DIR}/../data/flameshot.rc # windows binary icon resource file
         ${QM_FILES}
@@ -165,7 +162,6 @@ target_include_directories(
   flameshot
   PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../>
          $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/>
-         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../external/Qt-Color-Widgets/include>
          $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../dbus/>
          $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/cli>
          $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/config>
@@ -205,16 +201,6 @@ target_include_directories(
          $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/>
          )
 
-
-if (USE_SINGLEAPPLICATION)
-  message(STATUS "SingleApplication is used!")
-  add_compile_definitions(USE_SINGLEAPPLICATION=1)
-  target_include_directories(
-      flameshot
-      PUBLIC
-      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../external/singleapplication>)
-endif()
-
 target_link_libraries(
         flameshot
         project_warnings
@@ -227,6 +213,8 @@ target_link_libraries(
 )
 
 if (USE_SINGLEAPPLICATION)
+  message(STATUS "SingleApplication is used!")
+  add_compile_definitions(USE_SINGLEAPPLICATION=1)
   target_link_libraries(
           flameshot
           SingleApplication::SingleApplication

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -207,10 +207,12 @@ target_include_directories(
 
 
 if (USE_SINGLEAPPLICATION)
-    target_include_directories(
-        flameshot
-        PUBLIC
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../external/singleapplication>)
+  message(STATUS "SingleApplication is used!")
+  add_compile_definitions(USE_SINGLEAPPLICATION=1)
+  target_include_directories(
+      flameshot
+      PUBLIC
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../external/singleapplication>)
 endif()
 
 target_link_libraries(

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,10 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // SPDX-FileCopyrightText: 2017-2019 Alejandro Sirgo Rica & Contributors
 
-#ifndef USE_EXTERNAL_SINGLEAPPLICATION
+#ifdef USE_SINGLEAPPLICATION
 #include "singleapplication.h"
-#else
-#include "QtSolutions/qtsingleapplication.h"
 #endif
 
 #include "abstractlogger.h"
@@ -129,12 +127,12 @@ int main(int argc, char* argv[])
 
     // no arguments, just launch Flameshot
     if (argc == 1) {
-        //  #ifndef USE_EXTERNAL_SINGLEAPPLICATION
-        //          SingleApplication app(argc, argv);
-        //  #else
-        //          QtSingleApplication app(argc, argv);
-        //  #endif
+#ifdef USE_SINGLEAPPLICATION
+        SingleApplication app(argc, argv);
+#else
         QApplication app(argc, argv);
+#endif
+
         configureApp(true);
         auto c = Flameshot::instance();
         FlameshotDaemon::start();


### PR DESCRIPTION
As mentioned in the [v13 Readiness discussion](https://github.com/flameshot-org/flameshot/discussions/4012#discussioncomment-13502680), Singleapplication can be enabled again, as the main issue in the Qt6 version only occurs when the application is crashing - which should not happen during normal operation!

I removed the option for the deprecated 'Qt5Solutions SingleApplication' and instead made the 'SingleApplication' optional, but enabled by default.