### PR TITLE
Show keyboard shortcut in the tray icon menu

### DIFF
--- a/src/widgets/trayicon.cpp
+++ b/src/widgets/trayicon.cpp
@@ -186,12 +186,14 @@ void TrayIcon::initMenu()
 
 void TrayIcon::updateCaptureActionShortcut()
 {
+#if defined(Q_OS_MACOS)
     if (!m_captureAction) {
         return;
     }
 
     QString shortcut = ConfigHandler().shortcut("TAKE_SCREENSHOT");
     m_captureAction->setShortcut(QKeySequence(shortcut));
+#endif
 }
 
 #if !defined(DISABLE_UPDATE_CHECKER)

--- a/src/widgets/trayicon.cpp
+++ b/src/widgets/trayicon.cpp
@@ -78,7 +78,7 @@ TrayIcon::TrayIcon(QObject* parent)
     connect(ConfigHandler::getInstance(),
             &ConfigHandler::fileChanged,
             this,
-            [this]() {});
+            [this]() { updateCaptureActionShortcut(); });
 }
 
 TrayIcon::~TrayIcon()
@@ -97,8 +97,11 @@ void TrayIcon::initMenu()
 {
     m_menu = new QMenu();
 
-    auto* captureAction = new QAction(tr("&Take Screenshot"), this);
-    connect(captureAction, &QAction::triggered, this, [this]() {
+    m_captureAction = new QAction(tr("&Take Screenshot"), this);
+
+    updateCaptureActionShortcut();
+
+    connect(m_captureAction, &QAction::triggered, this, [this]() {
 #if defined(Q_OS_MACOS)
         auto currentMacOsVersion = QOperatingSystemVersion::current();
         if (currentMacOsVersion >= QOperatingSystemVersion::MacOSBigSur) {
@@ -163,7 +166,7 @@ void TrayIcon::initMenu()
             Flameshot::instance(),
             &Flameshot::openSavePath);
 
-    m_menu->addAction(captureAction);
+    m_menu->addAction(m_captureAction);
     m_menu->addAction(launcherAction);
     m_menu->addSeparator();
 #ifdef ENABLE_IMGUR
@@ -179,6 +182,16 @@ void TrayIcon::initMenu()
     m_menu->addAction(infoAction);
     m_menu->addSeparator();
     m_menu->addAction(quitAction);
+}
+
+void TrayIcon::updateCaptureActionShortcut()
+{
+    if (!m_captureAction) {
+        return;
+    }
+
+    QString shortcut = ConfigHandler().shortcut("TAKE_SCREENSHOT");
+    m_captureAction->setShortcut(QKeySequence(shortcut));
 }
 
 #if !defined(DISABLE_UPDATE_CHECKER)

--- a/src/widgets/trayicon.h
+++ b/src/widgets/trayicon.h
@@ -18,6 +18,7 @@ public:
 private:
     void initTrayIcon();
     void initMenu();
+    void updateCaptureActionShortcut();
 #if !defined(DISABLE_UPDATE_CHECKER)
     void enableCheckUpdatesAction(bool enable);
 #endif
@@ -25,6 +26,7 @@ private:
     void startGuiCapture();
 
     QMenu* m_menu;
+    QAction* m_captureAction;
 #if !defined(DISABLE_UPDATE_CHECKER)
     QAction* m_appUpdates;
 #endif


### PR DESCRIPTION
Inspired by: #3637

Unfortunately I don't have a Linux or Windows machine to build and check how it would work on these platforms. Anyway, it doesn't seem too difficult to add "PrtSc" to the menu, even though there is no explicitly set shortcut for taking a screenshot in the `ConfigHandler`. I would appreciate it if anybody could build and run it, and provide feedback.

<img width="270" height="255" alt="image" src="https://github.com/user-attachments/assets/7b8cd891-39f6-4ef2-9a8b-09938fe9c871" />
