### PR TITLE
Add shortcut 'G' to set cursor color to position's color

### DIFF
--- a/src/tools/capturetool.h
+++ b/src/tools/capturetool.h
@@ -87,7 +87,7 @@ public:
     {}
 
     // TODO unused
-    virtual void setCapture(const QPixmap& pixmap){};
+    virtual void setCapture(const QPixmap& pixmap) {};
 
     // Returns false when the tool is in an inconsistent state and shouldn't
     // be included in the tool undo/redo stack.

--- a/src/utils/confighandler.cpp
+++ b/src/utils/confighandler.cpp
@@ -55,15 +55,12 @@ bool verifyLaunchFile()
  *             misbehave.
  */
 #define OPTION(KEY, TYPE)                                                      \
-    {                                                                          \
-        QStringLiteral(KEY), QSharedPointer<ValueHandler>(new TYPE)            \
-    }
+    { QStringLiteral(KEY), QSharedPointer<ValueHandler>(new TYPE) }
 
 #define SHORTCUT(NAME, DEFAULT_VALUE)                                          \
-    {                                                                          \
-        QStringLiteral(NAME), QSharedPointer<KeySequence>(new KeySequence(     \
-                                QKeySequence(QLatin1String(DEFAULT_VALUE))))   \
-    }
+    { QStringLiteral(NAME),                                                    \
+      QSharedPointer<KeySequence>(                                             \
+        new KeySequence(QKeySequence(QLatin1String(DEFAULT_VALUE)))) }
 
 /**
  * This map contains all the information that is needed to parse, verify and
@@ -142,6 +139,7 @@ static QMap<class QString, QSharedPointer<ValueHandler>>
 static QMap<QString, QSharedPointer<KeySequence>> recognizedShortcuts = {
 //           NAME                           DEFAULT_SHORTCUT
     SHORTCUT("TYPE_PENCIL"              ,   "P"                     ),
+    SHORTCUT("TYPE_GRAB_COLOR"          ,   "G"                     ),//new shotcut
     SHORTCUT("TYPE_DRAWER"              ,   "D"                     ),
     SHORTCUT("TYPE_ARROW"               ,   "A"                     ),
     SHORTCUT("TYPE_SELECTION"           ,   "S"                     ),
@@ -210,7 +208,7 @@ ConfigHandler::ConfigHandler()
         QObject::connect(m_configWatcher.data(),
                          &QFileSystemWatcher::fileChanged,
                          [](const QString& fileName) {
-                             emit getInstance()->fileChanged();
+                             emit getInstance() -> fileChanged();
 
                              if (QFile(fileName).exists()) {
                                  m_configWatcher->addPath(fileName);
@@ -710,12 +708,12 @@ void ConfigHandler::setErrorState(bool error) const
     if (!hadError && m_hasError) {
         QString msg = errorMessage();
         AbstractLogger::error() << msg;
-        emit getInstance()->error();
+        emit getInstance() -> error();
     } else if (hadError && !m_hasError) {
         auto msg =
           tr("You have successfully resolved the configuration error.");
         AbstractLogger::info() << msg;
-        emit getInstance()->errorResolved();
+        emit getInstance() -> errorResolved();
     }
 }
 

--- a/src/widgets/capture/capturetoolbutton.cpp
+++ b/src/widgets/capture/capturetoolbutton.cpp
@@ -130,30 +130,38 @@ void CaptureToolButton::setColor(const QColor& c)
 
 QColor CaptureToolButton::m_mainColor;
 
-static std::map<CaptureTool::Type, int> buttonTypeOrder
-{
-    { CaptureTool::TYPE_PENCIL, 0 }, { CaptureTool::TYPE_DRAWER, 1 },
-      { CaptureTool::TYPE_ARROW, 2 }, { CaptureTool::TYPE_SELECTION, 3 },
-      { CaptureTool::TYPE_RECTANGLE, 4 }, { CaptureTool::TYPE_CIRCLE, 5 },
-      { CaptureTool::TYPE_MARKER, 6 }, { CaptureTool::TYPE_TEXT, 7 },
-      { CaptureTool::TYPE_PIXELATE, 8 }, { CaptureTool::TYPE_INVERT, 9 },
-      { CaptureTool::TYPE_CIRCLECOUNT, 10 },
-      { CaptureTool::TYPE_MOVESELECTION, 12 }, { CaptureTool::TYPE_UNDO, 13 },
-      { CaptureTool::TYPE_REDO, 14 }, { CaptureTool::TYPE_COPY, 15 },
-      { CaptureTool::TYPE_SAVE, 16 },
+static std::map<CaptureTool::Type, int> buttonTypeOrder{
+    { CaptureTool::TYPE_PENCIL, 0 },
+    { CaptureTool::TYPE_DRAWER, 1 },
+    { CaptureTool::TYPE_ARROW, 2 },
+    { CaptureTool::TYPE_SELECTION, 3 },
+    { CaptureTool::TYPE_RECTANGLE, 4 },
+    { CaptureTool::TYPE_CIRCLE, 5 },
+    { CaptureTool::TYPE_MARKER, 6 },
+    { CaptureTool::TYPE_TEXT, 7 },
+    { CaptureTool::TYPE_PIXELATE, 8 },
+    { CaptureTool::TYPE_INVERT, 9 },
+    { CaptureTool::TYPE_CIRCLECOUNT, 10 },
+    { CaptureTool::TYPE_MOVESELECTION, 12 },
+    { CaptureTool::TYPE_UNDO, 13 },
+    { CaptureTool::TYPE_REDO, 14 },
+    { CaptureTool::TYPE_COPY, 15 },
+    { CaptureTool::TYPE_SAVE, 16 },
 #ifdef ENABLE_IMGUR
-      { CaptureTool::TYPE_IMAGEUPLOADER, 17 },
+    { CaptureTool::TYPE_IMAGEUPLOADER, 17 },
 #endif
-      { CaptureTool::TYPE_ACCEPT, 18 },
+    { CaptureTool::TYPE_ACCEPT, 18 },
 #if !defined(Q_OS_MACOS)
-      { CaptureTool::TYPE_OPEN_APP, 19 }, { CaptureTool::TYPE_EXIT, 20 },
-      { CaptureTool::TYPE_PIN, 21 },
+    { CaptureTool::TYPE_OPEN_APP, 19 },
+    { CaptureTool::TYPE_EXIT, 20 },
+    { CaptureTool::TYPE_PIN, 21 },
 #else
-      { CaptureTool::TYPE_EXIT, 19 }, { CaptureTool::TYPE_PIN, 20 },
+    { CaptureTool::TYPE_EXIT, 19 },
+    { CaptureTool::TYPE_PIN, 20 },
 #endif
 
-      { CaptureTool::TYPE_SIZEINCREASE, 22 },
-      { CaptureTool::TYPE_SIZEDECREASE, 23 },
+    { CaptureTool::TYPE_SIZEINCREASE, 22 },
+    { CaptureTool::TYPE_SIZEDECREASE, 23 },
 };
 
 int CaptureToolButton::getPriorityByButton(CaptureTool::Type b)

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -293,7 +293,7 @@ CaptureWidget::~CaptureWidget()
         Flameshot::instance()->exportCapture(
           pixmap(), geometry, m_context.request);
     } else {
-        emit Flameshot::instance()->captureFailed();
+        emit Flameshot::instance() -> captureFailed();
     }
 }
 
@@ -415,6 +415,23 @@ void CaptureWidget::onGridSizeChanged(int size)
 {
     m_gridSize = size;
     repaint();
+}
+
+void CaptureWidget::grabColorFromMousePosition()
+{
+    const QRect& screenshotRect = m_context.selection;
+    if (screenshotRect.width() == 0 || screenshotRect.height() == 0)
+        return;
+    QPoint localMousePos = mapFromGlobal(QCursor::pos());
+    qreal scaleFactor = m_context.screenshot.devicePixelRatio();
+    QPoint scaledPos(localMousePos.x() * scaleFactor,
+                     localMousePos.y() * scaleFactor);
+    if (!screenshotRect.contains(scaledPos))
+        return; // Mouse position exceeds the screenshot range, unable to pick
+                // color
+    QImage screenshotImage = m_context.screenshot.toImage();
+    QColor pickedColor = screenshotImage.pixel(scaledPos);
+    setDrawColor(pickedColor);
 }
 
 void CaptureWidget::showxywh()
@@ -1619,6 +1636,10 @@ void CaptureWidget::initShortcuts()
     newShortcut(QKeySequence(ConfigHandler().shortcut("TYPE_CANCEL")),
                 this,
                 SLOT(cancel()));
+
+    newShortcut(QKeySequence(ConfigHandler().shortcut("TYPE_GRAB_COLOR")),
+                this,
+                SLOT(grabColorFromMousePosition()));
 
     newShortcut(
       QKeySequence(ConfigHandler().shortcut("TYPE_DELETE_CURRENT_TOOL")),

--- a/src/widgets/capture/capturewidget.h
+++ b/src/widgets/capture/capturewidget.h
@@ -91,6 +91,7 @@ private slots:
     void xywhTick();
     void onDisplayGridChanged(bool display);
     void onGridSizeChanged(int size);
+    void grabColorFromMousePosition();
 
 public:
     void removeToolObject(int index = -1);


### PR DESCRIPTION
This PR introduces a new shortcut functionality: pressing the 'g' key will set the brush color to match the pixel color at the cursor's current position.
﻿
Key implementation details:
- Added 'g' key listener in the input handling module to trigger color sampling
- Implemented logic to extract the exact color values from the pixel under the cursor's coordinates
- Integrated the sampled color into the brush's active color configuration, ensuring immediate application to subsequent drawing actions
- Verified no conflicts with existing shortcut keys by cross-checking against the project's key binding registry
- Tested in multiple scenarios: different image resolutions, transparent backgrounds, and with various brush sizes (all function as expected)
﻿
This feature streamlines the workflow for users who need to quickly match colors from the canvas, reducing the need to manually select colors through the palette, thus improving editing efficiency.