### PR TITLE
Add support for logging to a log file in the qt standard state directory

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -539,3 +539,7 @@ if (APPLE)
 
 
 endif ()
+
+if(${Qt6Core_VERSION} VERSION_GREATER_EQUAL 6.7)
+    target_compile_definitions(flameshot PRIVATE QT_STATE_DIR_SUPPORTED=1)
+endif()

--- a/src/config/generalconf.cpp
+++ b/src/config/generalconf.cpp
@@ -2,7 +2,9 @@
 // SPDX-FileCopyrightText: 2017-2019 Alejandro Sirgo Rica & Contributors
 #include "generalconf.h"
 #include "src/core/flameshot.h"
+#include "src/utils/abstractlogger.h"
 #include "src/utils/confighandler.h"
+#include "src/utils/logfile.h"
 #include <QCheckBox>
 #include <QComboBox>
 #include <QFile>
@@ -56,6 +58,7 @@ GeneralConf::GeneralConf(QWidget* parent)
     initAntialiasingPinZoom();
     initUndoLimit();
     initInsecurePixelate();
+    initLogToFile();
 #ifdef ENABLE_IMGUR
     initCopyAndCloseAfterUpload();
     initUploadWithoutConfirmation();
@@ -121,6 +124,9 @@ void GeneralConf::_updateComponents(bool allowEmptySavePath)
     if (allowEmptySavePath || !config.savePath().isEmpty()) {
         m_savePath->setText(config.savePath());
     }
+    m_logToFile->setChecked(config.logToFile());
+    m_logFilePath->setText(config.logFilePath());
+
 #if defined(Q_OS_LINUX) || defined(Q_OS_UNIX)
     m_showTray->setChecked(!config.disabledTrayIcon());
 #endif
@@ -244,6 +250,7 @@ void GeneralConf::resetConfiguration()
     if (reply == QMessageBox::Yes) {
         m_savePath->setText(
           QStandardPaths::writableLocation(QStandardPaths::PicturesLocation));
+        m_logFilePath->setText(LogFile::defaultLogFilePath());
         ConfigHandler().setDefaultSettings();
         _updateComponents(true);
     }
@@ -706,6 +713,33 @@ void GeneralConf::changeSavePath()
     }
 }
 
+void GeneralConf::changeLogFilePath()
+{
+    QString path = ConfigHandler().logFilePath();
+
+    if (path.isEmpty()) {
+        path = LogFile::defaultLogFilePath();
+    }
+
+    path = QFileDialog::getExistingDirectory(
+      this,
+      tr("Choose a Folder"),
+      path,
+      QFileDialog::ShowDirsOnly | QFileDialog::DontResolveSymlinks);
+
+    if (!QFileInfo(path).isWritable()) {
+        QMessageBox::about(
+          this, tr("Error"), tr("Unable to write to directory."));
+        path = QString();
+    }
+
+    if (!path.isEmpty()) {
+        m_logFilePath->setText(path);
+        ConfigHandler().setLogFilePath(path);
+        LogFile::resetLogFile();
+    }
+}
+
 void GeneralConf::initCopyPathAfterSave()
 {
     m_copyPathAfterSave = new QCheckBox(tr("Copy file path after save"), this);
@@ -880,7 +914,7 @@ void GeneralConf::initInsecurePixelate()
 {
     m_insecurePixelate = new QCheckBox(tr("Insecure Pixelate"), this);
     m_insecurePixelate->setToolTip(
-      tr("Draw the pixelation effect in an insecure but more asethetic way."));
+      tr("Draw the pixelation effect in an insecure but more aesthetic way."));
     m_insecurePixelate->setChecked(ConfigHandler().insecurePixelate());
     m_scrollAreaLayout->addWidget(m_insecurePixelate);
 
@@ -888,6 +922,70 @@ void GeneralConf::initInsecurePixelate()
             &QCheckBox::clicked,
             this,
             &GeneralConf::setInsecurePixelate);
