### PR TITLE
fix: Screen positions in multi-monitor configuration when devicePixelRatio is other than one

### DIFF
--- a/src/utils/screengrabber.cpp
+++ b/src/utils/screengrabber.cpp
@@ -211,23 +211,16 @@ QPixmap ScreenGrabber::grabEntireDesktop(bool& ok)
     // multi-monitor setups where screens have different positions/heights.
     // This fixes the dual monitor offset bug and handles edge cases where
     // the desktop bounding box includes virtual space.
+    QScreen* primaryScreen = QGuiApplication::primaryScreen();
+    QRect r = primaryScreen->geometry();
     QPixmap desktop(geometry.size());
     desktop.fill(Qt::black); // Fill with black background
-
-    QPainter painter(&desktop);
-    for (QScreen* screen : QGuiApplication::screens()) {
-        QRect screenGeom = screen->geometry();
-        QPixmap screenCapture = screen->grabWindow(wid);
-
-        // Qt6 provides a screen position in real pixels, not logical ones
-        qreal dpr = screen->devicePixelRatio();
-        screenGeom.moveTo(
-          QPointF(screenGeom.x() / dpr, screenGeom.y() / dpr).toPoint());
-
-        painter.drawPixmap(screenGeom.topLeft(), screenCapture);
-    }
-    painter.end();
-
+    desktop =
+      primaryScreen->grabWindow(wid,
+                                -r.x() / primaryScreen->devicePixelRatio(),
+                                -r.y() / primaryScreen->devicePixelRatio(),
+                                geometry.width(),
+                                geometry.height());
     return desktop;
 #endif
 }

--- a/src/widgets/capture/buttonhandler.cpp
+++ b/src/widgets/capture/buttonhandler.cpp
@@ -64,7 +64,7 @@ size_t ButtonHandler::size() const
 
 // updatePosition updates the position of the buttons around the
 // selection area. Ignores the sides blocked by the end of the screen.
-// When the selection is too small it works on a virtual selection with
+// When the selection is too small, it works on a virtual selection with
 // the original in the center.
 void ButtonHandler::updatePosition(const QRect& selection)
 {
@@ -122,7 +122,7 @@ void ButtonHandler::updatePosition(const QRect& selection)
               horizontalPoints(center, addCounter, true);
             moveButtonsToPoints(positions, elemIndicator);
         }
-        // Add buttons at the right side of the selection
+        // Add buttons to the right side of the selection
         if (!m_blockedRight && elemIndicator < vecLength) {
             int addCounter = buttonsPerCol;
             addCounter = qBound(0, addCounter, vecLength - elemIndicator);
@@ -146,7 +146,7 @@ void ButtonHandler::updatePosition(const QRect& selection)
               horizontalPoints(center, addCounter, false);
             moveButtonsToPoints(positions, elemIndicator);
         }
