### PR TITLE
Qt 6 - Windows issues loading dis-/enabled tool buttons (fix for #4077)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -31,6 +31,9 @@
 #include <desktopinfo.h>
 #endif
 
+// Required for saving button list QList<CaptureTool::Type>
+Q_DECLARE_METATYPE(QList<int>)
+
 int requestCaptureAndWait(const CaptureRequest& req)
 {
     Flameshot* flameshot = Flameshot::instance();
@@ -134,6 +137,9 @@ void reinitializeAsQApplication(int& argc, char* argv[])
 
 int main(int argc, char* argv[])
 {
+    // Required for saving button list QList<CaptureTool::Type>
+    qRegisterMetaType<QList<int>>();
+
     QCoreApplication::setApplicationVersion(APP_VERSION);
     QCoreApplication::setApplicationName(QStringLiteral("flameshot"));
     QCoreApplication::setOrganizationName(QStringLiteral("flameshot"));


### PR DESCRIPTION
This PR fixes #4077 

I doubled checked it with the old Qt 5 build and dis-/enabling tool buttons worked on Windows. With Qt 6 loading the saved configuration didn't work anymore and debug console output was showing: "QVariant::load: unknown user type with name QList<int>."

There must have been changes in the Qt meta-type system and platform-specific differences. QList<int> is not a built-in QVariant type. To use custom types we need to register them using Q_DECLARE_METATYPE(QList<int>) and qRegisterMetaType<QList<int>>().

In Qt 5, handling of QList<T> was more permissive, so QList<int> sometimes worked without explicit registration. Starting with Qt 6, the meta-type system has become stricter and does not recognize QList<int> natively anymore. This causes the type to be unknown when deserializing (e.g. from QSettings), unless explicitly registered.

I couldn't find clear explanation for the differences on Windows and Linux, but AI mentioned: "The Qt build configuration or available precompiled meta-types can differ between Windows and Linux, which is why the problem only appears on one platform."

I tested this PR on Windows and on Manjaro and it worked on both systems, so I'd say we don't need explicit `#if defined(Q_OS_WIN)`.