+}
+
+void GeneralConf::initLogToFile()
+{
+    auto* box = new QGroupBox(tr("Logging"));
+    box->setFlat(true);
+    m_layout->addWidget(box);
+
+    auto* vboxLayout = new QVBoxLayout();
+    box->setLayout(vboxLayout);
+
+    m_logToFile = new QCheckBox(tr("Log to file"), this);
+    m_logToFile->setToolTip(
+      tr("Save all log messages produced by flameshot to a file"));
+    m_logToFile->setChecked(ConfigHandler().logToFile());
+
+    connect(m_logToFile, &QCheckBox::clicked, this, &GeneralConf::setLogToFile);
+    vboxLayout->addWidget(m_logToFile);
+
+    auto* pathLayout = new QHBoxLayout();
+
+    QString path = ConfigHandler().logFilePath();
+    m_logFilePath = new QLineEdit(path, this);
+    m_logFilePath->setToolTip(
+      tr("The directory where log files will be saved"));
+    m_logFilePath->setDisabled(true);
+    QString foreground = this->palette().windowText().color().name();
+    m_logFilePath->setStyleSheet(QStringLiteral("color:%1").arg(foreground));
+    pathLayout->addWidget(m_logFilePath);
+
+    m_changeLogFilePathButton = new QPushButton(tr("Change..."), this);
+    pathLayout->addWidget(m_changeLogFilePathButton);
+    connect(m_changeLogFilePathButton,
+            &QPushButton::clicked,
+            this,
+            &GeneralConf::changeLogFilePath);
+
+    vboxLayout->addLayout(pathLayout);
+
+    auto* levelLayout = new QHBoxLayout();
+    auto* levelLabel = new QLabel(tr("Minimum Log Level"));
+    levelLabel->setToolTip(
+      tr("Specify the minimum severity level of log messages that "
+         "should be saved to disk"));
+    levelLayout->addWidget(levelLabel);
+
+    m_logFileLevel = new QComboBox(this);
+
+    m_logFileLevel->addItem(tr("Info (All Log Messages)"),
+                            AbstractLogger::Channel::Info);
+    m_logFileLevel->addItem(tr("Warnings and Errors"),
+                            AbstractLogger::Channel::Warning);
+    m_logFileLevel->addItem(tr("Errors"), AbstractLogger::Channel::Error);
+
+    auto level = ConfigHandler().value("logFileLevel").toInt();
+    m_logFileLevel->setCurrentIndex(m_logFileLevel->findData(level));
+
+    connect(
+      m_logFileLevel,
+      static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
+      this,
+      &GeneralConf::setLogFileLevel);
+    levelLayout->addWidget(m_logFileLevel);
+    vboxLayout->addLayout(levelLayout);
 }
 
 void GeneralConf::setSelGeoHideTime(int v)
@@ -929,4 +1027,14 @@ void GeneralConf::setReverseArrow(bool checked)
 void GeneralConf::setInsecurePixelate(bool checked)
 {
     ConfigHandler().setInsecurePixelate(checked);
+}
+
+void GeneralConf::setLogToFile(bool checked)
+{
+    ConfigHandler().setLogToFile(checked);
+}
+
+void GeneralConf::setLogFileLevel(int index)
+{
+    ConfigHandler().setValue("logFileLevel", m_logFileLevel->itemData(index));
 }

--- a/src/config/generalconf.h
+++ b/src/config/generalconf.h
@@ -50,6 +50,7 @@ private slots:
     void undoLimit(int limit);
     void saveAfterCopyChanged(bool checked);
     void changeSavePath();
+    void changeLogFilePath();
     void importConfiguration();
     void exportFileConfiguration();
     void resetConfiguration();
@@ -62,6 +63,8 @@ private slots:
     void setJpegQuality(int v);
     void setReverseArrow(bool checked);
     void setInsecurePixelate(bool checked);
+    void setLogToFile(bool checked);
+    void setLogFileLevel(int index);
 
 private:
     const QString chooseFolder(const QString& currentPath = "");
@@ -101,6 +104,7 @@ private:
     void initJpegQuality();
     void initReverseArrow();
     void initInsecurePixelate();
+    void initLogToFile();
 
     void _updateComponents(bool allowEmptySavePath);
 
@@ -150,4 +154,8 @@ private:
     QSpinBox* m_jpegQuality;
     QCheckBox* m_reverseArrow;
     QCheckBox* m_insecurePixelate;
+    QCheckBox* m_logToFile;
+    QLineEdit* m_logFilePath;
+    QPushButton* m_changeLogFilePathButton;
+    QComboBox* m_logFileLevel;
 };

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -25,19 +25,20 @@ target_sources(
           colorutils.cpp
           history.cpp
           strfparse.cpp
+          logfile.cpp
 )
 
 IF (UNIX AND NOT APPLE)
-target_sources(
-  flameshot
-  PRIVATE request.h
-          request.cpp
-)
+    target_sources(
+      flameshot
+      PRIVATE request.h
+              request.cpp
+    )
 ENDIF()
 
 IF (WIN32)
-  target_sources(
-    flameshot
-    PRIVATE winlnkfileparse.cpp
-  )
+    target_sources(
+        flameshot
+        PRIVATE winlnkfileparse.cpp
+      )
 ENDIF()

