### PR TITLE
Minor RPM spec file tweaks

### DIFF
--- a/packaging/rpm/fedora/flameshot.spec
+++ b/packaging/rpm/fedora/flameshot.spec
@@ -1,9 +1,9 @@
 #
-# spec file for package flameshot on fedora, rehl
+# spec file for package flameshot on fedora, rhel
 #
 Name: flameshot
-Version: 13.0.0
-Release: 1%{?dist}
+Version: 13.1.0
+Release: 2%{?dist}
 License: GPLv3+ and ASL 2.0 and GPLv2 and LGPLv3 and Free Art
 Summary: Powerful yet simple to use screenshot software
 URL: https://github.com/flameshot-org/flameshot
@@ -24,7 +24,6 @@ BuildRequires: cmake(Qt6LinguistTools) >= 6.0.0
 BuildRequires: cmake(Qt6Network) >= 6.0.0
 BuildRequires: cmake(Qt6Svg) >= 6.0.0
 BuildRequires: cmake(Qt6Widgets) >= 6.0.0
-
 
 Requires: hicolor-icon-theme
 Requires: qt6-qtbase >= 6.0.0
@@ -47,7 +46,6 @@ Features:
  * Easy to use.
  * In-app screenshot edition.
  * DBus interface.
- * Upload to Imgur
 
 %prep
 %autosetup -p1
@@ -97,6 +95,9 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/*.desktop
 %{_mandir}/man1/%{name}.1*
 
 %changelog
+* Sat Aug 16 2025 Elliott Tallis <tallis.elliott@gmail.com> - 13.1.0-2
+- Minor spec file tweaks
+
 * Sun Aug 13 2025 Jeremy Borgman <borgman.jeremy@pm.me> - 13.1.0
 - Update for v13.1.0 release
 

--- a/packaging/rpm/fedora/flameshot.spec
+++ b/packaging/rpm/fedora/flameshot.spec
@@ -1,13 +1,14 @@
 #
 # spec file for package flameshot on fedora, rhel
 #
-Name: flameshot
+Name:    flameshot
 Version: 13.1.0
 Release: 2%{?dist}
 License: GPLv3+ and ASL 2.0 and GPLv2 and LGPLv3 and Free Art
 Summary: Powerful yet simple to use screenshot software
-URL: https://github.com/flameshot-org/flameshot
+URL:     https://github.com/flameshot-org/flameshot
 Source0: %{url}/archive/v%{version}/%{name}-%{version}.tar.gz
+Vendor:  Flameshot
 
 BuildRequires: cmake >= 3.13.0
 BuildRequires: gcc-c++ >= 7

--- a/packaging/rpm/opensuse/flameshot.spec
+++ b/packaging/rpm/opensuse/flameshot.spec
@@ -1,13 +1,14 @@
 #
 # spec file for package flameshot on opensuse leap 15.x
 #
-Name: flameshot
+Name:    flameshot
 Version: 13.1.0
 Release: 2
 License: GPLv3+ and ASL 2.0 and GPLv2 and LGPLv3 and Free Art
 Summary: Powerful yet simple to use screenshot software
-URL: https://github.com/flameshot-org/flameshot
+URL:     https://github.com/flameshot-org/flameshot
 Source0: %{url}/archive/v%{version}/%{name}-%{version}.tar.gz
+Vendor:  Flameshot
 
 BuildRequires: cmake >= 3.13.0
 BuildRequires: gcc-c++ >= 7

--- a/packaging/rpm/opensuse/flameshot.spec
+++ b/packaging/rpm/opensuse/flameshot.spec
@@ -2,8 +2,8 @@
 # spec file for package flameshot on opensuse leap 15.x
 #
 Name: flameshot
-Version: 13.0.0
-Release: 1
+Version: 13.1.0
+Release: 2
 License: GPLv3+ and ASL 2.0 and GPLv2 and LGPLv3 and Free Art
 Summary: Powerful yet simple to use screenshot software
 URL: https://github.com/flameshot-org/flameshot
@@ -23,7 +23,6 @@ BuildRequires: cmake(Qt6LinguistTools) >= 6.0.0
 BuildRequires: cmake(Qt6Network) >= 6.0.0
 BuildRequires: cmake(Qt6Svg) >= 6.0.0
 BuildRequires: cmake(Qt6Widgets) >= 6.0.0
-
 
 Requires: hicolor-icon-theme
 Requires: qt6-base >= 6.0.0
@@ -46,7 +45,6 @@ Features:
  * Easy to use.
  * In-app screenshot edition.
  * DBus interface.
- * Upload to Imgur
 
 %prep
 %autosetup -p1
@@ -95,6 +93,9 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/*.desktop
 %{_mandir}/man1/%{name}.1*
 
 %changelog
+* Sat Aug 16 2025 Elliott Tallis <tallis.elliott@gmail.com> - 13.1.0-2
+- Minor spec file tweaks
+
 * Sun Aug 15 2025 Jeremy Borgman <borgman.jeremy@pm.me> - 13.1.0
 - Update for v13.1.0 release
 


### PR DESCRIPTION
Was just looking at the RPM spec file now that I can actually use the newer builds thanks to #4127, but just noticed some minor issues that I thought I'd correct:

- Corrected version to match actual release
- Removed mention of Imgur from description since its no longer included in the build
- Corrected RHEL typo in the comment at the top for the Fedora spec
- Add RPM vendor for use with [`allow_vendor_change=False`](https://dnf.readthedocs.io/en/latest/conf_ref.html#main-options) (in Fedora, this is set true by default)
- Bumped release for previous issues

Thanks,
Elliott