### PR TITLE
Fix: multiple displays

### DIFF
--- a/src/core/flameshot.cpp
+++ b/src/core/flameshot.cpp
@@ -160,6 +160,9 @@ void Flameshot::screen(CaptureRequest req, const int screenNumber)
     } else {
         screen = qApp->screens()[screenNumber];
     }
+
+    // TODO: Switch to the DesktopCapture, ScreenGrabber is deprecated
+    // It is still used her, but does not properly work
     QPixmap p(ScreenGrabber().grabScreen(screen, ok));
     if (ok) {
         QRect geometry = ScreenGrabber().screenGeometry(screen);

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -4,6 +4,7 @@ target_sources(
   PRIVATE abstractlogger.h
           filenamehandler.h
           screengrabber.h
+          DesktopCapturer.h
           systemnotification.h
           valuehandler.h
           strfparse.h
@@ -14,6 +15,7 @@ target_sources(
   PRIVATE abstractlogger.cpp
           filenamehandler.cpp
           screengrabber.cpp
+          DesktopCapturer.cpp
           confighandler.cpp
           systemnotification.cpp
           valuehandler.cpp

--- a/src/utils/DesktopCapturer.cpp
+++ b/src/utils/DesktopCapturer.cpp
@@ -78,6 +78,7 @@ QRect DesktopCapturer::geometry()
 QPixmap DesktopCapturer::captureDesktopComposite()
 {
     m_screenToDraw = QGuiApplication::primaryScreen();
+    qreal screenToDrawDpr = screenToDraw()->devicePixelRatio();
 
     // Calculate screen geometry
     geometry();
@@ -104,10 +105,13 @@ QPixmap DesktopCapturer::captureDesktopComposite()
         painter.drawPixmap(geo.x(), geo.y(), pix);
 
         // Prepare areas
-        // (everything, including location, should be in logical pixels)
-        QRect areaRect = geo;
-        areaRect.moveLeft(geo.x() / screen->devicePixelRatio());
-        areaRect.moveTop(geo.y() / screen->devicePixelRatio());
+        // Everything, including location, should be in logical pixels
+        // of the screen to draw a grabbed area (primary screen)
+        QRect areaRect =
+          QRect(static_cast<int>(geo.x() / screenToDrawDpr),
+                static_cast<int>(geo.y() / screenToDrawDpr),
+                static_cast<int>(pix.width() / screenToDrawDpr),
+                static_cast<int>(pix.height() / screenToDrawDpr));
         m_areas.append(areaRect);
     }
     painter.end();

--- a/src/utils/DesktopCapturer.cpp
+++ b/src/utils/DesktopCapturer.cpp
@@ -1,0 +1,165 @@
+#include "DesktopCapturer.h"
+
+#include <QCursor>
+#include <QGuiApplication>
+#include <QImage>
+#include <QPainter>
+#include <QPixmap>
+#include <QScreen>
+
+DesktopCapturer::DesktopCapturer()
+    : m_screenToDraw(nullptr)
+{
+    reset();
+}
+
+void DesktopCapturer::reset() {
+    m_geometry = QRect(0, 0, 0, 0);
+}
+
+QSize DesktopCapturer::screenSize() const
+{
+    return m_geometry.size();
+}
+
+QPoint DesktopCapturer::topLeft() const
+{
+    return m_geometry.topLeft();
+}
+
+QPoint DesktopCapturer::topLeftScaledToScreen()  const{
+    return screenToDraw()->geometry().topLeft() / screenToDraw()->devicePixelRatio();
+}
+
+QRect DesktopCapturer::geometry() {
+    // Get Top Left and Bottom Right
+    QPoint maxPoint(INT_MIN, INT_MIN);
+    QPoint topLeft = QPoint(INT_MAX, INT_MAX);
+    for (QScreen  const* screen : QGuiApplication::screens()) {
+        QRect const geo = screen->geometry();
+        int const width = static_cast<int>(geo.width() * screen->devicePixelRatio());
+        int const height= static_cast<int>(geo.height() * screen->devicePixelRatio());
+        int const maxX = width + geo.x();
+        int const maxY = height + geo.y();
+
+        // Get Top Left
+        if (geo.x() < topLeft.x()) {
+            topLeft.setX(geo.x());
+        }
+        if (geo.y() < topLeft.y()) {
+            topLeft.setY(geo.y());
+        }
+
+        // Get Bottom Right
+        if (maxX > maxPoint.x()) {
+            maxPoint.setX(maxX);
+        }
+        if (maxY > maxPoint.y()) {
+            maxPoint.setY(maxY);
+        }
+    }
+
+    // Get Desktop size
+    m_geometry.setX(topLeft.x());
+    m_geometry.setY(topLeft.y());
+    m_geometry.setWidth(maxPoint.x() - topLeft.x());
+    m_geometry.setHeight(maxPoint.y() - topLeft.y());
+
+    return m_geometry;
+}
+
+QPixmap DesktopCapturer::captureDesktopComposite() {
+    m_screenToDraw = QGuiApplication::primaryScreen();
+
+    // Calculate screen geometry
+    geometry();
+
+    // Create Desktop image
+    QPixmap desktop(screenSize());
+    desktop.fill(Qt::black);
+
+    // Draw composite screenshot
+    QPainter painter(&desktop);
+    for (QScreen *screen : QGuiApplication::screens()) {
+        QRect const geo = screen->geometry();
+        QPixmap pix = screen->grabWindow(0);
+
+        // Composite screenshot should have pixel ratio 1 to draw all screen with different ratios.
+        pix.setDevicePixelRatio(1);
+
+        // Calculate offset
+        int const xPos = geo.x() - topLeft().x();
+        int const yPos = geo.y() - topLeft().y();
+
+        painter.drawPixmap(xPos, yPos, pix);
+    }
+    painter.end();
+
+
+    // Set pixmap DevicePixelRatio of the screen where it should be drawn.
+    desktop.setDevicePixelRatio(screenToDraw()->devicePixelRatio());
+
+    return desktop;
+}
+
+QPixmap DesktopCapturer::captureDesktopAtCursorPos() {
+    // Active is where the mouse cursor is, it can be not an active screen
+    QScreen *screen = screenAtCursorPos();
+    QPixmap pix;
+    if (screen == nullptr) {
+        return pix;
+    }
+    pix = screen->grabWindow(0);
+    m_geometry = screen->geometry();
+    m_geometry.setWidth(
+      static_cast<int>(m_geometry.width() * screen->devicePixelRatio()));
+    m_geometry.setHeight(
+        static_cast<int>(m_geometry.height() * screen->devicePixelRatio()));
+    return pix;
+}
+
+QScreen* DesktopCapturer::screenAtCursorPos() {
+    // Get the current global position of the mouse cursor.
+    // This position is in the virtual desktop coordinate system, which spans all screens.
+    const QPoint mousePos = QCursor::pos();
+    m_screenToDraw = QGuiApplication::primaryScreen();
+
+
+    // Iterate through all screens available to the application.
+    for (QScreen* screen : QGuiApplication::screens()) {
+        // Get the screen's geometry in the virtual desktop coordinate system.
+        // This is the rectangle that defines the screen's position and size.
+
+        // Check if the screen's geometry contains the mouse cursor's position.
+        if (screen->geometry().contains(mousePos)) {
+            m_screenToDraw = screen;
+            break;
+        }
+    }
+
+    // Return nullptr if the cursor is not found on any screen.
+    return m_screenToDraw;
+}
+
+QPixmap DesktopCapturer::captureDesktop(bool composite) {
+    QPixmap desktop;
+    reset();
+#ifdef Q_OS_MAC
+    composite = false;
+#elif defined(Q_OS_LINUX) || defined(Q_OS_UNIX)
+    // Wayland sessions cannot use composite
+    // composite = false;
+#endif
+    if (composite) {
+        desktop = captureDesktopComposite();
+    }
+    else {
+        desktop = captureDesktopAtCursorPos();
+    }
+    return desktop;
+}
+
+QScreen* DesktopCapturer::screenToDraw() const
+{
+    return m_screenToDraw;
+}

--- a/src/utils/DesktopCapturer.cpp
+++ b/src/utils/DesktopCapturer.cpp
@@ -8,12 +8,13 @@
 #include <QScreen>
 
 DesktopCapturer::DesktopCapturer()
-    : m_screenToDraw(nullptr)
+  : m_screenToDraw(nullptr)
 {
     reset();
 }
 
-void DesktopCapturer::reset() {
+void DesktopCapturer::reset()
+{
     m_geometry = QRect(0, 0, 0, 0);
     m_areas.clear();
 }
@@ -28,18 +29,23 @@ QPoint DesktopCapturer::topLeft() const
     return m_geometry.topLeft();
 }
 
-QPoint DesktopCapturer::topLeftScaledToScreen()  const{
-    return screenToDraw()->geometry().topLeft() / screenToDraw()->devicePixelRatio();
+QPoint DesktopCapturer::topLeftScaledToScreen() const
+{
+    return screenToDraw()->geometry().topLeft() /
+           screenToDraw()->devicePixelRatio();
 }
 
-QRect DesktopCapturer::geometry() {
+QRect DesktopCapturer::geometry()
+{
     // Get Top Left and Bottom Right
     QPoint maxPoint(INT_MIN, INT_MIN);
     QPoint topLeft = QPoint(INT_MAX, INT_MAX);
-    for (QScreen  const* screen : QGuiApplication::screens()) {
+    for (QScreen const* screen : QGuiApplication::screens()) {
         QRect geo = screen->geometry();
-        int const width = static_cast<int>(geo.width() * screen->devicePixelRatio());
-        int const height= static_cast<int>(geo.height() * screen->devicePixelRatio());
+        int const width =
+          static_cast<int>(geo.width() * screen->devicePixelRatio());
+        int const height =
+          static_cast<int>(geo.height() * screen->devicePixelRatio());
         int const maxX = width + geo.x();
         int const maxY = height + geo.y();
 
@@ -69,7 +75,8 @@ QRect DesktopCapturer::geometry() {
     return m_geometry;
 }
 
-QPixmap DesktopCapturer::captureDesktopComposite() {
+QPixmap DesktopCapturer::captureDesktopComposite()
+{
     m_screenToDraw = QGuiApplication::primaryScreen();
 
     // Calculate screen geometry
@@ -81,11 +88,12 @@ QPixmap DesktopCapturer::captureDesktopComposite() {
 
     // Draw composite screenshot
     QPainter painter(&desktop);
-    for (QScreen *screen : QGuiApplication::screens()) {
+    for (QScreen* screen : QGuiApplication::screens()) {
         QRect geo = screen->geometry();
         QPixmap pix = screen->grabWindow(0);
 
-        // Composite screenshot should have pixel ratio 1 to draw all screen with different ratios.
+        // Composite screenshot should have pixel ratio 1 to draw all screen
+        // with different ratios.
         pix.setDevicePixelRatio(1);
 
         // Calculate the offset of the current screen
@@ -104,16 +112,16 @@ QPixmap DesktopCapturer::captureDesktopComposite() {
     }
     painter.end();
 
-
     // Set pixmap DevicePixelRatio of the screen where it should be drawn.
     desktop.setDevicePixelRatio(screenToDraw()->devicePixelRatio());
 
     return desktop;
 }
 
-QPixmap DesktopCapturer::captureDesktopAtCursorPos() {
+QPixmap DesktopCapturer::captureDesktopAtCursorPos()
+{
     // Active is where the mouse cursor is, it can be not an active screen
-    QScreen *screen = screenAtCursorPos();
+    QScreen* screen = screenAtCursorPos();
     QPixmap pix;
     if (screen == nullptr) {
         return pix;
@@ -123,16 +131,17 @@ QPixmap DesktopCapturer::captureDesktopAtCursorPos() {
     m_geometry.setWidth(
       static_cast<int>(m_geometry.width() * screen->devicePixelRatio()));
     m_geometry.setHeight(
-        static_cast<int>(m_geometry.height() * screen->devicePixelRatio()));
+      static_cast<int>(m_geometry.height() * screen->devicePixelRatio()));
     return pix;
 }
 
-QScreen* DesktopCapturer::screenAtCursorPos() {
+QScreen* DesktopCapturer::screenAtCursorPos()
+{
     // Get the current global position of the mouse cursor.
-    // This position is in the virtual desktop coordinate system, which spans all screens.
+    // This position is in the virtual desktop coordinate system, which spans
+    // all screens.
     const QPoint mousePos = QCursor::pos();
     m_screenToDraw = QGuiApplication::primaryScreen();
-
 
     // Iterate through all screens available to the application.
     for (QScreen* screen : QGuiApplication::screens()) {
@@ -150,7 +159,8 @@ QScreen* DesktopCapturer::screenAtCursorPos() {
     return m_screenToDraw;
 }
 
-QPixmap DesktopCapturer::captureDesktop(bool composite) {
+QPixmap DesktopCapturer::captureDesktop(bool composite)
+{
     QPixmap desktop;
     reset();
 #ifdef Q_OS_MAC
@@ -161,17 +171,18 @@ QPixmap DesktopCapturer::captureDesktop(bool composite) {
 #endif
     if (composite) {
         desktop = captureDesktopComposite();
-    }
-    else {
+    } else {
         desktop = captureDesktopAtCursorPos();
     }
     return desktop;
 }
 
-QScreen* DesktopCapturer::screenToDraw() const {
+QScreen* DesktopCapturer::screenToDraw() const
+{
     return m_screenToDraw;
 }
 
-const QList<QRect>& DesktopCapturer::areas() const {
+const QList<QRect>& DesktopCapturer::areas() const
+{
     return m_areas;
 }

--- a/src/utils/DesktopCapturer.cpp
+++ b/src/utils/DesktopCapturer.cpp
@@ -193,7 +193,11 @@ const QList<QRect>& DesktopCapturer::areas() const
 
 QScreen* DesktopCapturer::lastScreen()
 {
+#if (defined(Q_OS_LINUX) || defined(Q_OS_UNIX))
     // At least in Gnome+XOrg, the last screen is actually the first screen
     // and all calculations are started from it, not from the PrimaryScreen.
     return QGuiApplication::screens().last();
+#else
+    return QGuiApplication::primaryScreen();
+#endif
 }

--- a/src/utils/DesktopCapturer.cpp
+++ b/src/utils/DesktopCapturer.cpp
@@ -77,7 +77,7 @@ QRect DesktopCapturer::geometry()
 
 QPixmap DesktopCapturer::captureDesktopComposite()
 {
-    m_screenToDraw = QGuiApplication::primaryScreen();
+    m_screenToDraw = lastScreen();
     qreal screenToDrawDpr = screenToDraw()->devicePixelRatio();
 
     // Calculate screen geometry
@@ -145,7 +145,7 @@ QScreen* DesktopCapturer::screenAtCursorPos()
     // This position is in the virtual desktop coordinate system, which spans
     // all screens.
     const QPoint mousePos = QCursor::pos();
-    m_screenToDraw = QGuiApplication::primaryScreen();
+    m_screenToDraw = lastScreen();
 
     // Iterate through all screens available to the application.
     for (QScreen* screen : QGuiApplication::screens()) {
@@ -189,4 +189,11 @@ QScreen* DesktopCapturer::screenToDraw() const
 const QList<QRect>& DesktopCapturer::areas() const
 {
     return m_areas;
+}
+
+QScreen* DesktopCapturer::lastScreen()
+{
+    // At least in Gnome+XOrg, the last screen is actually the first screen
+    // and all calculations are started from it, not from the PrimaryScreen.
+    return QGuiApplication::screens().last();
 }

--- a/src/utils/DesktopCapturer.cpp
+++ b/src/utils/DesktopCapturer.cpp
@@ -88,16 +88,19 @@ QPixmap DesktopCapturer::captureDesktopComposite() {
         // Composite screenshot should have pixel ratio 1 to draw all screen with different ratios.
         pix.setDevicePixelRatio(1);
 
-        // Calculate offset
+        // Calculate the offset of the current screen
+        // from the top left corner of the composite screen
         geo.setX(geo.x() - topLeft().x());
         geo.setY(geo.y() - topLeft().y());
 
         painter.drawPixmap(geo.x(), geo.y(), pix);
 
         // Prepare areas
-        geo.setX(geo.x() / screen->devicePixelRatio());
-        geo.setY(geo.y() / screen->devicePixelRatio());
-        m_areas.append(geo);
+        // (everything, including location, should be in logical pixels)
+        QRect areaRect = geo;
+        areaRect.moveLeft(geo.x() / screen->devicePixelRatio());
+        areaRect.moveTop(geo.y() / screen->devicePixelRatio());
+        m_areas.append(areaRect);
     }
     painter.end();
 

--- a/src/utils/DesktopCapturer.cpp
+++ b/src/utils/DesktopCapturer.cpp
@@ -77,7 +77,7 @@ QRect DesktopCapturer::geometry()
 
 QPixmap DesktopCapturer::captureDesktopComposite()
 {
-    m_screenToDraw = lastScreen();
+    m_screenToDraw = primaryScreen();
     qreal screenToDrawDpr = screenToDraw()->devicePixelRatio();
 
     // Calculate screen geometry
@@ -145,7 +145,7 @@ QScreen* DesktopCapturer::screenAtCursorPos()
     // This position is in the virtual desktop coordinate system, which spans
     // all screens.
     const QPoint mousePos = QCursor::pos();
-    m_screenToDraw = lastScreen();
+    m_screenToDraw = primaryScreen();
 
     // Iterate through all screens available to the application.
     for (QScreen* screen : QGuiApplication::screens()) {
@@ -191,7 +191,7 @@ const QList<QRect>& DesktopCapturer::areas() const
     return m_areas;
 }
 
-QScreen* DesktopCapturer::lastScreen()
+QScreen* DesktopCapturer::primaryScreen()
 {
 #if (defined(Q_OS_LINUX) || defined(Q_OS_UNIX))
     // At least in Gnome+XOrg, the last screen is actually the first screen

--- a/src/utils/DesktopCapturer.h
+++ b/src/utils/DesktopCapturer.h
@@ -1,0 +1,82 @@
+#ifndef DESKTOP_CAPTURER_H
+#define DESKTOP_CAPTURER_H
+
+#include <QObject>
+#include <QPixmap>
+#include <QPoint>
+#include <QRect>
+#include <QSize>
+#include <QScreen>
+
+/**
+ * @class DesktopCapturer
+ * @brief Provides functionality to capture screenshots of the desktop.
+ *
+ * This class can capture either a composite screenshot of all screens
+ * or a screenshot of the single screen where the mouse cursor is located.
+ */
+class DesktopCapturer : public QObject {
+    Q_OBJECT
+
+public:
+    DesktopCapturer();
+    ~DesktopCapturer() = default;
+
+    /**
+     * @brief Resets the internal geometry data.
+     */
+    void reset();
+
+    /**
+     * @brief Gets the size of the captured desktop area.
+     * @return The size as a QSize object.
+     */
+    QSize screenSize() const;
+
+    /**
+     * @brief Gets the top-left coordinate of the captured desktop area.
+     * @return The top-left point as a QPoint object.
+     */
+    QPoint topLeft() const;
+
+    QPoint topLeftScaledToScreen() const;
+
+    /**
+     * @brief Calculates and returns the geometry of the entire virtual desktop.
+     * @return The geometry as a QRect object.
+     */
+    QRect geometry();
+
+    /**
+     * @brief Captures a composite screenshot of all desktops.
+     * @return A QPixmap containing the combined desktop image.
+     */
+    QPixmap captureDesktopComposite();
+
+    /**
+     * @brief Captures a screenshot of the desktop at the mouse cursor's position.
+     * @return A QPixmap of the screen where the cursor is located.
+     */
+    QPixmap captureDesktopAtCursorPos();
+
+    /**
+     * @brief Main function to capture the desktop based on the composite flag.
+     * @param composite If true, captures a composite screenshot; otherwise, captures the screen at the cursor.
+     * @return The captured QPixmap.
+     */
+    QPixmap captureDesktop(bool composite = true);
+
+    QScreen* screenToDraw() const;
+
+private:
+    /**
+     * @brief Finds the QScreen instance where the mouse cursor is currently located.
+     * @return A pointer to the QScreen object.
+     */
+    QScreen* screenAtCursorPos();
+
+    QRect m_geometry;
+    QScreen* m_screenToDraw;
+};
+
+#endif // DESKTOP_CAPTURER_H

--- a/src/utils/DesktopCapturer.h
+++ b/src/utils/DesktopCapturer.h
@@ -82,6 +82,8 @@ private:
      * @return A pointer to the QScreen object.
      */
 
+    QScreen* lastScreen();
+
     QRect m_geometry;
     QScreen* m_screenToDraw;
     QVector<QRect> m_areas;

--- a/src/utils/DesktopCapturer.h
+++ b/src/utils/DesktopCapturer.h
@@ -68,6 +68,8 @@ public:
 
     QScreen* screenToDraw() const;
 
+    const QList<QRect>& areas() const;
+
 private:
     /**
      * @brief Finds the QScreen instance where the mouse cursor is currently located.
@@ -75,8 +77,9 @@ private:
      */
     QScreen* screenAtCursorPos();
 
-    QRect m_geometry;
-    QScreen* m_screenToDraw;
+    QRect           m_geometry;
+    QScreen*        m_screenToDraw;
+    QVector<QRect>  m_areas;
 };
 
 #endif // DESKTOP_CAPTURER_H

--- a/src/utils/DesktopCapturer.h
+++ b/src/utils/DesktopCapturer.h
@@ -5,8 +5,8 @@
 #include <QPixmap>
 #include <QPoint>
 #include <QRect>
-#include <QSize>
 #include <QScreen>
+#include <QSize>
 
 /**
  * @class DesktopCapturer
@@ -15,7 +15,8 @@
  * This class can capture either a composite screenshot of all screens
  * or a screenshot of the single screen where the mouse cursor is located.
  */
-class DesktopCapturer : public QObject {
+class DesktopCapturer : public QObject
+{
     Q_OBJECT
 
 public:
@@ -54,14 +55,16 @@ public:
     QPixmap captureDesktopComposite();
 
     /**
-     * @brief Captures a screenshot of the desktop at the mouse cursor's position.
+     * @brief Captures a screenshot of the desktop at the mouse cursor's
+     * position.
      * @return A QPixmap of the screen where the cursor is located.
      */
     QPixmap captureDesktopAtCursorPos();
 
     /**
      * @brief Main function to capture the desktop based on the composite flag.
-     * @param composite If true, captures a composite screenshot; otherwise, captures the screen at the cursor.
+     * @param composite If true, captures a composite screenshot; otherwise,
+     * captures the screen at the cursor.
      * @return The captured QPixmap.
      */
     QPixmap captureDesktop(bool composite = true);
@@ -72,14 +75,15 @@ public:
 
 private:
     /**
-     * @brief Finds the QScreen instance where the mouse cursor is currently located.
+     * @brief Finds the QScreen instance where the mouse cursor is currently
+     * located.
      * @return A pointer to the QScreen object.
      */
     QScreen* screenAtCursorPos();
 
-    QRect           m_geometry;
-    QScreen*        m_screenToDraw;
-    QVector<QRect>  m_areas;
+    QRect m_geometry;
+    QScreen* m_screenToDraw;
+    QVector<QRect> m_areas;
 };
 
 #endif // DESKTOP_CAPTURER_H

--- a/src/utils/DesktopCapturer.h
+++ b/src/utils/DesktopCapturer.h
@@ -73,13 +73,14 @@ public:
 
     const QList<QRect>& areas() const;
 
+    QScreen* screenAtCursorPos();
+
 private:
     /**
      * @brief Finds the QScreen instance where the mouse cursor is currently
      * located.
      * @return A pointer to the QScreen object.
      */
-    QScreen* screenAtCursorPos();
 
     QRect m_geometry;
     QScreen* m_screenToDraw;

--- a/src/utils/DesktopCapturer.h
+++ b/src/utils/DesktopCapturer.h
@@ -74,6 +74,7 @@ public:
     const QList<QRect>& areas() const;
 
     QScreen* screenAtCursorPos();
+    bool isComposite() const;
 
 private:
     /**
@@ -87,6 +88,7 @@ private:
     QRect m_geometry;
     QScreen* m_screenToDraw;
     QVector<QRect> m_areas;
+    bool m_composite;
 };
 
 #endif // DESKTOP_CAPTURER_H

--- a/src/utils/DesktopCapturer.h
+++ b/src/utils/DesktopCapturer.h
@@ -82,7 +82,7 @@ private:
      * @return A pointer to the QScreen object.
      */
 
-    QScreen* lastScreen();
+    QScreen* primaryScreen();
 
     QRect m_geometry;
     QScreen* m_screenToDraw;

--- a/src/utils/screengrabber.cpp
+++ b/src/utils/screengrabber.cpp
@@ -271,6 +271,7 @@ QRect ScreenGrabber::desktopGeometry()
 
     for (QScreen* const screen : QGuiApplication::screens()) {
         QRect scrRect = screen->geometry();
+        qWarning() << "ScreenGrabber::desktopGeometry() - scrRect =" << scrRect;
         // Qt6 fix: Don't divide by devicePixelRatio for multi-monitor setups
         // This was causing coordinate offset issues in dual monitor
         // configurations
@@ -279,6 +280,7 @@ QRect ScreenGrabber::desktopGeometry()
         scrRect.moveTo(QPointF(scrRect.x() / dpr, scrRect.y() / dpr).toPoint());
         geometry = geometry.united(scrRect);
     }
+    qWarning() << "ScreenGrabber::desktopGeometry() - geometry =" << geometry;
     return geometry;
 }
 

--- a/src/utils/screengrabber.cpp
+++ b/src/utils/screengrabber.cpp
@@ -276,10 +276,8 @@ QRect ScreenGrabber::desktopGeometry()
         // This was causing coordinate offset issues in dual monitor
         // configurations
         // But it still has a screen position in real pixels, not logical ones
-#if Q_OS_LINUX
         qreal dpr = screen->devicePixelRatio();
         scrRect.moveTo(QPointF(scrRect.x() / dpr, scrRect.y() / dpr).toPoint());
-#endif
         qWarning() << "ScreenGrabber::desktopGeometry() - scrRect (scaled) =" << scrRect;
         geometry = geometry.united(scrRect);
     }

--- a/src/utils/screengrabber.cpp
+++ b/src/utils/screengrabber.cpp
@@ -277,6 +277,7 @@ QRect ScreenGrabber::desktopGeometry()
         // configurations
         // But it still has a screen position in real pixels, not logical ones
         qreal dpr = screen->devicePixelRatio();
+        qWarning() << "ScreenGrabber::desktopGeometry() - dpr =" << dpr;
         scrRect.moveTo(QPointF(scrRect.x() / dpr, scrRect.y() / dpr).toPoint());
         qWarning() << "ScreenGrabber::desktopGeometry() - scrRect (scaled) =" << scrRect;
         geometry = geometry.united(scrRect);

--- a/src/utils/screengrabber.cpp
+++ b/src/utils/screengrabber.cpp
@@ -269,6 +269,10 @@ QRect ScreenGrabber::desktopGeometry()
 {
     QRect geometry;
 
+    QScreen *primaryScreen = QGuiApplication::primaryScreen();
+    qreal primaryScreenDpr = primaryScreen->devicePixelRatio();
+    qWarning() << "ScreenGrabber::desktopGeometry() - primaryScreenDpr =" << primaryScreenDpr;
+
     for (QScreen* const screen : QGuiApplication::screens()) {
         QRect scrRect = screen->geometry();
         qWarning() << "ScreenGrabber::desktopGeometry() - scrRect =" << scrRect;
@@ -276,9 +280,14 @@ QRect ScreenGrabber::desktopGeometry()
         // This was causing coordinate offset issues in dual monitor
         // configurations
         // But it still has a screen position in real pixels, not logical ones
-        qreal dpr = screen->devicePixelRatio();
-        qWarning() << "ScreenGrabber::desktopGeometry() - dpr =" << dpr;
-        scrRect.moveTo(QPointF(scrRect.x() / dpr, scrRect.y() / dpr).toPoint());
+
+        //qreal dpr = screen->devicePixelRatio();
+        // qreal dpr = primaryScreenDpr;
+        // qWarning() << "ScreenGrabber::desktopGeometry() - dpr =" << dpr;
+
+        qWarning() << "ScreenGrabber::desktopGeometry() - primaryScreenDpr =" << primaryScreenDpr;
+        // scrRect.moveTo(QPointF(scrRect.x() / dpr, scrRect.y() / dpr).toPoint());
+        scrRect.moveTo(QPointF(scrRect.x() / primaryScreenDpr, scrRect.y() / primaryScreenDpr).toPoint());
         qWarning() << "ScreenGrabber::desktopGeometry() - scrRect (scaled) =" << scrRect;
         geometry = geometry.united(scrRect);
     }

--- a/src/utils/screengrabber.cpp
+++ b/src/utils/screengrabber.cpp
@@ -276,8 +276,11 @@ QRect ScreenGrabber::desktopGeometry()
         // This was causing coordinate offset issues in dual monitor
         // configurations
         // But it still has a screen position in real pixels, not logical ones
+#if Q_OS_LINUX
         qreal dpr = screen->devicePixelRatio();
         scrRect.moveTo(QPointF(scrRect.x() / dpr, scrRect.y() / dpr).toPoint());
+#endif
+        qWarning() << "ScreenGrabber::desktopGeometry() - scrRect (scaled) =" << scrRect;
         geometry = geometry.united(scrRect);
     }
     qWarning() << "ScreenGrabber::desktopGeometry() - geometry =" << geometry;

--- a/src/utils/screengrabber.cpp
+++ b/src/utils/screengrabber.cpp
@@ -226,10 +226,10 @@ QPixmap ScreenGrabber::grabEntireDesktop(bool& ok)
                                 geometry.width(),
                                 geometry.height());
 
-    QString downloadsPath = QStandardPaths::writableLocation(QStandardPaths::DownloadLocation);
+    QString downloadsPath =
+      QStandardPaths::writableLocation(QStandardPaths::DownloadLocation);
     QString filePath = downloadsPath + "/screenshot.png";
     desktop.save(filePath, "PNG");
-
 
     return desktop;
 #endif
@@ -281,9 +281,10 @@ QRect ScreenGrabber::desktopGeometry()
 
     qreal dpr = 1.0;
 #ifdef Q_OS_WIN
-    QScreen *primaryScreen = QGuiApplication::primaryScreen();
+    QScreen* primaryScreen = QGuiApplication::primaryScreen();
     dpr = primaryScreen->devicePixelRatio();
-    qWarning() << "ScreenGrabber::desktopGeometry() - (primaryScreen) dpr =" << dpr;
+    qWarning() << "ScreenGrabber::desktopGeometry() - (primaryScreen) dpr ="
+               << dpr;
 #endif
 
     for (QScreen* const screen : QGuiApplication::screens()) {
@@ -298,7 +299,8 @@ QRect ScreenGrabber::desktopGeometry()
 #endif
 
         scrRect.moveTo(QPointF(scrRect.x() / dpr, scrRect.y() / dpr).toPoint());
-        qWarning() << "ScreenGrabber::desktopGeometry() - scrRect (scaled = "<< dpr << ") =" << scrRect;
+        qWarning() << "ScreenGrabber::desktopGeometry() - scrRect (scaled = "
+                   << dpr << ") =" << scrRect;
         geometry = geometry.united(scrRect);
     }
     qWarning() << "ScreenGrabber::desktopGeometry() - geometry =" << geometry;

--- a/src/utils/screengrabber.cpp
+++ b/src/utils/screengrabber.cpp
@@ -23,6 +23,9 @@
 #include <QUuid>
 #endif
 
+// TODO: This should be removed after the complete switch to the DesktopCapture
+// It is still used (but does not properly work) for non-fullscreen captures
+
 ScreenGrabber::ScreenGrabber(QObject* parent)
   : QObject(parent)
 {}

--- a/src/utils/screengrabber.cpp
+++ b/src/utils/screengrabber.cpp
@@ -13,6 +13,7 @@
 #include <QProcess>
 #include <QScreen>
 
+#include <QStandardPaths>
 #if !(defined(Q_OS_MACOS) || defined(Q_OS_WIN))
 #include "request.h"
 #include <QDBusInterface>

--- a/src/utils/screengrabber.h
+++ b/src/utils/screengrabber.h
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // SPDX-FileCopyrightText: 2017-2019 Alejandro Sirgo Rica & Contributors
 
+// TODO: This should be removed after the complete switch to the DesktopCapture
+// It is still used (but does not properly work) for non-fullscreen captures
+
 #pragma once
 
 #include "src/utils/desktopinfo.h"

--- a/src/widgets/capture/buttonhandler.cpp
+++ b/src/widgets/capture/buttonhandler.cpp
@@ -76,7 +76,7 @@ void ButtonHandler::updatePosition(const QRect& selection)
     // Copy of the selection area for internal modifications
     m_selection = intersectWithAreas(selection);
     updateBlockedSides();
-    ensureSelectionMinimunSize();
+    ensureSelectionMinimumSize();
     // Indicates the actual button to be moved
     int elemIndicator = 0;
 
@@ -290,8 +290,8 @@ void ButtonHandler::expandSelection()
 
 void ButtonHandler::positionButtonsInside(int index)
 {
-    // Position the buttons in the botton-center of the main but inside of the
-    // selection.
+    // Position the buttons at the bottom center of the main area,
+    // but inside the selection.
     QRect mainArea = m_selection;
     mainArea = intersectWithAreas(mainArea);
     const int buttonsPerRow = (mainArea.width()) / (m_buttonExtendedSize);
@@ -312,7 +312,7 @@ void ButtonHandler::positionButtonsInside(int index)
     m_buttonsAreInside = true;
 }
 
-void ButtonHandler::ensureSelectionMinimunSize()
+void ButtonHandler::ensureSelectionMinimumSize()
 {
     // Detect if a side is smaller than a button in order to prevent collision
     // and redimension the base area the the base size of a single button per

--- a/src/widgets/capture/buttonhandler.h
+++ b/src/widgets/capture/buttonhandler.h
@@ -73,7 +73,7 @@ private:
     void updateBlockedSides();
     void expandSelection();
     void positionButtonsInside(int index);
-    void ensureSelectionMinimunSize();
+    void ensureSelectionMinimumSize();
     void moveButtonsToPoints(const QVector<QPoint>& points, int& index);
     void adjustHorizontalCenter(QPoint& center);
 };

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -193,11 +193,14 @@ CaptureWidget::CaptureWidget(const CaptureRequest& req,
         // LINUX & WINDOWS
         for (QScreen* const screen : QGuiApplication::screens()) {
             QRect r = screen->geometry();
+            qWarning() << "CaptureWidget::CaptureWidget; r =" << r;
             r.moveTo(r.x() / screen->devicePixelRatio(),
                      r.y() / screen->devicePixelRatio());
             r.moveTo(r.topLeft() - topLeftOffset);
+            qWarning() << "CaptureWidget::CaptureWidget - scaled; r =" << r;
             areas.append(r);
         }
+
 #endif
     } else {
         areas.append(rect());

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -114,11 +114,9 @@ CaptureWidget::CaptureWidget(const CaptureRequest& req,
         bool ok = true;
         // m_context.screenshot = ScreenGrabber().grabEntireDesktop(ok);
 
-
 #if defined(FLAMESHOT_DEBUG_CAPTURE)
         m_context.screenshot.save("screenshot.png", "PNG");
 #endif
-
 
         if (!ok) {
             AbstractLogger::error() << tr("Unable to capture screen");
@@ -129,23 +127,23 @@ CaptureWidget::CaptureWidget(const CaptureRequest& req,
         ////////////////////////////////////////
         // Set CaptureWidget properties
 #if defined(Q_OS_WIN)
-    // Call cmake with -DFLAMESHOT_DEBUG_CAPTURE=ON to enable easier debugging
-    #if !defined(FLAMESHOT_DEBUG_CAPTURE)
+// Call cmake with -DFLAMESHOT_DEBUG_CAPTURE=ON to enable easier debugging
+#if !defined(FLAMESHOT_DEBUG_CAPTURE)
         setWindowFlags(Qt::WindowStaysOnTopHint | Qt::FramelessWindowHint |
                        Qt::SubWindow // Hides the taskbar icon
         );
-    #endif
+#endif
 #elif defined(Q_OS_MACOS)
         QScreen* currentScreen = QGuiAppCurrentScreen().currentScreen();
         move(currentScreen->geometry().x(), currentScreen->geometry().y());
         resize(currentScreen->size());
 // LINUX
 #else
-    // Call cmake with -DFLAMESHOT_DEBUG_CAPTURE=ON to enable easier debugging
-    #if !defined(FLAMESHOT_DEBUG_CAPTURE)
+// Call cmake with -DFLAMESHOT_DEBUG_CAPTURE=ON to enable easier debugging
+#if !defined(FLAMESHOT_DEBUG_CAPTURE)
         setWindowFlags(Qt::BypassWindowManagerHint | Qt::WindowStaysOnTopHint |
                        Qt::FramelessWindowHint | Qt::Tool);
-    #endif
+#endif
 #endif
         // Set CaptureWidget properties ^^^
         //^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -153,13 +151,14 @@ CaptureWidget::CaptureWidget(const CaptureRequest& req,
         ////////////////////////////////////////
         // Resize and move CaptureWidget
         if (!compositeDesktop) {
-            resize(desktopCapturer.screenSize() / desktopCapturer.screenToDraw()->devicePixelRatio());
+            resize(desktopCapturer.screenSize() /
+                   desktopCapturer.screenToDraw()->devicePixelRatio());
             move(desktopCapturer.screenToDraw()->geometry().topLeft());
-        }
-        else {
+        } else {
             resize(desktopCapturer.screenSize());
 #ifdef Q_OS_WIN
-            move(desktopCapturer.topLeft() / desktopCapturer.screenToDraw()->devicePixelRatio());
+            move(desktopCapturer.topLeft() /
+                 desktopCapturer.screenToDraw()->devicePixelRatio());
 #elif (defined(Q_OS_LINUX) || defined(Q_OS_UNIX))
             move(desktopCapturer.topLeftScaledToScreen());
 #else

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -162,7 +162,7 @@ CaptureWidget::CaptureWidget(const CaptureRequest& req,
         else {
             resize(desktopCapturer.screenSize());
 #ifdef Q_OS_WIN
-            move(0, 0);
+            move(desktopCapturer.topLeft() / desktopCapturer.screenToDraw()->devicePixelRatio());
 #elif (defined(Q_OS_LINUX) || defined(Q_OS_UNIX))
             move(desktopCapturer.topLeftScaledToScreen());
 #else

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -106,7 +106,8 @@ CaptureWidget::CaptureWidget(const CaptureRequest& req,
     ///////////////////////////////////////////////////////////////////////////
     // Capture Desktop Screen(s)
     DesktopCapturer desktopCapturer;
-    m_context.screenshot = desktopCapturer.captureDesktop();
+    bool compositeDesktop = true;
+    m_context.screenshot = desktopCapturer.captureDesktop(compositeDesktop);
 
     if (fullScreen) {
         // Grab Screenshot
@@ -151,8 +152,23 @@ CaptureWidget::CaptureWidget(const CaptureRequest& req,
 
         ////////////////////////////////////////
         // Resize and move CaptureWidget
-        resize(desktopCapturer.screenSize());
-        move(desktopCapturer.topLeftScaledToScreen());
+        qWarning() << "desktopCapturer.screenSize()" << desktopCapturer.screenSize();
+        qWarning() << "desktopCapturer.screenToDraw()" << desktopCapturer.screenToDraw()->name();
+        qWarning() << "desktopCapturer.screenToDraw()" << desktopCapturer.screenToDraw()->geometry();
+        if (!compositeDesktop) {
+            resize(desktopCapturer.screenSize() / desktopCapturer.screenToDraw()->devicePixelRatio());
+            move(desktopCapturer.screenToDraw()->geometry().topLeft());
+        }
+        else {
+            resize(desktopCapturer.screenSize());
+#ifdef Q_OS_WIN
+            move(0, 0);
+#elif (defined(Q_OS_LINUX) || defined(Q_OS_UNIX))
+            move(desktopCapturer.topLeftScaledToScreen());
+#else
+            // MACOS - no need, is resolved below
+#endif
+        }
         //^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     }
     // Capture Desktop Screen(s) ^^^

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -151,10 +151,11 @@ CaptureWidget::CaptureWidget(const CaptureRequest& req,
         } else {
             resize(m_desktopCapturer.screenSize());
 #ifdef Q_OS_WIN
-            move(m_desktopCapturer.topLeft() /
-                 m_desktopCapturer.screenToDraw()->devicePixelRatio());
+            // move(m_desktopCapturer.topLeft() /
+                 // m_desktopCapturer.screenToDraw()->devicePixelRatio());
+            move(m_desktopCapturer.topLeft());
 #elif (defined(Q_OS_LINUX) || defined(Q_OS_UNIX))
-            move(m_desktopCapturer.topLeftScaledToScreen());
+            move(m_desktopCapturer.topLeft());
 #else
             // MACOS - no need, is resolved below
 #endif

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -263,13 +263,22 @@ CaptureWidget::CaptureWidget(const CaptureRequest& req,
 
     // Qt6 has only sizes in logical values, position is in physical values.
     // Move Help message to the logical pixel with devicePixelRatio.
+
     QScreen* currentScreen = QGuiAppCurrentScreen().currentScreen();
     QRect currentScreenGeometry = currentScreen->geometry();
     qreal currentScreenDpr = currentScreen->devicePixelRatio();
     currentScreenGeometry.moveTo(
-      int(currentScreenGeometry.x() / currentScreenDpr),
-      int(currentScreenGeometry.y() / currentScreenDpr));
-    OverlayMessage::init(this, currentScreenGeometry);
+      static_cast<int>(currentScreenGeometry.x() / currentScreenDpr),
+      static_cast<int>(currentScreenGeometry.y() / currentScreenDpr));
+
+    QRect screenToDrawGeometry = desktopCapturer.screenToDraw()->geometry();
+    screenToDrawGeometry.moveTo(
+      static_cast<int>(screenToDrawGeometry.x() / currentScreenDpr),
+      static_cast<int>(screenToDrawGeometry.y() / currentScreenDpr));
+    qWarning() << "screenToDrawGeometry =" << screenToDrawGeometry;
+    qWarning() << "currentScreenGeometry = " << currentScreenGeometry;
+
+    OverlayMessage::init(this, screenToDrawGeometry);
 
     if (m_config.showHelp()) {
         initHelpMessage();

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -152,9 +152,6 @@ CaptureWidget::CaptureWidget(const CaptureRequest& req,
 
         ////////////////////////////////////////
         // Resize and move CaptureWidget
-        qWarning() << "desktopCapturer.screenSize()" << desktopCapturer.screenSize();
-        qWarning() << "desktopCapturer.screenToDraw()" << desktopCapturer.screenToDraw()->name();
-        qWarning() << "desktopCapturer.screenToDraw()" << desktopCapturer.screenToDraw()->geometry();
         if (!compositeDesktop) {
             resize(desktopCapturer.screenSize() / desktopCapturer.screenToDraw()->devicePixelRatio());
             move(desktopCapturer.screenToDraw()->geometry().topLeft());
@@ -190,7 +187,7 @@ CaptureWidget::CaptureWidget(const CaptureRequest& req,
         r.moveTo(0, 0);
         areas.append(r);
 #else
-        areas.append(desktopCapturer.geometry());
+        areas = desktopCapturer.areas();
 #endif
     } else {
         areas.append(rect());

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -258,10 +258,11 @@ CaptureWidget::CaptureWidget(const CaptureRequest& req,
     // Qt6 has only sizes in logical values, position is in physical values.
     // Move Help message to the logical pixel with devicePixelRatio.
     QScreen* screenAtCursorPos = m_desktopCapturer.screenAtCursorPos();
-    qreal screenAtCursorPosDpr = screenAtCursorPos->devicePixelRatio();
+    qreal screenToDrawDpr =
+      m_desktopCapturer.screenToDraw()->devicePixelRatio();
     QRect screenToDrawGeometry = m_desktopCapturer.screenToDraw()->geometry();
     screenToDrawGeometry.moveTo(screenAtCursorPos->geometry().topLeft() /
-                                screenAtCursorPosDpr);
+                                screenToDrawDpr);
     OverlayMessage::init(this, screenToDrawGeometry);
 
     if (m_config.showHelp()) {
@@ -1149,9 +1150,11 @@ void CaptureWidget::initPanel()
     }
 
     QScreen* screenAtCursorPos = m_desktopCapturer.screenAtCursorPos();
-    qreal screenAtCursorPosDpr = screenAtCursorPos->devicePixelRatio();
+    qreal screenToDrawDpr =
+      m_desktopCapturer.screenToDraw()->devicePixelRatio();
     QRect screenToDrawGeometry = m_desktopCapturer.screenToDraw()->geometry();
-    screenToDrawGeometry.moveTo(screenAtCursorPos->geometry().topLeft());
+    screenToDrawGeometry.moveTo(screenAtCursorPos->geometry().topLeft() /
+                                screenToDrawDpr);
 
     if (ConfigHandler().showSidePanelButton()) {
         auto* panelToggleButton =
@@ -1167,8 +1170,8 @@ void CaptureWidget::initPanel()
             static_cast<int>(panelToggleButton->width() / 2));
 #else
         panelToggleButton->move(
-          static_cast<int>(screenToDrawGeometry.x() / screenAtCursorPosDpr),
-          static_cast<int>(screenToDrawGeometry.y() / screenAtCursorPosDpr +
+          static_cast<int>(screenToDrawGeometry.x() / screenToDrawDpr),
+          static_cast<int>(screenToDrawGeometry.y() / screenToDrawDpr +
                            (screenToDrawGeometry.height() / 2 -
                             panelToggleButton->width() / 2)));
 #endif
@@ -1193,9 +1196,8 @@ void CaptureWidget::initPanel()
     panelRect.moveTo(mapFromGlobal(screenToDrawGeometry.topLeft()));
     panelRect.setWidth(m_colorPicker->width() * 1.5);
     m_panel->setGeometry(panelRect);
-    m_panel->move(
-      static_cast<int>(screenToDrawGeometry.x() / screenAtCursorPosDpr),
-      static_cast<int>(screenToDrawGeometry.y() / screenAtCursorPosDpr));
+    m_panel->move(static_cast<int>(screenToDrawGeometry.x() / screenToDrawDpr),
+                  static_cast<int>(screenToDrawGeometry.y() / screenToDrawDpr));
 
 #endif
     connect(m_panel,

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -1169,11 +1169,10 @@ void CaptureWidget::initPanel()
           static_cast<int>(panelRect.height() / 2) -
             static_cast<int>(panelToggleButton->width() / 2));
 #else
-        panelToggleButton->move(
-          static_cast<int>(screenToDrawGeometry.x() / screenToDrawDpr),
-          static_cast<int>(screenToDrawGeometry.y() / screenToDrawDpr +
-                           (screenToDrawGeometry.height() / 2 -
-                            panelToggleButton->width() / 2)));
+        panelToggleButton->move(screenToDrawGeometry.x(),
+                                screenToDrawGeometry.y() +
+                                  (screenToDrawGeometry.height() / 2 -
+                                   panelToggleButton->width() / 2));
 #endif
         panelToggleButton->setCursor(Qt::ArrowCursor);
         (new DraggableWidgetMaker(this))->makeDraggable(panelToggleButton);
@@ -1196,8 +1195,7 @@ void CaptureWidget::initPanel()
     panelRect.moveTo(mapFromGlobal(screenToDrawGeometry.topLeft()));
     panelRect.setWidth(m_colorPicker->width() * 1.5);
     m_panel->setGeometry(panelRect);
-    m_panel->move(static_cast<int>(screenToDrawGeometry.x() / screenToDrawDpr),
-                  static_cast<int>(screenToDrawGeometry.y() / screenToDrawDpr));
+    m_panel->move(screenToDrawGeometry.x(), screenToDrawGeometry.y());
 
 #endif
     connect(m_panel,
@@ -1845,8 +1843,6 @@ CaptureTool::Type CaptureWidget::activeButtonToolType() const
 QPoint CaptureWidget::snapToGrid(const QPoint& point) const
 {
     QPoint snapPoint = mapToGlobal(point);
-
-    const auto scale{ m_context.screenshot.devicePixelRatio() };
 
     snapPoint.setX((qRound(snapPoint.x() / double(m_gridSize)) * m_gridSize));
     snapPoint.setY((qRound(snapPoint.y() / double(m_gridSize)) * m_gridSize));

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -257,12 +257,11 @@ CaptureWidget::CaptureWidget(const CaptureRequest& req,
 
     // Qt6 has only sizes in logical values, position is in physical values.
     // Move Help message to the logical pixel with devicePixelRatio.
-    QScreen *screenAtCursorPos = m_desktopCapturer.screenAtCursorPos();
+    QScreen* screenAtCursorPos = m_desktopCapturer.screenAtCursorPos();
     qreal screenAtCursorPosDpr = screenAtCursorPos->devicePixelRatio();
     QRect screenToDrawGeometry = m_desktopCapturer.screenToDraw()->geometry();
-    screenToDrawGeometry.moveTo(
-        screenAtCursorPos->geometry().topLeft() / screenAtCursorPosDpr);
-
+    screenToDrawGeometry.moveTo(screenAtCursorPos->geometry().topLeft() /
+                                screenAtCursorPosDpr);
     OverlayMessage::init(this, screenToDrawGeometry);
 
     if (m_config.showHelp()) {
@@ -1149,7 +1148,7 @@ void CaptureWidget::initPanel()
 #endif
     }
 
-    QScreen *screenAtCursorPos = m_desktopCapturer.screenAtCursorPos();
+    QScreen* screenAtCursorPos = m_desktopCapturer.screenAtCursorPos();
     qreal screenAtCursorPosDpr = screenAtCursorPos->devicePixelRatio();
     QRect screenToDrawGeometry = m_desktopCapturer.screenToDraw()->geometry();
     screenToDrawGeometry.moveTo(screenAtCursorPos->geometry().topLeft());
@@ -1168,10 +1167,10 @@ void CaptureWidget::initPanel()
             static_cast<int>(panelToggleButton->width() / 2));
 #else
         panelToggleButton->move(
-            static_cast<int>(screenToDrawGeometry.x() / screenAtCursorPosDpr),
-            static_cast<int>(screenToDrawGeometry.y() / screenAtCursorPosDpr +
-                (screenToDrawGeometry.height() / 2 - panelToggleButton->width() / 2)));
-
+          static_cast<int>(screenToDrawGeometry.x() / screenAtCursorPosDpr),
+          static_cast<int>(screenToDrawGeometry.y() / screenAtCursorPosDpr +
+                           (screenToDrawGeometry.height() / 2 -
+                            panelToggleButton->width() / 2)));
 #endif
         panelToggleButton->setCursor(Qt::ArrowCursor);
         (new DraggableWidgetMaker(this))->makeDraggable(panelToggleButton);
@@ -1190,14 +1189,13 @@ void CaptureWidget::initPanel()
     m_panel->setFixedWidth(static_cast<int>(m_colorPicker->width() * 1.5));
     m_panel->setFixedHeight(currentScreen->geometry().height());
 #else
-    // QRect screenToDrawGeometry = m_desktopCapturer.screenToDraw()->geometry();
     panelRect.setHeight(screenToDrawGeometry.height());
     panelRect.moveTo(mapFromGlobal(screenToDrawGeometry.topLeft()));
     panelRect.setWidth(m_colorPicker->width() * 1.5);
     m_panel->setGeometry(panelRect);
     m_panel->move(
-        static_cast<int>(screenToDrawGeometry.x() / screenAtCursorPosDpr),
-        static_cast<int>(screenToDrawGeometry.y() / screenAtCursorPosDpr));
+      static_cast<int>(screenToDrawGeometry.x() / screenAtCursorPosDpr),
+      static_cast<int>(screenToDrawGeometry.y() / screenAtCursorPosDpr));
 
 #endif
     connect(m_panel,

--- a/src/widgets/capture/capturewidget.h
+++ b/src/widgets/capture/capturewidget.h
@@ -17,6 +17,7 @@
 #include "src/config/generalconf.h"
 #include "src/tools/capturecontext.h"
 #include "src/tools/capturetool.h"
+#include "src/utils/DesktopCapturer.h"
 #include "src/utils/confighandler.h"
 #include "src/widgets/capture/magnifierwidget.h"
 #include "src/widgets/capture/selectionwidget.h"
@@ -36,6 +37,7 @@ class QNetworkReply;
 class ColorPicker;
 class NotifierBox;
 class HoverEventFilter;
+
 #if !defined(DISABLE_UPDATE_CHECKER)
 class UpdateNotificationWidget;
 #endif
@@ -229,4 +231,7 @@ private:
     // Grid
     bool m_displayGrid{ false };
     int m_gridSize{ 10 };
+
+    //
+    DesktopCapturer m_desktopCapturer;
 };

--- a/src/widgets/capture/capturewidget.h
+++ b/src/widgets/capture/capturewidget.h
@@ -114,6 +114,7 @@ protected:
     void changeEvent(QEvent* changeEvent) override;
 
 private:
+    void setWidgetFlags();
     void pushObjectsStateToUndoStack();
     void releaseActiveTool();
     void uncheckActiveTool();

--- a/src/widgets/capture/capturewidget.h
+++ b/src/widgets/capture/capturewidget.h
@@ -37,6 +37,8 @@ class QNetworkReply;
 class ColorPicker;
 class NotifierBox;
 class HoverEventFilter;
+class OverlayMessage;
+class OrientablePushButton;
 
 #if !defined(DISABLE_UPDATE_CHECKER)
 class UpdateNotificationWidget;
@@ -102,6 +104,7 @@ public:
 
 protected:
     void paintEvent(QPaintEvent* paintEvent) override;
+    void leaveEvent(QEvent* event) override;
     void mousePressEvent(QMouseEvent* mouseEvent) override;
     void mouseMoveEvent(QMouseEvent* mouseEvent) override;
     void mouseReleaseEvent(QMouseEvent* mouseEvent) override;
@@ -114,6 +117,9 @@ protected:
     void changeEvent(QEvent* changeEvent) override;
 
 private:
+    void showHelp();
+    void initScreenshotEditor(bool compositeDesktop);
+    void moveToActiveScreen();
     void setWidgetFlags();
     void pushObjectsStateToUndoStack();
     void releaseActiveTool();
@@ -235,4 +241,6 @@ private:
 
     //
     DesktopCapturer m_desktopCapturer;
+    OverlayMessage* m_ovelayMessage;
+    OrientablePushButton* m_panelToggleButton;
 };

--- a/src/widgets/capture/overlaymessage.cpp
+++ b/src/widgets/capture/overlaymessage.cpp
@@ -35,11 +35,6 @@ OverlayMessage::OverlayMessage(QWidget* parent, const QRect& targetArea)
     QWidget::hide();
 }
 
-void OverlayMessage::init(QWidget* parent, const QRect& targetArea)
-{
-    new OverlayMessage(parent, targetArea);
-}
-
 /**
  * @brief Push a message to the message stack.
  * @param msg Message text formatted as rich text

--- a/src/widgets/capture/overlaymessage.h
+++ b/src/widgets/capture/overlaymessage.h
@@ -19,10 +19,11 @@
  */
 class OverlayMessage : public QLabel
 {
+    Q_OBJECT
 public:
-    OverlayMessage() = delete;
+    OverlayMessage(QWidget* parent, const QRect& targetArea);
 
-    static void init(QWidget* parent, const QRect& targetArea);
+    OverlayMessage* init(QWidget* parent, const QRect& targetArea);
     static void push(const QString& msg);
     static void pop();
     static void setVisibility(bool visible);
@@ -36,8 +37,6 @@ private:
     QRect m_targetArea;
     QColor m_fillColor, m_textColor;
     static OverlayMessage* m_instance;
-
-    OverlayMessage(QWidget* parent, const QRect& center);
 
     void paintEvent(QPaintEvent*) override;
 


### PR DESCRIPTION
The fix works for:
- Windows
- Linux+XOrg, with a good preparation for Wayland
- Most likely for MacOS, wasn't tested.

Qt6 has an issue with the primary display detection.
Depending on the location of the screens, the primary screen doesn't remain unchanged for Qt. I also tried using first/last, but it didn't work either. It means that I cannot detect the offset for the composite (all screens) screenshot.
The screenshot generates properly, but I didn't find a way to locate it correctly.
So I reworked the logic of the application.

New logic:
- Take a screenshot from only the active display (mouse position).
- If you move the mouse cursor to another display, it will make a screenshot for the new active display.
- If you started to edit a screenshot, a new screenshot won't be taken.

This approach simplifies work for Mac and Wayland (once implemented). The issue with "no icon in the status bar" is handled.

Also, I partially removed some features, like "take an area" from the command line, as it didn't work anyway. I reworked a screenshot-grabbing mechanism from scratch.

Note: This MR is not well-tested. Please help me with it.

@borgmanJeremy @mmahmoudian 