### PR TITLE
feat: add capture delay option to the tray icon

### DIFF
--- a/src/config/generalconf.cpp
+++ b/src/config/generalconf.cpp
@@ -49,6 +49,8 @@ GeneralConf::GeneralConf(QWidget* parent)
     initShowQuitPrompt();
     initAllowMultipleGuiInstances();
     initSaveLastRegion();
+    initCaptureDelay();
+
     initShowHelp();
     initShowSidePanelButton();
     initUseJpgForClipboard();
@@ -108,6 +110,16 @@ void GeneralConf::_updateComponents(bool allowEmptySavePath)
     m_showMagnifier->setChecked(config.showMagnifier());
     m_squareMagnifier->setChecked(config.squareMagnifier());
     m_saveLastRegion->setChecked(config.saveLastRegion());
+
+    // Find and select the item with matching capture delay value
+    int currentDelayMs = config.captureDelay();
+    for (int i = 0; i < m_captureDelay->count(); ++i) {
+        if (m_captureDelay->itemData(i).toInt() == currentDelayMs) {
+            m_captureDelay->setCurrentIndex(i);
+            break;
+        }
+    }
+
     m_reverseArrow->setChecked(config.reverseArrow());
 
 #if !defined(Q_OS_WIN)
@@ -144,6 +156,13 @@ void GeneralConf::updateComponents()
 void GeneralConf::saveLastRegion(bool checked)
 {
     ConfigHandler().setSaveLastRegion(checked);
+}
+
+void GeneralConf::captureDelayChanged(int index)
+{
+    // Get the delay value (in milliseconds) from the selected item's data
+    int delayMs = m_captureDelay->itemData(index).toInt();
+    ConfigHandler().setCaptureDelay(delayMs);
 }
 
 void GeneralConf::showHelpChanged(bool checked)
@@ -298,6 +317,39 @@ void GeneralConf::initSaveLastRegion()
             &QCheckBox::clicked,
             this,
             &GeneralConf::saveLastRegion);
+}
+
+void GeneralConf::initCaptureDelay()
+{
+    auto* delayLayout = new QHBoxLayout();
+
+    m_captureDelay = new QComboBox(this);
+
+    // Add the same options as in the tray icon menu
+    m_captureDelay->addItem(tr("No delay"), 0);
+    m_captureDelay->addItem(tr("1 second"), 1000);
+    m_captureDelay->addItem(tr("3 seconds"), 3000);
+    m_captureDelay->addItem(tr("5 seconds"), 5000);
+    m_captureDelay->addItem(tr("10 seconds"), 10000);
+
+    m_captureDelay->setToolTip(
+      tr("Delay before capturing screenshot when triggered from tray icon"));
+
+    auto* delayLabel = new QLabel(tr("Screenshot delay"), this);
+    delayLabel->setToolTip(
+      tr("Delay before capturing screenshot when triggered from tray icon"));
+
+    delayLayout->addWidget(m_captureDelay);
+    delayLayout->addWidget(delayLabel);
+    delayLayout->addStretch();
+
+    m_scrollAreaLayout->addLayout(delayLayout);
+
+    connect(
+      m_captureDelay,
+      static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
+      this,
+      &GeneralConf::captureDelayChanged);
 }
 
 void GeneralConf::initShowSidePanelButton()

--- a/src/config/generalconf.h
+++ b/src/config/generalconf.h
@@ -35,6 +35,7 @@ public slots:
 private slots:
     void showHelpChanged(bool checked);
     void saveLastRegion(bool checked);
+    void captureDelayChanged(int index);
     void showSidePanelButtonChanged(bool checked);
     void showDesktopNotificationChanged(bool checked);
     void showAbortNotificationChanged(bool checked);
@@ -100,6 +101,7 @@ private:
     void initUploadHistoryMax();
     void initUploadClientSecret();
     void initSaveLastRegion();
+    void initCaptureDelay();
     void initShowSelectionGeometry();
     void initJpegQuality();
     void initReverseArrow();
@@ -130,6 +132,7 @@ private:
     QCheckBox* m_copyPathAfterSave;
     QCheckBox* m_antialiasingPinZoom;
     QCheckBox* m_saveLastRegion;
+    QComboBox* m_captureDelay;
     QCheckBox* m_uploadWithoutConfirmation;
     QPushButton* m_importButton;
     QPushButton* m_exportButton;

