### PR TITLE
Windows cli copy (fix for #4118)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,7 +10,7 @@ find_package(
         LinguistTools
 )
 
-if (UNIX)
+if (UNIX AND NOT APPLE)
 find_package(
         Qt${QT_VERSION_MAJOR}
         CONFIG
@@ -220,7 +220,7 @@ target_link_libraries(
         Qt${QT_VERSION_MAJOR}::Widgets
         QtColorWidgets
 )
-if (UNIX)
+if (UNIX AND NOT APPLE)
 target_link_libraries(
         flameshot
         Qt${QT_VERSION_MAJOR}::DBus

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,9 +7,17 @@ find_package(
         Widgets
         Network
         Svg
-        DBus
         LinguistTools
 )
+
+if (UNIX)
+find_package(
+        Qt${QT_VERSION_MAJOR}
+        CONFIG
+        REQUIRED
+        DBus
+)
+endif()
 
 if (USE_WAYLAND_CLIPBOARD)
     find_package(KF6GuiAddons)
@@ -208,11 +216,16 @@ target_link_libraries(
         project_warnings
         project_options
         Qt${QT_VERSION_MAJOR}::Svg
-        Qt${QT_VERSION_MAJOR}::DBus
         Qt${QT_VERSION_MAJOR}::Network
         Qt${QT_VERSION_MAJOR}::Widgets
         QtColorWidgets
 )
+if (UNIX)
+target_link_libraries(
+        flameshot
+        Qt${QT_VERSION_MAJOR}::DBus
+)
+endif()
 
 if (USE_KDSINGLEAPPLICATION)
   message(STATUS "KDSingleApplication is used!")

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -11,7 +11,7 @@ target_sources(flameshot PRIVATE
     qguiappcurrentscreen.cpp
 )
 
-if (UNIX)
+if (UNIX AND NOT APPLE)
 target_sources(flameshot PRIVATE
     flameshotdbusadapter.h
     flameshotdbusadapter.cpp

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1,7 +1,6 @@
 target_sources(flameshot PRIVATE
     flameshot.h
     flameshotdaemon.h
-    flameshotdbusadapter.h
     qguiappcurrentscreen.h
 )
 
@@ -9,9 +8,15 @@ target_sources(flameshot PRIVATE
     capturerequest.cpp
     flameshot.cpp
     flameshotdaemon.cpp
-    flameshotdbusadapter.cpp
     qguiappcurrentscreen.cpp
 )
+
+if (UNIX)
+target_sources(flameshot PRIVATE
+    flameshotdbusadapter.h
+    flameshotdbusadapter.cpp
+)
+endif ()
 
 if (USE_KDSINGLEAPPLICATION)
 if (NOT WIN32)

--- a/src/core/flameshotdaemon.cpp
+++ b/src/core/flameshotdaemon.cpp
@@ -10,11 +10,14 @@
 #include "src/widgets/trayicon.h"
 #include <QApplication>
 #include <QClipboard>
-#include <QDBusConnection>
-#include <QDBusMessage>
 #include <QIODevice>
 #include <QPixmap>
 #include <QRect>
+
+#if !(defined(Q_OS_MACOS) || defined(Q_OS_WIN))
+#include <QDBusConnection>
+#include <QDBusMessage>
+#endif
 
 #if !defined(DISABLE_UPDATE_CHECKER)
 #include <QDesktopServices>
@@ -24,6 +27,12 @@
 #include <QNetworkReply>
 #include <QTimer>
 #include <QUrl>
+#endif
+
+#if defined(USE_KDSINGLEAPPLICATION) &&                                        \
+  (defined(Q_OS_MACOS) || defined(Q_OS_WIN))
+#include <QBuffer>
+#include <kdsingleapplication.h>
 #endif
 
 #ifdef Q_OS_WIN
@@ -62,9 +71,9 @@ FlameshotDaemon::FlameshotDaemon()
   , m_clipboardSignalBlocked(false)
   , m_trayIcon(nullptr)
 #if !defined(DISABLE_UPDATE_CHECKER)
-  , m_networkCheckUpdates(nullptr)
-  , m_showCheckAppUpdateStatus(false)
   , m_appLatestVersion(QStringLiteral(APP_VERSION).replace("v", ""))
+  , m_showCheckAppUpdateStatus(false)
+  , m_networkCheckUpdates(nullptr)
 #endif
 {
     connect(
@@ -116,11 +125,18 @@ void FlameshotDaemon::createPin(const QPixmap& capture, QRect geometry)
 
     QByteArray data;
     QDataStream stream(&data, QIODevice::WriteOnly);
-    stream << capture;
-    stream << geometry;
+
+#if defined(USE_KDSINGLEAPPLICATION) &&                                        \
+  (defined(Q_OS_MACOS) || defined(Q_OS_WIN))
+    auto kdsa = KDSingleApplication(QStringLiteral("org.flameshot.Flameshot"));
+    stream << QStringLiteral("attachPin") << capture << geometry;
+    kdsa.sendMessage(data);
+#else
+    stream << capture << geometry;
     QDBusMessage m = createMethodCall(QStringLiteral("attachPin"));
     m << data;
     call(m);
+#endif
 }
 
 void FlameshotDaemon::copyToClipboard(const QPixmap& capture)
@@ -130,15 +146,22 @@ void FlameshotDaemon::copyToClipboard(const QPixmap& capture)
         return;
     }
 
+    QByteArray data;
+    QDataStream stream(&data, QIODevice::WriteOnly);
+
+#if defined(USE_KDSINGLEAPPLICATION) &&                                        \
+  (defined(Q_OS_MACOS) || defined(Q_OS_WIN))
+    auto kdsa = KDSingleApplication(QStringLiteral("org.flameshot.Flameshot"));
+    stream << QStringLiteral("attachScreenshotToClipboard") << capture;
+    kdsa.sendMessage(data);
+#else
+    stream << capture;
     QDBusMessage m =
       createMethodCall(QStringLiteral("attachScreenshotToClipboard"));
 
-    QByteArray data;
-    QDataStream stream(&data, QIODevice::WriteOnly);
-    stream << capture;
-
     m << data;
     call(m);
+#endif
 }
 
 void FlameshotDaemon::copyToClipboard(const QString& text,
@@ -148,13 +171,22 @@ void FlameshotDaemon::copyToClipboard(const QString& text,
         instance()->attachTextToClipboard(text, notification);
         return;
     }
-    auto m = createMethodCall(QStringLiteral("attachTextToClipboard"));
 
+#if defined(USE_KDSINGLEAPPLICATION) &&                                        \
+  (defined(Q_OS_MACOS) || defined(Q_OS_WIN))
+    auto kdsa = KDSingleApplication(QStringLiteral("org.flameshot.Flameshot"));
+    QByteArray data;
+    QDataStream stream(&data, QIODevice::WriteOnly);
+    stream << QStringLiteral("attachTextToClipboard") << text << notification;
+    kdsa.sendMessage(data);
+#else
+    auto m = createMethodCall(QStringLiteral("attachTextToClipboard"));
     m << text << notification;
 
     QDBusConnection sessionBus = QDBusConnection::sessionBus();
     checkDBusConnection(sessionBus);
     sessionBus.call(m);
+#endif
 }
 
 /**
@@ -282,7 +314,7 @@ void FlameshotDaemon::attachScreenshotToClipboard(const QPixmap& pixmap)
     clipboard->blockSignals(false);
 }
 
-// D-BUS ADAPTER METHODS
+// D-BUS / KDSingleApplication METHODS
 
 void FlameshotDaemon::attachPin(const QByteArray& data)
 {
@@ -396,6 +428,7 @@ void FlameshotDaemon::handleReplyCheckUpdates(QNetworkReply* reply)
 }
 #endif
 
+#if !(defined(Q_OS_MACOS) || defined(Q_OS_WIN))
 QDBusMessage FlameshotDaemon::createMethodCall(const QString& method)
 {
     QDBusMessage m =
@@ -420,6 +453,64 @@ void FlameshotDaemon::call(const QDBusMessage& m)
     checkDBusConnection(sessionBus);
     sessionBus.call(m);
 }
+#endif
+
+#if defined(USE_KDSINGLEAPPLICATION) &&                                        \
+  (defined(Q_OS_MACOS) || defined(Q_OS_WIN))
+void FlameshotDaemon::messageReceivedFromSecondaryInstance(
+  const QByteArray& message)
+{
+    // qDebug() << "Received message from second instance:" << message;
+
+    QByteArray messageCopy = message;
+    QBuffer buffer(&messageCopy);
+    buffer.open(QIODevice::ReadOnly);
+    QDataStream stream(&buffer);
+    QString methodCall;
+    stream >> methodCall;
+    // qDebug() << "Method:" << methodCall;
+
+    if (methodCall == QStringLiteral("attachPin")) {
+        QPixmap capture;
+        QRect geometry;
+        stream >> capture >> geometry;
+        // qDebug() << "Pixmap:" << capture;
+        // qDebug() << "Geometry:" << geometry;
+        if (!capture.isNull()) {
+            FlameshotDaemon::instance()->attachPin(capture, geometry);
+        } else {
+            qWarning() << "Received \"attachPin\" from second instance, but "
+                          "pixmap is empty!";
+        }
+    } else if (methodCall == QStringLiteral("attachScreenshotToClipboard")) {
+        QPixmap capture;
+        stream >> capture;
+        // qDebug() << "Pixmap:" << capture;
+        if (!capture.isNull()) {
+            FlameshotDaemon::instance()->attachScreenshotToClipboard(capture);
+        } else {
+            qWarning() << "Received \"attachScreenshotToClipboard\" from "
+                          "second instance, but pixmap is empty!";
+        }
+    } else if (methodCall == (QStringLiteral("attachTextToClipboard"))) {
+        QString text;
+        QString notification;
+        stream >> text >> notification;
+        // qDebug() << "Text:" << text;
+        // qDebug() << "Notification:" << notification;
+        if (!text.isEmpty()) {
+            FlameshotDaemon::instance()->attachTextToClipboard(text,
+                                                               notification);
+        } else {
+            qWarning() << "Received \"attachTextToClipboard\" from second "
+                          "instance, but text is empty!";
+        }
+    } else {
+        qWarning() << "Received unknown message from second instance:"
+                   << message;
+    }
+}
+#endif
 
 // STATIC ATTRIBUTES
 FlameshotDaemon* FlameshotDaemon::m_instance = nullptr;

--- a/src/core/flameshotdaemon.h
+++ b/src/core/flameshotdaemon.h
@@ -2,7 +2,10 @@
 
 #include <QByteArray>
 #include <QObject>
+
+#if !(defined(Q_OS_MACOS) || defined(Q_OS_WIN))
 #include <QtDBus/QDBusAbstractAdaptor>
+#endif
 
 class QPixmap;
 class QRect;
@@ -34,7 +37,14 @@ public:
       const QString& title = QStringLiteral("Flameshot Info"),
       const int timeout = 5000);
 
+#if defined(USE_KDSINGLEAPPLICATION) &&                                        \
+  (defined(Q_OS_MACOS) || defined(Q_OS_WIN))
+public slots:
+    void messageReceivedFromSecondaryInstance(const QByteArray& message);
+#endif
+
 #if !defined(DISABLE_UPDATE_CHECKER)
+public:
     void showUpdateNotificationIfAvailable(CaptureWidget* widget);
 
 public slots:
@@ -62,10 +72,11 @@ private:
     void initTrayIcon();
     void enableTrayIcon(bool enable);
 
-private:
+#if !(defined(Q_OS_MACOS) || defined(Q_OS_WIN))
     static QDBusMessage createMethodCall(const QString& method);
     static void checkDBusConnection(const QDBusConnection& connection);
     static void call(const QDBusMessage& m);
+#endif
 
     bool m_persist;
     bool m_hostingClipboard;
@@ -82,5 +93,7 @@ private:
 
     static FlameshotDaemon* m_instance;
 
+#if !(defined(Q_OS_MACOS) || defined(Q_OS_WIN))
     friend class FlameshotDBusAdapter;
+#endif
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -26,10 +26,8 @@
 #include <QSharedMemory>
 #include <QTimer>
 #include <QTranslator>
-#if defined(Q_OS_LINUX) || defined(Q_OS_UNIX)
-#include "abstractlogger.h"
+#if !(defined(Q_OS_MACOS) || defined(Q_OS_WIN))
 #include "src/core/flameshotdbusadapter.h"
-#include <QApplication>
 #include <QDBusConnection>
 #include <QDBusMessage>
 #include <desktopinfo.h>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -182,7 +182,8 @@ int main(int argc, char* argv[])
         setup_unix_signal_handlers();
         auto signalDaemon = SignalDaemon();
 #endif
-        auto kdsa = KDSingleApplication(QStringLiteral("flameshot"));
+        auto kdsa =
+          KDSingleApplication(QStringLiteral("org.flameshot.Flameshot"));
 
         if (!kdsa.isPrimaryInstance()) {
             return 0; // Quit
@@ -192,6 +193,17 @@ int main(int argc, char* argv[])
         configureApp(true);
         auto c = Flameshot::instance();
         FlameshotDaemon::start();
+
+#if defined(USE_KDSINGLEAPPLICATION) &&                                        \
+  (defined(Q_OS_MACOS) || defined(Q_OS_WIN))
+        if (kdsa.isPrimaryInstance()) {
+            QObject::connect(
+              &kdsa,
+              &KDSingleApplication::messageReceived,
+              FlameshotDaemon::instance(),
+              &FlameshotDaemon::messageReceivedFromSecondaryInstance);
+        }
+#endif
 
 #if !(defined(Q_OS_MACOS) || defined(Q_OS_WIN))
         new FlameshotDBusAdapter(c);

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -27,7 +27,7 @@ target_sources(
           strfparse.cpp
 )
 
-IF (UNIX)
+IF (UNIX AND NOT APPLE)
 target_sources(
   flameshot
   PRIVATE request.h

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -6,7 +6,6 @@ target_sources(
           screengrabber.h
           systemnotification.h
           valuehandler.h
-          request.h
           strfparse.h
 )
 
@@ -26,8 +25,15 @@ target_sources(
           colorutils.cpp
           history.cpp
           strfparse.cpp
+)
+
+IF (UNIX)
+target_sources(
+  flameshot
+  PRIVATE request.h
           request.cpp
 )
+ENDIF()
 
 IF (WIN32)
   target_sources(

--- a/src/utils/screengrabber.cpp
+++ b/src/utils/screengrabber.cpp
@@ -28,7 +28,7 @@ ScreenGrabber::ScreenGrabber(QObject* parent)
 
 void ScreenGrabber::generalGrimScreenshot(bool& ok, QPixmap& res)
 {
-#if defined(Q_OS_LINUX) || defined(Q_OS_UNIX)
+#if !(defined(Q_OS_MACOS) || defined(Q_OS_WIN))
     if (!ConfigHandler().useGrimAdapter()) {
         return;
     }

--- a/src/utils/screengrabber.cpp
+++ b/src/utils/screengrabber.cpp
@@ -13,7 +13,7 @@
 #include <QProcess>
 #include <QScreen>
 
-#if defined(Q_OS_LINUX) || defined(Q_OS_UNIX)
+#if !(defined(Q_OS_MACOS) || defined(Q_OS_WIN))
 #include "request.h"
 #include <QDBusInterface>
 #include <QDBusReply>
@@ -60,7 +60,7 @@ void ScreenGrabber::generalGrimScreenshot(bool& ok, QPixmap& res)
 void ScreenGrabber::freeDesktopPortal(bool& ok, QPixmap& res)
 {
 
-#if defined(Q_OS_LINUX) || defined(Q_OS_UNIX)
+#if !(defined(Q_OS_MACOS) || defined(Q_OS_WIN))
     QDBusInterface screenshotInterface(
       QStringLiteral("org.freedesktop.portal.Desktop"),
       QStringLiteral("/org/freedesktop/portal/desktop"),


### PR DESCRIPTION
As mentioned in #4118, copying a screenshot is not working when the flameshot CLI is used on Windows. Currently Flameshot daemon is using D-Bus to forward the CLI request to the main Flameshot instace and D-Bus is not available on Windows (and MacOS as far as I know).

This PR is using a feature from the recently added KDSingleApplication, with which we can send a message from the second (CLI) Flameshot instance to the first instance without D-Bus.
I successfully tested it on Windows 10; I don't have MacOS, but I'd assume it should work there as well - if somebody could test it on mac it would be great! Additionally I added further ifdefs, so that the Windows and MacOS build has no dependency to Qt D-Bus module anymore.

_Side note:_ I tested this functionality on Manjaro linux as well (after adjusting the code to use the KDSingleApplication message feature instead of the usual D-Bus code for linux) and it worked as well. So I am raising the question if we should consider to remove `flameshotdbusadapter` completely and use KDSingleApplication messages on all platforms?! (for sure D-Bus will remain in general for the Linux builds, as D-Bus is used e.g. by `ScreenGrabber`). Discussion #1999 might be a better place to discuss this in detail.