-        // Add buttons at the left side of the selection
+        // Add buttons to the left side of the selection
         if (!m_blockedLeft && elemIndicator < vecLength) {
             int addCounter = buttonsPerCol;
             addCounter = qBound(0, addCounter, vecLength - elemIndicator);

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -13,11 +13,8 @@
 #include "abstractlogger.h"
 #include "copytool.h"
 #include "src/config/cacheutils.h"
-#include "src/config/generalconf.h"
 #include "src/core/flameshot.h"
 #include "src/core/qguiappcurrentscreen.h"
-#include "src/tools/toolfactory.h"
-#include "src/utils/colorutils.h"
 #include "src/utils/screengrabber.h"
 #include "src/utils/screenshotsaver.h"
 #include "src/utils/systemnotification.h"
@@ -32,9 +29,7 @@
 #include <QApplication>
 #include <QCheckBox>
 #include <QDateTime>
-#include <QDebug>
 #include <QFontMetrics>
-#include <QLabel>
 #include <QMessageBox>
 #include <QPaintEvent>
 #include <QPainter>
@@ -150,6 +145,7 @@ CaptureWidget::CaptureWidget(const CaptureRequest& req,
         QScreen* currentScreen = QGuiAppCurrentScreen().currentScreen();
         move(currentScreen->geometry().x(), currentScreen->geometry().y());
         resize(currentScreen->size());
+// LINUX
 #else
 // Call cmake with -DFLAMESHOT_DEBUG_CAPTURE=ON to enable easier debugging
 #if !defined(FLAMESHOT_DEBUG_CAPTURE)
@@ -161,6 +157,18 @@ CaptureWidget::CaptureWidget(const CaptureRequest& req,
         move(desktopGeom.topLeft());
         resize(desktopGeom.size());
 #endif
+        // Need to move to the top left screen
+        QPoint topLeft(0, INT_MAX);
+        for (QScreen* const screen : QGuiApplication::screens()) {
+            qreal dpr = screen->devicePixelRatio();
+            QPoint topLeftScreen = screen->geometry().topLeft() / dpr;
+            if (topLeftScreen.x() == 0) {
+                if (topLeftScreen.y() < topLeft.y()) {
+                    topLeft.setY(topLeftScreen.y());
+                }
+            }
+        }
+        move(topLeft);
 #endif
     }
     QVector<QRect> areas;
@@ -168,9 +176,7 @@ CaptureWidget::CaptureWidget(const CaptureRequest& req,
         QPoint topLeftOffset = QPoint(0, 0);
 #if defined(Q_OS_WIN)
         topLeftOffset = topLeft;
-#endif
-
-#if defined(Q_OS_MACOS)
+#elif defined(Q_OS_MACOS)
         // MacOS works just with one active display, so we need to append
         // just one current display and keep multiple displays logic for
         // other OS
@@ -182,6 +188,7 @@ CaptureWidget::CaptureWidget(const CaptureRequest& req,
         r.moveTo(0, 0);
         areas.append(r);
 #else
+        // LINUX
         for (QScreen* const screen : QGuiApplication::screens()) {
             QRect r = screen->geometry();
             r.moveTo(r.x() / screen->devicePixelRatio(),
@@ -259,8 +266,15 @@ CaptureWidget::CaptureWidget(const CaptureRequest& req,
                 OverlayMessage::instance()->update();
             });
 
-    OverlayMessage::init(this,
-                         QGuiAppCurrentScreen().currentScreen()->geometry());
+    // Qt6 has only sizes in logical values, position is in physical values.
+    // Move Help message to the logical pixel with devicePixelRatio.
+    QScreen* currentScreen = QGuiAppCurrentScreen().currentScreen();
+    QRect currentScreenGeometry = currentScreen->geometry();
+    qreal currentScreenDpr = currentScreen->devicePixelRatio();
+    currentScreenGeometry.moveTo(
+      int(currentScreenGeometry.x() / currentScreenDpr),
+      int(currentScreenGeometry.y() / currentScreenDpr));
+    OverlayMessage::init(this, currentScreenGeometry);
 
     if (m_config.showHelp()) {
         initHelpMessage();

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -176,7 +176,9 @@ CaptureWidget::CaptureWidget(const CaptureRequest& req,
         QPoint topLeftOffset = QPoint(0, 0);
 #if defined(Q_OS_WIN)
         topLeftOffset = topLeft;
-#elif defined(Q_OS_MACOS)
+#endif
+
+#if defined(Q_OS_MACOS)
         // MacOS works just with one active display, so we need to append
         // just one current display and keep multiple displays logic for
         // other OS
@@ -188,7 +190,7 @@ CaptureWidget::CaptureWidget(const CaptureRequest& req,
         r.moveTo(0, 0);
         areas.append(r);
 #else
-        // LINUX
+        // LINUX & WINDOWS
         for (QScreen* const screen : QGuiApplication::screens()) {
             QRect r = screen->geometry();
             r.moveTo(r.x() / screen->devicePixelRatio(),


### PR DESCRIPTION
Screen positions in multi-monitor configuration with devicePixelRatio != 1 

Works for:
- Xorg and likely Windows
- Wayland is not fixed