### PR TITLE
Update shell.nix for QT6

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -3,9 +3,8 @@
 pkgs.mkShell {
   nativeBuildInputs = with pkgs; [
     cmake
-    qt5.full
-    qt5.qttools
-    qt5.qtsvg
+    kdePackages.qtsvg
+    kdePackages.qttools
   ];
-  buildInputs = with pkgs; [ qt5.qtbase libsForQt5.kguiaddons ];
+  buildInputs = with pkgs; [ kdePackages.qtbase kdePackages.kguiaddons ];
 }


### PR DESCRIPTION
The namespace for qt6 is `kdePackages` instead of `libsForQt5`