--- a/src/utils/confighandler.cpp
+++ b/src/utils/confighandler.cpp
@@ -104,6 +104,7 @@ static QMap<class QString, QSharedPointer<ValueHandler>>
     OPTION("savePathFixed"               ,Bool               ( false         )),
     OPTION("saveAsFileExtension"         ,SaveFileExtension  (               )),
     OPTION("saveLastRegion"              ,Bool               ( false         )),
+    OPTION("captureDelay"                ,LowerBoundedInt    ( 0, 0          )),
     OPTION("uploadHistoryMax"            ,LowerBoundedInt    ( 0, 25         )),
     OPTION("undoLimit"                   ,BoundedInt         ( 0, 999, 100   )),
     // Interface tab

--- a/src/utils/confighandler.h
+++ b/src/utils/confighandler.h
@@ -134,6 +134,7 @@ public:
     CONFIG_GETTER_SETTER(copyOnDoubleClick, setCopyOnDoubleClick, bool)
     CONFIG_GETTER_SETTER(uploadClientSecret, setUploadClientSecret, QString)
     CONFIG_GETTER_SETTER(saveLastRegion, setSaveLastRegion, bool)
+    CONFIG_GETTER_SETTER(captureDelay, setCaptureDelay, int)
     CONFIG_GETTER_SETTER(showSelectionGeometry, setShowSelectionGeometry, int)
     CONFIG_GETTER_SETTER(jpegQuality, setJpegQuality, int)
     CONFIG_GETTER_SETTER(reverseArrow, setReverseArrow, bool)

--- a/src/widgets/CMakeLists.txt
+++ b/src/widgets/CMakeLists.txt
@@ -16,6 +16,7 @@ target_sources(
         loadspinner.h
         notificationwidget.h
         orientablepushbutton.h
+        countdownwindow.h
 
         colorpickerwidget.h
         capture/capturetoolobjects.h
@@ -44,6 +45,7 @@ target_sources(
         loadspinner.cpp
         notificationwidget.cpp
         orientablepushbutton.cpp
+        countdownwindow.cpp
         colorpickerwidget.cpp
         capture/capturetoolobjects.cpp
 )

--- a/src/widgets/countdownwindow.cpp
+++ b/src/widgets/countdownwindow.cpp
@@ -1,0 +1,90 @@
+#include "countdownwindow.h"
+
+#include "src/utils/confighandler.h"
+#include <QApplication>
+#include <QLabel>
+#include <QScreen>
+#include <QTimer>
+#include <QVBoxLayout>
+
+CountdownWindow::CountdownWindow(int seconds, QWidget* parent)
+  : QWidget(parent,
+            Qt::ToolTip | Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint |
+              Qt::WindowTransparentForInput)
+  , m_remainingSeconds(seconds)
+{
+    setAttribute(Qt::WA_TranslucentBackground);
+    setAttribute(Qt::WA_DeleteOnClose);
+    setAttribute(Qt::WA_TransparentForMouseEvents);
+
+    auto* layout = new QVBoxLayout(this);
+    layout->setContentsMargins(15, 15, 15, 15);
+
+    m_label = new QLabel(this);
+    m_label->setAlignment(Qt::AlignCenter);
+
+    QColor uiColor = ConfigHandler().uiColor();
+    QColor textColor = uiColor.lightness() > 127 ? Qt::black : Qt::white;
+
+    // Make background semi-transparent (75% opacity)
+    uiColor.setAlphaF(0.75);
+
+    m_label->setStyleSheet(QString("QLabel {"
+                                   "    background-color: rgba(%1, %2, %3, %4);"
+                                   "    color: %5;"
+                                   "    border-radius: 8px;"
+                                   "    padding: 15px 20px;"
+                                   "    font-size: 14pt;"
+                                   "    font-weight: bold;"
+                                   "}")
+                             .arg(uiColor.red())
+                             .arg(uiColor.green())
+                             .arg(uiColor.blue())
+                             .arg(int(uiColor.alphaF() * 255))
+                             .arg(textColor.name()));
+
+    layout->addWidget(m_label);
+
+    m_timer = new QTimer(this);
+    m_timer->setInterval(1000);
+    connect(m_timer, &QTimer::timeout, this, &CountdownWindow::updateDisplay);
+
+    // Position window at top-right (about 5% from edges)
+    updateDisplay(); // Update text first so we know the size
+    adjustSize();    // Resize to fit content
+
+    QScreen* screen = QGuiApplication::primaryScreen();
+    if (screen) {
+        QRect screenGeometry = screen->availableGeometry();
+
+        // Calculate position: 5% from right edge, 5% from top edge
+        int xOffset = screenGeometry.width() * 0.05;
+        int yOffset = screenGeometry.height() * 0.05;
+
+        int x = screenGeometry.right() - width() - xOffset;
+        int y = screenGeometry.top() + yOffset;
+
+        move(x, y);
+    }
+}
+
+void CountdownWindow::startCountdown()
+{
+    show();
+    m_timer->start();
+}
+
+void CountdownWindow::updateDisplay()
+{
+    if (m_remainingSeconds > 0) {
+        QString suffix =
+          m_remainingSeconds == 1 ? tr(" second") : tr(" seconds");
+        m_label->setText(
+          tr("Screenshot in\n%1%2").arg(m_remainingSeconds).arg(suffix));
+        m_remainingSeconds--;
+    } else {
+        m_timer->stop();
+        close();
+        emit countdownFinished();
+    }
+}

--- a/src/widgets/countdownwindow.h
+++ b/src/widgets/countdownwindow.h
@@ -1,0 +1,24 @@
+#include <QWidget>
+
+#pragma once
+
+class QLabel;
+class QTimer;
+
+class CountdownWindow : public QWidget
+{
+    Q_OBJECT
+public:
+    explicit CountdownWindow(int seconds, QWidget* parent = nullptr);
+    void startCountdown();
+
+signals:
+    void countdownFinished();
+
+private:
+    void updateDisplay();
+
+    QLabel* m_label;
+    QTimer* m_timer;
+    int m_remainingSeconds;
+};

--- a/src/widgets/trayicon.cpp
+++ b/src/widgets/trayicon.cpp
@@ -1,10 +1,12 @@
 #include "trayicon.h"
 
+#include "countdownwindow.h"
 #include "src/core/flameshot.h"
 #include "src/core/flameshotdaemon.h"
 #include "src/utils/globalvalues.h"
 
 #include "src/utils/confighandler.h"
+#include <QActionGroup>
 #include <QApplication>
 #include <QMenu>
 #include <QTimer>
@@ -17,6 +19,10 @@
 
 TrayIcon::TrayIcon(QObject* parent)
   : QSystemTrayIcon(parent)
+  , m_delayMenu(nullptr)
+  , m_delayActionGroup(nullptr)
+  , m_countdownTimer(nullptr)
+  , m_remainingSeconds(0)
 {
     initMenu();
 
@@ -85,11 +91,20 @@ TrayIcon::TrayIcon(QObject* parent)
     connect(ConfigHandler::getInstance(),
             &ConfigHandler::fileChanged,
             this,
-            [this]() { updateCaptureActionShortcut(); });
+            [this]() {
+                updateCaptureActionShortcut();
+                updateDelayActions();
+            });
 }
 
 TrayIcon::~TrayIcon()
 {
+    if (m_countdownTimer) {
+        m_countdownTimer->stop();
+        delete m_countdownTimer;
+    }
+    delete m_delayMenu;
+    delete m_delayActionGroup;
     delete m_menu;
 }
 
