### PR TITLE
Add UI language selection

### DIFF
--- a/flameshot.example.ini
+++ b/flameshot.example.ini
@@ -18,6 +18,9 @@
 ;; Default file extension for screenshots
 ;saveAsFileExtension=.png
 ;
+;; UI language (auto = detected system language)
+; uiLanguage=auto
+;
 ;; Main UI color
 ;; Color is any valid hex code or W3C color name
 ;uiColor=#740096

--- a/src/config/visualseditor.h
+++ b/src/config/visualseditor.h
@@ -5,6 +5,7 @@
 
 #include <QTabWidget>
 #include <QWidget>
+#include <QComboBox>
 
 class ExtendedSlider;
 class QVBoxLayout;
@@ -35,6 +36,9 @@ private:
     ButtonListView* m_buttonList;
     ExtendedSlider* m_opacitySlider;
 
+    QComboBox* m_selectTranslation;
+
     void initWidgets();
     void initOpacitySlider();
+    void initTranslations();
 };

--- a/src/config/visualseditor.h
+++ b/src/config/visualseditor.h
@@ -3,9 +3,9 @@
 
 #pragma once
 
+#include <QComboBox>
 #include <QTabWidget>
 #include <QWidget>
-#include <QComboBox>
 
 class ExtendedSlider;
 class QVBoxLayout;

--- a/src/utils/confighandler.cpp
+++ b/src/utils/confighandler.cpp
@@ -55,15 +55,12 @@ bool verifyLaunchFile()
  *             misbehave.
  */
 #define OPTION(KEY, TYPE)                                                      \
-    {                                                                          \
-        QStringLiteral(KEY), QSharedPointer<ValueHandler>(new TYPE)            \
-    }
+    { QStringLiteral(KEY), QSharedPointer<ValueHandler>(new TYPE) }
 
 #define SHORTCUT(NAME, DEFAULT_VALUE)                                          \
-    {                                                                          \
-        QStringLiteral(NAME), QSharedPointer<KeySequence>(new KeySequence(     \
-                                QKeySequence(QLatin1String(DEFAULT_VALUE))))   \
-    }
+    { QStringLiteral(NAME),                                                    \
+      QSharedPointer<KeySequence>(                                             \
+        new KeySequence(QKeySequence(QLatin1String(DEFAULT_VALUE)))) }
 
 /**
  * This map contains all the information that is needed to parse, verify and
@@ -107,6 +104,7 @@ static QMap<class QString, QSharedPointer<ValueHandler>>
     OPTION("uploadHistoryMax"            ,LowerBoundedInt    ( 0, 25         )),
     OPTION("undoLimit"                   ,BoundedInt         ( 0, 999, 100   )),
     // Interface tab
+    OPTION("uiLanguage"                  ,String             ( "auto"        )),
     OPTION("uiColor"                     ,Color              ( {116, 0, 150} )),
     OPTION("contrastUiColor"             ,Color              ( {39, 0, 50}   )),
     OPTION("contrastOpacity"             ,BoundedInt         ( 0, 255, 190   )),
@@ -211,7 +209,7 @@ ConfigHandler::ConfigHandler()
         QObject::connect(m_configWatcher.data(),
                          &QFileSystemWatcher::fileChanged,
                          [](const QString& fileName) {
-                             emit getInstance()->fileChanged();
+                             emit getInstance() -> fileChanged();
 
                              if (QFile(fileName).exists()) {
                                  m_configWatcher->addPath(fileName);
@@ -711,12 +709,12 @@ void ConfigHandler::setErrorState(bool error) const
     if (!hadError && m_hasError) {
         QString msg = errorMessage();
         AbstractLogger::error() << msg;
-        emit getInstance()->error();
+        emit getInstance() -> error();
     } else if (hadError && !m_hasError) {
         auto msg =
           tr("You have successfully resolved the configuration error.");
         AbstractLogger::info() << msg;
-        emit getInstance()->errorResolved();
+        emit getInstance() -> errorResolved();
     }
 }
 

--- a/src/utils/confighandler.cpp
+++ b/src/utils/confighandler.cpp
@@ -55,12 +55,15 @@ bool verifyLaunchFile()
  *             misbehave.
  */
 #define OPTION(KEY, TYPE)                                                      \
-    { QStringLiteral(KEY), QSharedPointer<ValueHandler>(new TYPE) }
+    {                                                                          \
+        QStringLiteral(KEY), QSharedPointer<ValueHandler>(new TYPE)            \
+    }
 
 #define SHORTCUT(NAME, DEFAULT_VALUE)                                          \
-    { QStringLiteral(NAME),                                                    \
-      QSharedPointer<KeySequence>(                                             \
-        new KeySequence(QKeySequence(QLatin1String(DEFAULT_VALUE)))) }
+    {                                                                          \
+        QStringLiteral(NAME), QSharedPointer<KeySequence>(new KeySequence(     \
+                                QKeySequence(QLatin1String(DEFAULT_VALUE))))   \
+    }
 
 /**
  * This map contains all the information that is needed to parse, verify and
@@ -209,7 +212,7 @@ ConfigHandler::ConfigHandler()
         QObject::connect(m_configWatcher.data(),
                          &QFileSystemWatcher::fileChanged,
                          [](const QString& fileName) {
-                             emit getInstance() -> fileChanged();
+                             emit getInstance()->fileChanged();
 
                              if (QFile(fileName).exists()) {
                                  m_configWatcher->addPath(fileName);
@@ -709,12 +712,12 @@ void ConfigHandler::setErrorState(bool error) const
     if (!hadError && m_hasError) {
         QString msg = errorMessage();
         AbstractLogger::error() << msg;
-        emit getInstance() -> error();
+        emit getInstance()->error();
     } else if (hadError && !m_hasError) {
         auto msg =
           tr("You have successfully resolved the configuration error.");
         AbstractLogger::info() << msg;
-        emit getInstance() -> errorResolved();
+        emit getInstance()->errorResolved();
     }
 }
 

--- a/src/utils/confighandler.h
+++ b/src/utils/confighandler.h
@@ -74,6 +74,7 @@ public:
     CONFIG_GETTER_SETTER(userColors, setUserColors, QVector<QColor>);
     CONFIG_GETTER_SETTER(savePath, setSavePath, QString)
     CONFIG_GETTER_SETTER(savePathFixed, setSavePathFixed, bool)
+    CONFIG_GETTER_SETTER(uiLanguage, setUiLanguage, QString)
     CONFIG_GETTER_SETTER(uiColor, setUiColor, QColor)
     CONFIG_GETTER_SETTER(contrastUiColor, setContrastUiColor, QColor)
     CONFIG_GETTER_SETTER(drawColor, setDrawColor, QColor)


### PR DESCRIPTION
Currently Flameshot is using the detected system language for loading the UI language. Some users raised the question, if it would be possible to select a different language than the system language (see [translation-instruction/issues/25](https://github.com/flameshot-org/translation-instruction/issues/25) and discussion: #3513).

I used the word 'auto' to refer to the 'automatically' detected language as the default option in the language selection combo box. I'm not a native English speaker, so I'm not 100% sure if this is well understood when used in this context. In addition, this word must remain untranslated; otherwise, this configuration option will not work. It should therefore be understandable all over the world. Or do you have any other ideas on how this could be solved?

My current implementation requires a restart to load the new selected translation. I added a "TODO" in the source, so maybe somebody adds a direct re-translation of all UI elements without restart of the application in future.