### PR TITLE
Support for X11 and the standard file picker.

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -27,8 +27,6 @@ apps:
       - kde-neon-6
     environment:
       XDG_DATA_DIRS: $SNAP/share:$XDG_DATA_DIRS
-      QT_QPA_PLATFORM: wayland
-      QT_QPA_PLATFORMTHEME: gtk3
     slots: [dbus-flameshot]
     plugs:
       - home


### PR DESCRIPTION
A small change to make Flameshot Snap work on Xorg.

This also allows Flameshot to open the default file picker for the interface you are in.