### PR TITLE
link to qtdbus on macos

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,7 +10,7 @@ find_package(
         LinguistTools
 )
 
-if (UNIX AND NOT APPLE)
+if (UNIX)
 find_package(
         Qt${QT_VERSION_MAJOR}
         CONFIG
@@ -228,7 +228,7 @@ target_link_libraries(
         Qt${QT_VERSION_MAJOR}::Widgets
         QtColorWidgets
 )
-if (UNIX AND NOT APPLE)
+if (UNIX)
 target_link_libraries(
         flameshot
         Qt${QT_VERSION_MAJOR}::DBus


### PR DESCRIPTION
Macos does not actually use dbus, but for some reason expects to link to qtdbus. I'm not able to figure out _why_ its wants to link to dbus but this will act as a quick fix. This is how it worked on 13.1.0

fixes #4319 