### PR TITLE
Added libkf6guiaddons-dev as a debain dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,7 +438,7 @@ Also you can open and build/debug the project in a C++ IDE. For example, in Qt C
 apt install g++ cmake build-essential qt6-base-dev qt6-tools-dev-tools qt6-svg-dev qt6-tools-dev
 
 # Run-time
-apt install libqt6dbus6 libqt6network6 libqt6core6 libqt6widgets6 libqt6gui6 libqt6svg6 qt6-qpa-plugins
+apt install libkf6guiaddons-dev libqt6dbus6 libqt6network6 libqt6core6 libqt6widgets6 libqt6gui6 libqt6svg6 qt6-qpa-plugins
 
 # Optional
 apt install git openssl ca-certificates qt6-image-formats-plugins


### PR DESCRIPTION
In response to the issue #4280, added libkf6guiaddons-dev as a debian dependency in the Readme.md file.

`apt install libkf6guiaddons-dev libqt6dbus6 libqt6network6 libqt6core6 libqt6widgets6 libqt6gui6 libqt6svg6 qt6-qpa-plugins`

@borgmanJeremy @mmahmoudian 