### PR TITLE
revert accidental removal of window title introduced by #3766

### DIFF
--- a/src/tools/pin/pinwidget.cpp
+++ b/src/tools/pin/pinwidget.cpp
@@ -40,6 +40,7 @@ PinWidget::PinWidget(const QPixmap& pixmap,
     setFocusPolicy(Qt::StrongFocus);
     setAttribute(Qt::WA_TranslucentBackground);
     setAttribute(Qt::WA_DeleteOnClose);
+    setWindowTitle("flameshot-pin");
     ConfigHandler conf;
     m_baseColor = conf.uiColor();
     m_hoverColor = conf.contrastUiColor();


### PR DESCRIPTION
This feature initially introduced by #3766 but was removed in 58afdce7414bbe3881610042e4da3772d2d0365f. This can help configuring Flameshot in window managers in a more granular level.

@borgmanJeremy if this removal was intentional, please close this PR, but considering that it plays nicely with Qt6 as far as my testing goes, I'm proposing it back.