### PR TITLE
Fix Wayland screenshot scaling on multi-monitor setups

### DIFF
--- a/src/utils/screengrabber.cpp
+++ b/src/utils/screengrabber.cpp
@@ -105,11 +105,12 @@ void ScreenGrabber::freeDesktopPortal(bool& ok, QPixmap& res)
             // https://bugreports.qt.io/browse/QTBUG-135612
             QRect approxPhysGeo = desktopGeometry();
             QRect logicalGeo = logicalDesktopGeometry();
-            if (res.size() ==
-                approxPhysGeo.size()) // which means the res is physical size
-                                      // and the dpr is correct.
+            const auto appDpr = qApp->devicePixelRatio();
+            if (res.size() == approxPhysGeo.size() ||
+                res.size() / appDpr == approxPhysGeo.size())
+            // which means the res is physical size and the dpr is correct.
             {
-                res.setDevicePixelRatio(qApp->devicePixelRatio());
+                res.setDevicePixelRatio(appDpr);
             } else if (res.size() ==
                        logicalGeo.size()) // which means the res is logical size
                                           // and we need to do nothing.


### PR DESCRIPTION
The newly added if condition enables correct screenshot scaling in CaptureWidget on multi-monitor setups with scaling when running the app with the XCB platform plugin on Wayland. Previously the else branch would be taken, which would apply an incorrect device pixel ratio. Since the screenshot may already be scaled, we need to convert it back to physical dimensions and compare it with desktop geometry again.

Apologies that I do not have enough time to come up with a proper explanation as to why this works. I did test with Wayland, X11 and multiple platform plugins and this change did not affect the functionality of any other configuration. 