### PR TITLE
Fix: multi-screen DPI screenshot black edges by adjusting logic pixel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,4 @@ data/flatpak/.flatpak-builder
 # Miscellaneous
 !docs/dev/Makefile
 .direnv
+"KDSingleApplication/" 

--- a/src/utils/screengrabber.cpp
+++ b/src/utils/screengrabber.cpp
@@ -268,15 +268,17 @@ QPixmap ScreenGrabber::grabScreen(QScreen* screen, bool& ok)
 QRect ScreenGrabber::desktopGeometry()
 {
     QRect geometry;
-
+    qreal dpr = QGuiApplication::screens()[0]->devicePixelRatio();
     for (QScreen* const screen : QGuiApplication::screens()) {
         QRect scrRect = screen->geometry();
         // Qt6 fix: Don't divide by devicePixelRatio for multi-monitor setups
         // This was causing coordinate offset issues in dual monitor
         // configurations
         // But it still has a screen position in real pixels, not logical ones
-        qreal dpr = screen->devicePixelRatio();
         scrRect.moveTo(QPointF(scrRect.x() / dpr, scrRect.y() / dpr).toPoint());
+        scrRect.setWidth(scrRect.width() * screen->devicePixelRatio() / dpr);
+        scrRect.setHeight(scrRect.height() * screen->devicePixelRatio() / dpr);
+        // dpr = screen->devicePixelRatio();//这里应该是除以第一个屏幕的dpr
         geometry = geometry.united(scrRect);
     }
     return geometry;

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -132,8 +132,20 @@ CaptureWidget::CaptureWidget(const CaptureRequest& req,
                 topLeft.setY(topLeftScreen.y());
             }
         }
+// qDebug()<<topLeft;
+#if (defined(Q_OS_LINUX) || defined(Q_OS_MACOS))
         move(topLeft);
-        resize(pixmap().size());
+#endif
+        // move(QPoint(853,0));
+        resize(
+          pixmap().size() /
+          QGuiApplication::screens()[0]
+            ->devicePixelRatio()); //这里的pixmap()函数实际上返回的是m_context.screenshot
+                                   // QString savePath =
+        // "E:/QT/code/mflame/m_context__screenshot_diff1-25.png"; bool
+        // saveSuccess = m_context.screenshot.save(savePath, "PNG");
+        // qDebug()<<saveSuccess<<"; "<<__LINE__;
+
 #elif defined(Q_OS_MACOS)
         // Emulate fullscreen mode
         //        setWindowFlags(Qt::WindowStaysOnTopHint |


### PR DESCRIPTION
Adjusted the logical pixel calculation logic in src/utils/screengrabber.cpp and src/widgets/capture/capturewidget.cpp to adapt to multi-screen DPI differences, ensuring the screenshot area fits the screen accurately.
Tested on Windows system with 2 screens of different DPIs (2K-150% and 2K-125%). The screenshots have no black edges and fit the screens perfectly.
Verified that the single-screen scenario works normally with no regression issues.
I would also like to attach two images: one showing the issue before the fix, and one showing the result after the fix.
before the fix:
<img width="6144" height="1728" alt="m_context__screenshot_diff" src="https://github.com/user-attachments/assets/1d5a2736-88ee-4dcf-87cc-e022fb8e2aea" />

after the fix:
<img width="5119" height="1438" alt="fixed" src="https://github.com/user-attachments/assets/a670faac-c246-4034-8c46-de719c5386e0" />
