### PR TITLE
Remove StrftimeChooserWidget button layout creation constraints

### DIFF
--- a/src/config/strftimechooserwidget.cpp
+++ b/src/config/strftimechooserwidget.cpp
@@ -9,27 +9,33 @@
 StrftimeChooserWidget::StrftimeChooserWidget(QWidget* parent)
   : QWidget(parent)
 {
+    const quint8 MAXCOLUMNS = 2;
     auto* layout = new QGridLayout(this);
-    auto k = m_buttonData.keys();
-    int middle = k.length() / 2;
-    // add the buttons in 2 columns (they need to be even)
-    for (int i = 0; i < 2; i++) {
-        for (int j = 0; j < middle; j++) {
-            QString key = k.last();
-            k.pop_back();
-            QString variable = m_buttonData.value(key);
-            auto* button = new QPushButton(this);
-            button->setText(tr(key.toStdString().data()));
-            button->setToolTip(variable);
-            button->setSizePolicy(QSizePolicy::Expanding,
-                                  QSizePolicy::Expanding);
-            button->setMinimumHeight(25);
-            layout->addWidget(button, j, i);
-            connect(button, &QPushButton::clicked, this, [variable, this]() {
-                emit variableEmitted(variable);
-            });
+    quint8 row = 0;
+    quint8 col = 0;
+    QMapIterator<QString, QString> iterator(m_buttonData);
+
+    while (iterator.hasNext()) {
+        iterator.next();
+
+        QString variable = iterator.value();
+        auto* button = new QPushButton(this);
+        button->setText(tr(iterator.key().toStdString().data()));
+        button->setToolTip(variable);
+        button->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+        button->setMinimumHeight(25);
+        layout->addWidget(button, row, col);
+        connect(button, &QPushButton::clicked, this, [variable, this]() {
+            emit variableEmitted(variable);
+        });
+
+        col++;
+        if (col >= MAXCOLUMNS) {
+            row++;
+            col = 0;
         }
     }
+
     setLayout(layout);
 }
 


### PR DESCRIPTION
Currently there is a constraint, that `m_buttonData` must have even number of items:
https://github.com/flameshot-org/flameshot/blob/172d561fb877c4d5aa7ecdf74230576a94ab1263/src/config/strftimechooserwidget.cpp#L13-L16

This PR makes StrftimeChooserWidget button layout creation independent if number of buttons is even or odd.

This refers e.g. to #3710, which adds a new entry and discussion about the even/odd number of items started.