### PR TITLE
feat: color selection based on angle with widget

### DIFF
--- a/src/tools/capturetool.h
+++ b/src/tools/capturetool.h
@@ -87,7 +87,7 @@ public:
     {}
 
     // TODO unused
-    virtual void setCapture(const QPixmap& pixmap){};
+    virtual void setCapture(const QPixmap& pixmap) {};
 
     // Returns false when the tool is in an inconsistent state and shouldn't
     // be included in the tool undo/redo stack.

--- a/src/utils/confighandler.cpp
+++ b/src/utils/confighandler.cpp
@@ -55,15 +55,12 @@ bool verifyLaunchFile()
  *             misbehave.
  */
 #define OPTION(KEY, TYPE)                                                      \
-    {                                                                          \
-        QStringLiteral(KEY), QSharedPointer<ValueHandler>(new TYPE)            \
-    }
+    { QStringLiteral(KEY), QSharedPointer<ValueHandler>(new TYPE) }
 
 #define SHORTCUT(NAME, DEFAULT_VALUE)                                          \
-    {                                                                          \
-        QStringLiteral(NAME), QSharedPointer<KeySequence>(new KeySequence(     \
-                                QKeySequence(QLatin1String(DEFAULT_VALUE))))   \
-    }
+    { QStringLiteral(NAME),                                                    \
+      QSharedPointer<KeySequence>(                                             \
+        new KeySequence(QKeySequence(QLatin1String(DEFAULT_VALUE)))) }
 
 /**
  * This map contains all the information that is needed to parse, verify and
@@ -212,7 +209,7 @@ ConfigHandler::ConfigHandler()
         QObject::connect(m_configWatcher.data(),
                          &QFileSystemWatcher::fileChanged,
                          [](const QString& fileName) {
-                             emit getInstance()->fileChanged();
+                             emit getInstance() -> fileChanged();
 
                              if (QFile(fileName).exists()) {
                                  m_configWatcher->addPath(fileName);
@@ -712,12 +709,12 @@ void ConfigHandler::setErrorState(bool error) const
     if (!hadError && m_hasError) {
         QString msg = errorMessage();
         AbstractLogger::error() << msg;
-        emit getInstance()->error();
+        emit getInstance() -> error();
     } else if (hadError && !m_hasError) {
         auto msg =
           tr("You have successfully resolved the configuration error.");
         AbstractLogger::info() << msg;
-        emit getInstance()->errorResolved();
+        emit getInstance() -> errorResolved();
     }
 }
 

--- a/src/widgets/capture/capturetoolbutton.cpp
+++ b/src/widgets/capture/capturetoolbutton.cpp
@@ -130,30 +130,38 @@ void CaptureToolButton::setColor(const QColor& c)
 
 QColor CaptureToolButton::m_mainColor;
 
-static std::map<CaptureTool::Type, int> buttonTypeOrder
-{
-    { CaptureTool::TYPE_PENCIL, 0 }, { CaptureTool::TYPE_DRAWER, 1 },
-      { CaptureTool::TYPE_ARROW, 2 }, { CaptureTool::TYPE_SELECTION, 3 },
-      { CaptureTool::TYPE_RECTANGLE, 4 }, { CaptureTool::TYPE_CIRCLE, 5 },
-      { CaptureTool::TYPE_MARKER, 6 }, { CaptureTool::TYPE_TEXT, 7 },
-      { CaptureTool::TYPE_PIXELATE, 8 }, { CaptureTool::TYPE_INVERT, 9 },
-      { CaptureTool::TYPE_CIRCLECOUNT, 10 },
-      { CaptureTool::TYPE_MOVESELECTION, 12 }, { CaptureTool::TYPE_UNDO, 13 },
-      { CaptureTool::TYPE_REDO, 14 }, { CaptureTool::TYPE_COPY, 15 },
-      { CaptureTool::TYPE_SAVE, 16 },
+static std::map<CaptureTool::Type, int> buttonTypeOrder{
+    { CaptureTool::TYPE_PENCIL, 0 },
+    { CaptureTool::TYPE_DRAWER, 1 },
+    { CaptureTool::TYPE_ARROW, 2 },
+    { CaptureTool::TYPE_SELECTION, 3 },
+    { CaptureTool::TYPE_RECTANGLE, 4 },
+    { CaptureTool::TYPE_CIRCLE, 5 },
+    { CaptureTool::TYPE_MARKER, 6 },
+    { CaptureTool::TYPE_TEXT, 7 },
+    { CaptureTool::TYPE_PIXELATE, 8 },
+    { CaptureTool::TYPE_INVERT, 9 },
+    { CaptureTool::TYPE_CIRCLECOUNT, 10 },
+    { CaptureTool::TYPE_MOVESELECTION, 12 },
+    { CaptureTool::TYPE_UNDO, 13 },
+    { CaptureTool::TYPE_REDO, 14 },
+    { CaptureTool::TYPE_COPY, 15 },
+    { CaptureTool::TYPE_SAVE, 16 },
 #ifdef ENABLE_IMGUR
-      { CaptureTool::TYPE_IMAGEUPLOADER, 17 },
+    { CaptureTool::TYPE_IMAGEUPLOADER, 17 },
 #endif
-      { CaptureTool::TYPE_ACCEPT, 18 },
+    { CaptureTool::TYPE_ACCEPT, 18 },
 #if !defined(Q_OS_MACOS)
-      { CaptureTool::TYPE_OPEN_APP, 19 }, { CaptureTool::TYPE_EXIT, 20 },
-      { CaptureTool::TYPE_PIN, 21 },
+    { CaptureTool::TYPE_OPEN_APP, 19 },
+    { CaptureTool::TYPE_EXIT, 20 },
+    { CaptureTool::TYPE_PIN, 21 },
 #else
-      { CaptureTool::TYPE_EXIT, 19 }, { CaptureTool::TYPE_PIN, 20 },
+    { CaptureTool::TYPE_EXIT, 19 },
+    { CaptureTool::TYPE_PIN, 20 },
 #endif
 
-      { CaptureTool::TYPE_SIZEINCREASE, 22 },
-      { CaptureTool::TYPE_SIZEDECREASE, 23 },
+    { CaptureTool::TYPE_SIZEINCREASE, 22 },
+    { CaptureTool::TYPE_SIZEDECREASE, 23 },
 };
 
 int CaptureToolButton::getPriorityByButton(CaptureTool::Type b)

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -309,7 +309,7 @@ CaptureWidget::~CaptureWidget()
         Flameshot::instance()->exportCapture(
           pixmap(), geometry, m_context.request);
     } else {
-        emit Flameshot::instance()->captureFailed();
+        emit Flameshot::instance() -> captureFailed();
     }
 }
 

--- a/src/widgets/capture/colorpicker.cpp
+++ b/src/widgets/capture/colorpicker.cpp
@@ -4,11 +4,11 @@
 #include "colorpicker.h"
 #include "src/utils/confighandler.h"
 #include "src/utils/globalvalues.h"
-#include <cmath>
 #include <QMouseEvent>
 #include <QPainter>
 #include <QPoint>
 #include <QSize>
+#include <cmath>
 
 ColorPicker::ColorPicker(QWidget* parent)
   : ColorPickerWidget(parent)
@@ -33,9 +33,9 @@ void ColorPicker::setNewColor()
 void ColorPicker::mouseMoveEvent(QMouseEvent* e)
 {
     const size_t colsize = m_colorList.size();
-    const QSize  middle  = this->size() * 0.5;
-    const QPoint center  = -(this->pos() - this->mapToParent(e->pos())
-        + QPoint(middle.width(), middle.height()));
+    const QSize middle = this->size() * 0.5;
+    const QPoint center = -(this->pos() - this->mapToParent(e->pos()) +
+                            QPoint(middle.width(), middle.height()));
     const double arclength = 2.0 * M_PI / colsize;
 
     // Computes the new index based on the orientation of the mouse
@@ -52,12 +52,10 @@ void ColorPicker::mouseMoveEvent(QMouseEvent* e)
     //  of the first color is -3pi / 2 (in the screen coordinates,
     //  so pi/2 in normal coordinates) and the colors are being drawn
     //  counter clockwise.
-    m_selectedIndex = (
-       int(
-            (std::atan2(-center.y(), center.x()) + arclength / 2) / arclength
-            + 3 * colsize / 4.0
-        )
-    ) % colsize;
+    m_selectedIndex =
+      (int((std::atan2(-center.y(), center.x()) + arclength / 2) / arclength +
+           3 * colsize / 4.0)) %
+      colsize;
 
     update(m_colorAreaList.at(m_selectedIndex) + QMargins(10, 10, 10, 10));
     update(m_colorAreaList.at(m_lastIndex) + QMargins(10, 10, 10, 10));

--- a/src/widgets/capture/colorpicker.cpp
+++ b/src/widgets/capture/colorpicker.cpp
@@ -4,8 +4,11 @@
 #include "colorpicker.h"
 #include "src/utils/confighandler.h"
 #include "src/utils/globalvalues.h"
+#include <cmath>
 #include <QMouseEvent>
 #include <QPainter>
+#include <QPoint>
+#include <QSize>
 
 ColorPicker::ColorPicker(QWidget* parent)
   : ColorPickerWidget(parent)
@@ -29,15 +32,36 @@ void ColorPicker::setNewColor()
 
 void ColorPicker::mouseMoveEvent(QMouseEvent* e)
 {
-    for (int i = 0; i < m_colorList.size(); ++i) {
-        if (m_colorAreaList.at(i).contains(e->pos())) {
-            m_selectedIndex = i;
-            update(m_colorAreaList.at(i) + QMargins(10, 10, 10, 10));
-            update(m_colorAreaList.at(m_lastIndex) + QMargins(10, 10, 10, 10));
-            m_lastIndex = i;
-            break;
-        }
-    }
+    const size_t colsize = m_colorList.size();
+    const QSize  middle  = this->size() * 0.5;
+    const QPoint center  = -(this->pos() - this->mapToParent(e->pos())
+        + QPoint(middle.width(), middle.height()));
+    const double arclength = 2.0 * M_PI / colsize;
+
+    // Computes the new index based on the orientation of the mouse
+    // from the middle of the circle of colors.
+    //
+    // This is done with the following equation:
+    //
+    //  index = angle_made_on_unit_circle / angle_per_color + color_shift
+    //
+    //  Where andle_made_on_unit_circle is from [0, 2pi] given std::atan2,
+    //  and angle_per_color simply is 2pi / number_of_colors.
+    //
+    //  The color_shift is 3 * number_of_colors / 4 since the index
+    //  of the first color is -3pi / 2 (in the screen coordinates,
+    //  so pi/2 in normal coordinates) and the colors are being drawn
+    //  counter clockwise.
+    m_selectedIndex = (
+       int(
+            (std::atan2(-center.y(), center.x()) + arclength / 2) / arclength
+            + 3 * colsize / 4.0
+        )
+    ) % colsize;
+
+    update(m_colorAreaList.at(m_selectedIndex) + QMargins(10, 10, 10, 10));
+    update(m_colorAreaList.at(m_lastIndex) + QMargins(10, 10, 10, 10));
+    m_lastIndex = m_selectedIndex;
 }
 
 void ColorPicker::showEvent(QShowEvent* event)


### PR DESCRIPTION
The current process for selecting a new colour requires opening the colour picker with a right click and then selecting a colour with a left click on the chosen disk. This quickly become tedious when multiple colours are involved in the drawing.

This pull request aims to fix this issue by having the colour picker chose the colour that corresponds to the current orientation of the cursor, removing the requirement for a second mouse press.

This also fixes an inconvenience (possibly a bug) where if no tool is selected and the wheel is spawned on the sides of the selection panel, when choosing a colour outside the bounds of the selection, the selection will consider the left click as a new selection, effectively removing the previous selection area.