### PR TITLE
Another fix for savePath slashes on Windows

### DIFF
--- a/src/utils/screenshotsaver.cpp
+++ b/src/utils/screenshotsaver.cpp
@@ -268,6 +268,9 @@ bool saveToFilesystemGUI(const QPixmap& capture)
         AbstractLogger().attachNotificationPath(savePath) << msg;
 
         if (config.copyPathAfterSave()) {
+#ifdef Q_OS_WIN
+            savePath.replace('/', '\\');
+#endif
             FlameshotDaemon::copyToClipboard(
               savePath, QObject::tr("Path copied to clipboard as ") + savePath);
         }


### PR DESCRIPTION
With my changes in PR #4027 and #3997 I reverted the changes from #3136... See issue #3135, which reoccurred after the release of v13.
I would recommend keeping the Qt default '/' in paths wherever possible, and only converting to '\\' for Windows when it is really necessary (Windows can often handle '/' as well).