@@ -125,6 +140,40 @@ void TrayIcon::initMenu()
     });
 #endif
     });
+
+    // Create delay submenu
+    m_delayMenu = new QMenu(tr("Screenshot &Delay"), m_menu);
+    m_delayActionGroup = new QActionGroup(this);
+    m_delayActionGroup->setExclusive(true);
+
+    // Define delay options (in milliseconds)
+    QVector<QPair<QString, int>> delayOptions = { { tr("No Delay"), 0 },
+                                                  { tr("1 second"), 1000 },
+                                                  { tr("3 seconds"), 3000 },
+                                                  { tr("5 seconds"), 5000 },
+                                                  { tr("10 seconds"), 10000 } };
+
+    // Get current delay from config (default to 0)
+    int currentDelay = ConfigHandler().captureDelay();
+
+    for (const auto& option : delayOptions) {
+        QAction* delayAction = new QAction(option.first, m_delayMenu);
+        delayAction->setCheckable(true);
+        delayAction->setData(option.second);
+
+        if (option.second == currentDelay) {
+            delayAction->setChecked(true);
+        }
+
+        connect(delayAction, &QAction::triggered, this, [this, delayAction]() {
+            int delay = delayAction->data().toInt();
+            ConfigHandler().setCaptureDelay(delay);
+        });
+
+        m_delayActionGroup->addAction(delayAction);
+        m_delayMenu->addAction(delayAction);
+    }
+
     auto* launcherAction = new QAction(tr("&Open Launcher"), this);
     connect(launcherAction,
             &QAction::triggered,
@@ -181,6 +230,7 @@ void TrayIcon::initMenu()
 #endif
     m_menu->addAction(openSavePathAction);
     m_menu->addSeparator();
+    m_menu->addMenu(m_delayMenu);
     m_menu->addAction(configAction);
     m_menu->addSeparator();
 #if !defined(DISABLE_UPDATE_CHECKER)
@@ -203,6 +253,22 @@ void TrayIcon::updateCaptureActionShortcut()
 #endif
 }
 
