### PR TITLE
Support niri

### DIFF
--- a/src/utils/desktopinfo.cpp
+++ b/src/utils/desktopinfo.cpp
@@ -47,6 +47,9 @@ DesktopInfo::WM DesktopInfo::windowManager()
         if (desktop.contains(QLatin1String("cosmic"))) {
             return DesktopInfo::COSMIC;
         }
+        if (desktop.contains(QLatin1String("niri"))) {
+            return DesktopInfo::NIRI;
+        }
     }
 
     if (!GNOME_DESKTOP_SESSION_ID.isEmpty()) {

--- a/src/utils/desktopinfo.h
+++ b/src/utils/desktopinfo.h
@@ -15,6 +15,7 @@ public:
         GNOME,
         KDE,
         COSMIC,
+        NIRI,
         OTHER,
         QTILE,
         WLROOTS,

--- a/src/utils/screengrabber.cpp
+++ b/src/utils/screengrabber.cpp
@@ -164,6 +164,7 @@ QPixmap ScreenGrabber::grabEntireDesktop(bool& ok)
             case DesktopInfo::QTILE:
             case DesktopInfo::WLROOTS:
             case DesktopInfo::HYPRLAND:
+            case DesktopInfo::NIRI:
             case DesktopInfo::OTHER: {
                 if (!ConfigHandler().useGrimAdapter()) {
                     if (!ConfigHandler().disabledGrimWarning()) {


### PR DESCRIPTION
Closes #3605 - hopefully.

`niri` is a Wayland compositor. It's already supported if you lie to flameshot and tell it you're running `sway`, even though `niri` is not wlroots-based like sway is.

This PR hopes to make flameshot work in `niri` out of the box by simply treating `niri` like "qtile", "wlroots", "hyprland" and "other".
Alternately if flameshot just detected `niri` as "other" I would think it should also work, but right now in screengrabber.cpp it ends up in the default case, printing the error:
```
Unable to detect desktop environment (GNOME? KDE? Sway? ...)
```
...so it seems to me it's not treated as part of the "other" category in that file at the moment?

I have not tested this PR, so beware.