### PR TITLE
remove color set on widget hide

### DIFF
--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -981,6 +981,7 @@ void CaptureWidget::mouseReleaseEvent(QMouseEvent* e)
             m_context.color.isValid()) {
             pushObjectsStateToUndoStack();
         }
+        m_colorPicker->setNewColor();
         m_colorPicker->hide();
         if (!m_context.color.isValid()) {
             m_context.color = ConfigHandler().drawColor();

--- a/src/widgets/capture/colorpicker.cpp
+++ b/src/widgets/capture/colorpicker.cpp
@@ -22,6 +22,10 @@ ColorPicker::ColorPicker(QWidget* parent)
         }
     }
 }
+void ColorPicker::setNewColor()
+{
+    emit colorSelected(m_colorList.at(m_selectedIndex));
+}
 
 void ColorPicker::mouseMoveEvent(QMouseEvent* e)
 {
@@ -44,5 +48,4 @@ void ColorPicker::showEvent(QShowEvent* event)
 void ColorPicker::hideEvent(QHideEvent* event)
 {
     releaseMouse();
-    emit colorSelected(m_colorList.at(m_selectedIndex));
 }

--- a/src/widgets/capture/colorpicker.h
+++ b/src/widgets/capture/colorpicker.h
@@ -10,7 +10,7 @@ class ColorPicker : public ColorPickerWidget
     Q_OBJECT
 public:
     explicit ColorPicker(QWidget* parent = nullptr);
-
+    void setNewColor();
 signals:
     void colorSelected(QColor c);
 


### PR DESCRIPTION
The color picker had a "hack" where it would set the color when the widget was hid. This worked but had a side effect that when it was first hidden at init, it would override the user color with whatever color was at index 1 in the color picker. 

Now the color change is explicitly called when the user clicks a new color and not part of the "hide" function. 

Merging this will resolve #4148 