### PR TITLE
Fix scaling issue with last-region option

### DIFF
--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -303,7 +303,7 @@ CaptureWidget::~CaptureWidget()
     }
 #endif
     if (m_captureDone) {
-        auto lastRegion = m_selection->geometry();
+        auto lastRegion = extendedRect(m_selection->geometry());
         setLastRegion(lastRegion);
         QRect geometry(m_context.selection);
         geometry.setTopLeft(geometry.topLeft() + m_context.widgetOffset);


### PR DESCRIPTION
When memorising the last region captured on my Mac, I had an issue where the next screenshot's region would be smaller. Each time I did a new screenshot it would be smaller and smaller.
It seems to be a scaling issue similar to what I already saw on Windows with other softwares.
This PR fixes that (I compiled and tested this commit).