### PR TITLE
fix linting errors for flathub

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,28 +6,6 @@ set(FLAMESHOT_VERSION 13.0.0)
 # Flameshot-org
 set(GIT_API_URL "https://api.github.com/repos/flameshot-org/flameshot/releases/latest")
 
-# TODO - fix it for all linux distros
-#find_package (Git)
-#if (GIT_FOUND)
-#  message("git found: ${GIT_EXECUTABLE} in version     ${GIT_VERSION_STRING}")
-#
-#  # set flameshot updates url
-#  execute_process(COMMAND ${GIT_EXECUTABLE} ls-remote --get-url OUTPUT_VARIABLE GIT_ORIGIN_REMOTE)
-#  message("GIT_ORIGIN_REMOTE: ${GIT_ORIGIN_REMOTE}")
-#  string(REGEX REPLACE ".git\r*\n*$" "/releases/latest" GIT_API_URL ${GIT_ORIGIN_REMOTE})
-#  string(REGEX REPLACE "^.*:" "https://api.github.com/repos/" GIT_API_URL ${GIT_API_URL})
-#  message("GIT_API_URL: '${GIT_API_URL}'")
-#
-#  # get application version
-#  execute_process(COMMAND ${GIT_EXECUTABLE} describe --tags --abbrev=0 --match v[0-9]* OUTPUT_VARIABLE FLAMESHOT_VERSION)
-#  string(REGEX REPLACE "\r" "" FLAMESHOT_VERSION ${FLAMESHOT_VERSION})
-#  string(REGEX REPLACE "\n" "" FLAMESHOT_VERSION ${FLAMESHOT_VERSION})
-#  string(REGEX REPLACE "^v" "" FLAMESHOT_VERSION ${FLAMESHOT_VERSION})
-#  message("FLAMESHOT_VERSION: '${FLAMESHOT_VERSION}'")
-#else()
-#  message("git command is not found")
-#endif ()
-
 project(
         flameshot
         VERSION ${FLAMESHOT_VERSION}
@@ -46,23 +24,27 @@ option(BUILD_SHARED_LIBS OFF)
 #Needed due to linker error with QtColorWidget
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-FetchContent_Declare(
-    qtColorWidgets
-    GIT_REPOSITORY https://gitlab.com/mattbas/Qt-Color-Widgets.git
-    GIT_TAG 352bc8f99bf2174d5724ee70623427aa31ddc26a
-)
 
-#Workaround for duplicate GUID in windows WIX installer
-if (WIN32)
-    FetchContent_GetProperties(qtColorWidgets)
-    if(NOT qtcolorwidgets_POPULATED)
-        FetchContent_Populate(qtColorWidgets)
-        add_subdirectory(${qtcolorwidgets_SOURCE_DIR} ${qtcolorwidgets_BINARY_DIR} EXCLUDE_FROM_ALL)
-    endif()
+# Dependenccy can be fetched via flatpak builder
+if(EXISTS "${CMAKE_SOURCE_DIR}/external/Qt-Color-Widgets/CMakeLists.txt")
+    add_subdirectory("${CMAKE_SOURCE_DIR}/external/Qt-Color-Widgets" EXCLUDE_FROM_ALL)
 else()
-    FetchContent_MakeAvailable(qtColorWidgets)
+    FetchContent_Declare(
+        qtColorWidgets
+        GIT_REPOSITORY https://gitlab.com/mattbas/Qt-Color-Widgets.git
+        GIT_TAG 352bc8f99bf2174d5724ee70623427aa31ddc26a
+    )
+  #Workaround for duplicate GUID in windows WIX installer
+  if (WIN32)
+      FetchContent_GetProperties(qtColorWidgets)
+      if(NOT qtcolorwidgets_POPULATED)
+          FetchContent_Populate(qtColorWidgets)
+          add_subdirectory(${qtcolorwidgets_SOURCE_DIR} ${qtcolorwidgets_BINARY_DIR} EXCLUDE_FROM_ALL)
+      endif()
+  else()
+      FetchContent_MakeAvailable(qtColorWidgets)
+  endif()
 endif()
-
 
 # This can be read from ${PROJECT_NAME} after project() is called
 if (APPLE)
@@ -129,12 +111,17 @@ if (USE_KDSINGLEAPPLICATION)
   set(KDSingleApplication_EXAMPLES OFF CACHE BOOL "Don't build the examples")
   set(KDSingleApplication_STATIC ON CACHE BOOL "Build static versions of the libraries")
 
-  FetchContent_Declare(
-      kdsingleApplication
-      GIT_REPOSITORY https://github.com/KDAB/KDSingleApplication.git
-      GIT_TAG v1.2.0
-  )
-  FetchContent_MakeAvailable(KDSingleApplication)
+  # Check if KDSingleApplication is available locally
+  if(EXISTS "${CMAKE_SOURCE_DIR}/external/KDSingleApplication/CMakeLists.txt")
+    add_subdirectory("${CMAKE_SOURCE_DIR}/external/KDSingleApplication")
+  else()
+    FetchContent_Declare(
+        kdsingleApplication
+        GIT_REPOSITORY https://github.com/KDAB/KDSingleApplication.git
+        GIT_TAG v1.2.0
+    )
+    FetchContent_MakeAvailable(KDSingleApplication)
+  endif()
 endif()
 
 # ToDo: Check if this is used anywhere

--- a/packaging/flatpak/org.flameshot.Flameshot.yml
+++ b/packaging/flatpak/org.flameshot.Flameshot.yml
@@ -6,7 +6,7 @@ command: flameshot
 finish-args:
   # X11 + XShm access
   - --share=ipc
-  - --socket=x11
+  - --socket=fallback-x11
   # Wayland access
   - --socket=wayland
   - --device=dri
@@ -15,27 +15,34 @@ finish-args:
   # QtSingleApplication, allow other instances to see log files
   - --env=TMPDIR=/var/tmp
   # Allow loading/saving files from anywhere
-  - --filesystem=host
+  - --filesystem=xdg-pictures
   # Notification access
   - --talk-name=org.freedesktop.Notifications
   # System Tray Icon
   - --talk-name=org.kde.StatusNotifierWatcher
-  - --own-name=org.kde.*
-  - --own-name=org.flameshot.Flameshot
 modules:
   - name: flameshot
     buildsystem: cmake-ninja
-    build-options:
-      build-args:
-        - --share=network
     config-opts:
       - -DCMAKE_BUILD_TYPE=Release 
       - -DUSE_WAYLAND_CLIPBOARD=1
     sources:
-    # Keep this in until qt6 is merged to master branch. Makes it easy to test flatpak dev builds
-    # Change the path to the location of the cloned flameshot repo
-      #- type: dir 
-      #  path: /path/to/repo
+      - type: git
+        url: https://gitlab.com/mattbas/Qt-Color-Widgets.git
+        commit: 352bc8f99bf2174d5724ee70623427aa31ddc26a
+        dest: external/Qt-Color-Widgets
+
+      - type: git
+        url: https://github.com/KDAB/KDSingleApplication.git
+        tag: v1.2.0
+        dest: external/KDSingleApplication
+
       - type: git
         url: https://github.com/flameshot-org/flameshot.git
         branch: master
+        #tag: v13.0.0
+
+    cleanup:
+      - /share/bash-completion
+      - /share/man
+      - /share/zsh


### PR DESCRIPTION
This fixes the linting errors encountered when pushing v13 to flathub. One of the main issues was flathub does not allow network calls during the build so the dependencies must be fetched and CMake must accomodate both options. 