### PR TITLE
Force PNG clipboard on Windows (fix for #2487)

### DIFF
--- a/flameshot.example.ini
+++ b/flameshot.example.ini
@@ -19,7 +19,7 @@
 ;saveAsFileExtension=.png
 ;
 ;; UI language (auto = detected system language)
-; uiLanguage=auto
+;uiLanguage=auto
 ;
 ;; Main UI color
 ;; Color is any valid hex code or W3C color name
@@ -54,16 +54,17 @@
 ;; Whether the tray icon is disabled (bool)
 ;disabledTrayIcon=false
 ;
-;; Use grim-based wayland universal screenshot adapter
+;; Use grim-based wayland universal screenshot adapter (bool)
 ;useGrimAdapter=false
 ;
-;; Disable Grim Warning notification
+;; Disable Grim Warning notification (bool)
 ;disabledGrimWarning=true
 ;
-;; Automatically close daemon when it's not needed (not available on Windows)
+;; Automatically close daemon when it's not needed (bool)
+;; (This option is not available on Windows)
 ;autoCloseIdleDaemon=false
 ;
-;; Allow multiple instances of `flameshot gui` to run at the same time
+;; Allow multiple instances of `flameshot gui` to run at the same time (bool)
 ;allowMultipleGuiInstances=false
 ;
 ;; Last used tool thickness; same thickness shared by Pencil, Line, Arrow, Rectangular Selection, Circle (int)
@@ -102,23 +103,24 @@
 ;; Copy path to image after save (bool)
 ;copyPathAfterSave=false
 ;
-;; On successful upload, close the dialog and copy URL to clipboard.
+;; On successful upload, close the dialog and copy URL to clipboard (bool)
 ;copyAndCloseAfterUpload=true
 ;
 ;; Anti-aliasing image when zoom the pinned image (bool)
 ;antialiasingPinZoom=true
 ;
 ;; Use JPG format instead of PNG (bool)
+;; (This option is not available on Windows)
 ;useJpgForClipboard=false
 ;
 ;; Upload to imgur without confirmation (bool)
 ;uploadWithoutConfirmation=false
 ;
-;; Use larger color palette as the default one
-; predefinedColorPaletteLarge=false
+;; Use larger color palette as the default one (bool)
+;predefinedColorPaletteLarge=false
 ;
 ;; Set JPEG Quality (int in range 0-100)
-; jpegQuality=75
+;jpegQuality=75
 ;
 ;; Shortcut Settings for all tools
 ;[Shortcuts]

--- a/src/config/generalconf.cpp
+++ b/src/config/generalconf.cpp
@@ -688,14 +688,20 @@ void GeneralConf::initUseJpgForClipboard()
 {
     m_useJpgForClipboard =
       new QCheckBox(tr("Use JPG format for clipboard (PNG default)"), this);
+
+#ifdef Q_OS_WIN
+    ConfigHandler().setUseJpgForClipboard(false);
+    m_useJpgForClipboard->setVisible(false);
+#else
     m_useJpgForClipboard->setToolTip(
       tr("Use lossy JPG format for clipboard (lossless PNG default)"));
-    m_scrollAreaLayout->addWidget(m_useJpgForClipboard);
-
     connect(m_useJpgForClipboard,
             &QCheckBox::clicked,
             this,
             &GeneralConf::useJpgForClipboardChanged);
+#endif
+
+    m_scrollAreaLayout->addWidget(m_useJpgForClipboard);
 }
 
 void GeneralConf::saveAfterCopyChanged(bool checked)


### PR DESCRIPTION
As discussed in #2487, Windows doesn't support JPG images in the clipboard. This PR forces PNG and disables the option to choose JPG in the settings.