--- a/src/utils/confighandler.cpp
+++ b/src/utils/confighandler.cpp
@@ -138,6 +138,9 @@ static QMap<class QString, QSharedPointer<ValueHandler>>
     OPTION("jpegQuality"                 , BoundedInt        ( 0,100,75      )),
     OPTION("reverseArrow"                ,Bool               ( false         )),
     OPTION("insecurePixelate"            ,Bool               ( false         )),
+    OPTION("logToFile"                   ,Bool               ( true          )),
+    OPTION("logFilePath"                 ,LoggingDir         (               )),
+    OPTION("logFileLevel"                ,BoundedInt         ( AbstractLogger::Channel::Info, AbstractLogger::Channel::Error, AbstractLogger::Channel::Info)),  
 };
 
 static QMap<QString, QSharedPointer<KeySequence>> recognizedShortcuts = {

--- a/src/utils/confighandler.h
+++ b/src/utils/confighandler.h
@@ -141,6 +141,9 @@ public:
     CONFIG_GETTER_SETTER(showSelectionGeometryHideTime,
                          showSelectionGeometryHideTime,
                          int)
+    CONFIG_GETTER_SETTER(logToFile, setLogToFile, bool)
+    CONFIG_GETTER_SETTER(logFilePath, setLogFilePath, QString)
+    CONFIG_GETTER_SETTER(logFileLevel, setLogFileLevel, int)
 
     // SPECIAL CASES
     bool startupLaunch();

--- a/src/utils/logfile.cpp
+++ b/src/utils/logfile.cpp
@@ -1,0 +1,73 @@
+#include "logfile.h"
+
+#include "confighandler.h"
+
+#include <QDir>
+#include <QMutexLocker>
+#include <QStandardPaths>
+
+constexpr const char* LOG_FILE_NAME = "flameshot.log";
+constexpr const char* OLD_LOG_FILE_NAME = "flameshot.log.old";
+
+void LogFile::write(const QString* data)
+{
+    QMutexLocker locker(&m_mutex);
+    if (nullptr == m_instance) {
+        m_instance = new LogFile();
+    }
+
+    m_instance->writeToFile(data);
+}
+
+void LogFile::resetLogFile()
+{
+    QMutexLocker locker(&m_mutex);
+    delete m_instance;
+    m_instance = nullptr;
+}
+
+QString LogFile::defaultLogFilePath()
+{
+#ifdef QT_STATE_DIR_SUPPORTED
+    const auto defaultLocation = QStandardPaths::GenericStateLocation;
+#else
+    const auto defaultLocation = QStandardPaths::GenericDataLocation;
+#endif
+    return QDir::toNativeSeparators(
+      QStandardPaths::writableLocation(defaultLocation) + "/flameshot");
+}
+
+LogFile::LogFile()
+{
+    auto loggingDirectory = QDir(ConfigHandler().logFilePath());
+
+    if (!loggingDirectory.exists()) {
+        loggingDirectory.mkpath(".");
+    }
+
+    if (loggingDirectory.exists(OLD_LOG_FILE_NAME)) {
+        loggingDirectory.remove(OLD_LOG_FILE_NAME);
+    }
+
+    if (loggingDirectory.exists(LOG_FILE_NAME)) {
+        loggingDirectory.rename(LOG_FILE_NAME, OLD_LOG_FILE_NAME);
+    }
+
+    auto logFilePath = loggingDirectory.filePath(LOG_FILE_NAME);
+    m_logFile = std::make_unique<QFile>(logFilePath);
+    if (m_logFile->open(QIODeviceBase::WriteOnly | QIODeviceBase::Append)) {
+        m_writer = std::make_unique<QTextStream>();
+        m_writer->setDevice(m_logFile.get());
+    }
+}
+
+void LogFile::writeToFile(const QString* data)
+{
+    if (m_writer) {
+        *m_writer << *data;
+        m_writer->flush();
+    }
+}
+
+LogFile* LogFile::m_instance = nullptr;
+QMutex LogFile::m_mutex;

--- a/src/utils/logfile.h
+++ b/src/utils/logfile.h
@@ -1,0 +1,31 @@
+#ifndef LOGFILE_H
+#define LOGFILE_H
+
+#include <QFile>
+#include <QMutex>
+#include <QTextStream>
+#include <memory>
+
+class LogFile
+{
+public:
+    static void write(const QString* data);
+    static void resetLogFile();
+    static QString defaultLogFilePath();
+
+    LogFile(LogFile&& other) = delete;
+    LogFile(LogFile& other) = delete;
+    LogFile operator=(LogFile& other) = delete;
+    LogFile operator=(LogFile&& other) = delete;
+    ~LogFile() = default;
+
+private:
+    LogFile();
+    void writeToFile(const QString* data);
+    std::unique_ptr<QFile> m_logFile;
+    std::unique_ptr<QTextStream> m_writer;
+    static LogFile* m_instance;
+    static QMutex m_mutex;
+};
+
+#endif

--- a/src/utils/valuehandler.cpp
+++ b/src/utils/valuehandler.cpp
@@ -3,6 +3,7 @@
 #include "colorpickerwidget.h"
 #include "confighandler.h"
 #include "screengrabber.h"
+#include "utils/logfile.h"
 #include <QColor>
 #include <QFileInfo>
 #include <QImageWriter>
@@ -274,6 +275,27 @@ QVariant ExistingDir::fallback()
 QString ExistingDir::expected()
 {
     return QStringLiteral("existing directory");
+}
+
+// LOGGING DIR
+//
+bool LoggingDir::check(const QVariant& val)
+{
+    if (!val.canConvert<QString>() || val.toString().isEmpty()) {
+        return false;
+    }
+    QFileInfo info(val.toString());
+    return info.isDir() && info.isWritable();
+}
+
+QVariant LoggingDir::fallback()
+{
+    return LogFile::defaultLogFilePath();
+}
+
+QString LoggingDir::expected()
+{
+    return QStringLiteral("a writeable directory");
 }
 
 // FILENAME PATTERN

--- a/src/utils/valuehandler.h
+++ b/src/utils/valuehandler.h
@@ -169,6 +169,13 @@ class ExistingDir : public ValueHandler
     QString expected() override;
 };
 
