### PR TITLE
Fix multi monitor offset bug in Qt6 multi-monitor setups

### DIFF
--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -155,7 +155,11 @@ CaptureWidget::CaptureWidget(const CaptureRequest& req,
 #if !defined(FLAMESHOT_DEBUG_CAPTURE)
         setWindowFlags(Qt::BypassWindowManagerHint | Qt::WindowStaysOnTopHint |
                        Qt::FramelessWindowHint | Qt::Tool);
-        resize(pixmap().size());
+        // Fix for Qt6 dual monitor offset: position widget to cover entire
+        // desktop
+        QRect desktopGeom = ScreenGrabber().desktopGeometry();
+        move(desktopGeom.topLeft());
+        resize(desktopGeom.size());
 #endif
 #endif
     }
@@ -289,7 +293,7 @@ CaptureWidget::~CaptureWidget()
         Flameshot::instance()->exportCapture(
           pixmap(), geometry, m_context.request);
     } else {
-        emit Flameshot::instance()->captureFailed();
+        emit Flameshot::instance() -> captureFailed();
     }
 }
 


### PR DESCRIPTION
The issue was caused by using QApplication::primaryScreen() to capture the entire desktop, but in Qt6 the primary screen is not necessarily the leftmost screen. This caused coordinate system misalignment in multi-monitor setups where the primary screen is positioned to the right.

Additionally, the previous approach failed in edge cases where screens have different heights and the desktop bounding box includes virtual space that doesn't correspond to any physical screen.

Changes:
- Replace single-screen desktop capture with composite approach
- Capture each screen individually and composite them together
- Position capture widget to cover entire desktop geometry
- Remove devicePixelRatio division that caused coordinate issues
- Handle virtual desktop space by filling with black background

This solution works with any multi-monitor configuration including:
- Primary screen not being leftmost
- Screens with different resolutions and alignments
- Bottom-aligned or top-aligned screen arrangements
- Complex layouts with virtual coordinate space

Fixes #4111