+void TrayIcon::updateDelayActions()
+{
+    if (!m_delayActionGroup) {
+        return;
+    }
+
+    int currentDelay = ConfigHandler().captureDelay();
+
+    for (QAction* action : m_delayActionGroup->actions()) {
+        if (action->data().toInt() == currentDelay) {
+            action->setChecked(true);
+            break;
+        }
+    }
+}
+
 #if !defined(DISABLE_UPDATE_CHECKER)
 void TrayIcon::enableCheckUpdatesAction(bool enable)
 {
@@ -218,8 +284,39 @@ void TrayIcon::enableCheckUpdatesAction(bool enable)
 
 void TrayIcon::startGuiCapture()
 {
-    auto* widget = Flameshot::instance()->gui();
+    // Get the configured delay
+    int delay = ConfigHandler().captureDelay();
+
+    if (delay > 0) {
+        startGuiCaptureWithCountdown(delay);
+    } else {
+        // No delay, start immediately
+        auto* widget = Flameshot::instance()->gui();
 #if !defined(DISABLE_UPDATE_CHECKER)
-    FlameshotDaemon::instance()->showUpdateNotificationIfAvailable(widget);
+        FlameshotDaemon::instance()->showUpdateNotificationIfAvailable(widget);
 #endif
+    }
+}
+
+void TrayIcon::startGuiCaptureWithCountdown(int delayMs)
+{
+    int seconds = delayMs / 1000;
+
+    // Create countdown window
+    auto* countdownWindow = new CountdownWindow(seconds);
+
+    // When countdown finishes, take the screenshot
+    connect(
+      countdownWindow, &CountdownWindow::countdownFinished, this, [this]() {
+          // Add a small delay to ensure the window is fully closed
+          QTimer::singleShot(50, this, [this]() {
+              auto* widget = Flameshot::instance()->gui();
+#if !defined(DISABLE_UPDATE_CHECKER)
+              FlameshotDaemon::instance()->showUpdateNotificationIfAvailable(
+                widget);
+#endif
+          });
+      });
+
+    countdownWindow->startCountdown();
 }

--- a/src/widgets/trayicon.h
+++ b/src/widgets/trayicon.h
@@ -3,6 +3,8 @@
 #pragma once
 
 class QAction;
+class QActionGroup;
+class QTimer;
 
 class TrayIcon : public QSystemTrayIcon
 {
@@ -24,9 +26,15 @@ private:
 #endif
 
     void startGuiCapture();
+    void startGuiCaptureWithCountdown(int delayMs);
+    void updateDelayActions();
 
     QMenu* m_menu;
+    QMenu* m_delayMenu;
     QAction* m_captureAction;
+    QActionGroup* m_delayActionGroup;
+    QTimer* m_countdownTimer;
+    int m_remainingSeconds;
 #if !defined(DISABLE_UPDATE_CHECKER)
     QAction* m_appUpdates;
 #endif


### PR DESCRIPTION
Add a submenu to the tray icon to allow quick selection of the capture delay for captures initiated from the tray icon.
Introduce a new `captureDelay` config option to store this value.
When a delayed capture is started, a (not too big) countdown is displayed until the capture begins.

Easy delayed screenshot, using the interface, is a feature that I need very often, and it looks like that it is also a regularly requested feature:
https://github.com/flameshot-org/flameshot/issues/2625
https://github.com/flameshot-org/flameshot/issues/582
https://github.com/flameshot-org/flameshot/issues/233

And the countdown provided with this would probably also solve:
https://github.com/flameshot-org/flameshot/issues/3227
https://github.com/flameshot-org/flameshot/issues/358


Examples:
<img width="329" height="248" alt="Capture d’écran du 2025-11-24 02-27-21" src="https://github.com/user-attachments/assets/665b3a2c-0174-49e5-89ac-7a6515e129eb" />

(Don't mind the submenu that is on the left despite the arrow that is on the right, this is the standard behavior of my desktop when the tray icons are on the right)

<img width="259" height="212" alt="Capture d’écran du 2025-11-24 02-28-53" src="https://github.com/user-attachments/assets/ca63ebcb-44fb-4bbc-8959-8fad3d9e7990" />