+class LoggingDir : public ValueHandler
+{
+    bool check(const QVariant& val) override;
+    QVariant fallback() override;
+    QString expected() override;
+};
+
 class FilenamePattern : public ValueHandler
 {
     bool check(const QVariant&) override;

--- a/src/widgets/infowindow.cpp
+++ b/src/widgets/infowindow.cpp
@@ -5,7 +5,11 @@
 #include "./ui_infowindow.h"
 #include "src/core/flameshotdaemon.h"
 #include "src/core/qguiappcurrentscreen.h"
+#include "src/utils/abstractlogger.h"
+#include "src/utils/confighandler.h"
 #include "src/utils/globalvalues.h"
+#include <QDesktopServices>
+#include <QDir>
 #include <QKeyEvent>
 #include <QScreen>
 
@@ -22,6 +26,15 @@ InfoWindow::InfoWindow(QWidget* parent)
 
     connect(
       ui->CopyInfoButton, &QPushButton::clicked, this, &InfoWindow::copyInfo);
+
+    connect(ui->OpenLogPathButton,
+            &QPushButton::clicked,
+            this,
+            &InfoWindow::openLogDir);
+
+    ui->OpenLogPathButton->setEnabled(ConfigHandler().logToFile());
+    ui->OpenLogPathButton->setToolTip(
+      tr("Enable saving log messages to a file in the configuration menu"));
 
     show();
     // Call show() first, otherwise the correct geometry cannot be fetched for
@@ -56,4 +69,18 @@ void InfoWindow::copyInfo()
 {
     FlameshotDaemon::copyToClipboard(GlobalValues::versionInfo() + "\n" +
                                      generateKernelString());
+}
+
+void InfoWindow::openLogDir()
+{
+    auto path = ConfigHandler().logFilePath();
+    auto dir = QDir(path);
+
+    if (!dir.exists()) {
+        dir.mkpath(".");
+    }
+
+    auto url = QUrl::fromLocalFile(dir.path());
+
+    QDesktopServices::openUrl(url);
 }

--- a/src/widgets/infowindow.h
+++ b/src/widgets/infowindow.h
@@ -27,6 +27,7 @@ protected:
 
 private slots:
     void copyInfo();
+    void openLogDir();
 };
 
 QString generateKernelString();

--- a/src/widgets/infowindow.ui
+++ b/src/widgets/infowindow.ui
@@ -129,6 +129,13 @@
        </property>
       </widget>
      </item>
+     <item>
+      <widget class="QPushButton" name="OpenLogPathButton">
+       <property name="text">
+        <string>Open Log Directory</string>
+       </property>
+      </widget>
+     </item>
     </layout>
    </item>
   </layout>


### PR DESCRIPTION
By default, logging to file is disabled. It can be enabled via the configuration menu. Support for filtering by log level severity and choosing a different path to save the  log files has also been added.

The log file implements a simple roller that saves only the two most recent sets of logs generated by flameshot. This should stop log messages from eating users' disk.