### PR TITLE
Add gnome-based wayland universal screenshot adapter

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -229,6 +229,14 @@ if (USE_WAYLAND_CLIPBOARD)
   target_link_libraries(flameshot KF6::GuiAddons)
 endif()
 
+if(USE_WAYLAND_GNOME)
+    target_compile_definitions(flameshot PRIVATE USE_WAYLAND_GNOME=1)
+endif()
+
+if (USE_WAYLAND_GRIM)
+    target_compile_definitions(flameshot PRIVATE USE_WAYLAND_GRIM=1)
+endif()
+
 if (APPLE)
     set_target_properties(flameshot PROPERTIES
         MACOSX_BUNDLE TRUE

--- a/src/utils/screengrabber.h
+++ b/src/utils/screengrabber.h
@@ -17,6 +17,7 @@ public:
     QPixmap grabScreen(QScreen* screenNumber, bool& ok);
     void freeDesktopPortal(bool& ok, QPixmap& res);
     void generalGrimScreenshot(bool& ok, QPixmap& res);
+    void generalGnomeScreenshot(bool& ok, QPixmap& res);
     QRect desktopGeometry();
     QRect logicalDesktopGeometry();
 


### PR DESCRIPTION
Rebasing #3215  for @Kyuyrii  to test. Still needs to be reviewed and tested more. 


By default, flameshot uses the program's default dbus protocol interface to communicate with gnome's screenshot protocol, but this is now broken on some gnome installations, so we'll use gnome-screenshot as gnome's wayland screenshot adapter and then communicate directly with the gnome screenshot component!

To enable the GNOME-based generic wayland screenshot adapter, enable it using the following cmake parameter:

```
-DUSE_WAYLAND_GNOME=true
```