### PR TITLE
Link to translations folder

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -70,3 +70,7 @@ slots:
     interface: dbus
     bus: session
     name: org.flameshot.Flameshot
+
+layout:
+  /usr/share/flameshot/translations:
+    symlink: $SNAP/usr/share/flameshot/translations


### PR DESCRIPTION
This modification allows Flameshot Snap to find the translation files.