### PR TITLE
<strong> is not a supported tag per flathub guidelines

### DIFF
--- a/data/appdata/org.flameshot.Flameshot.metainfo.xml
+++ b/data/appdata/org.flameshot.Flameshot.metainfo.xml
@@ -36,7 +36,7 @@ SPDX-License-Identifier: CC0-1.0
       Powerful and simple to use screenshot software with built-in
       editor with advanced features.
     </p>
-    <p><strong>Features:</strong></p>
+    <p>Features:</p>
     <ul>
       <li>Customizable appearance</li>
       <li>Very easy to use</li>


### PR DESCRIPTION
```<strong>``` was not a supported tag per this guidelines breaking the flathub CI: https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines#description