### PR TITLE
Simplification of snapcraft.yaml

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -33,9 +33,12 @@ apps:
 
 parts:
   flameshot:
+    plugin: cmake
     source: https://github.com/flameshot-org/flameshot.git
     source-tag: v$SNAPCRAFT_PROJECT_VERSION
-    plugin: cmake
+    build-packages:
+      - libxkbcommon-dev
+      - libproxy-dev
     cmake-parameters:
       - -DFLAMESHOT_ICON=/snap/flameshot/current/usr/share/icons/hicolor/scalable/apps/flameshot.svg
       - -DCMAKE_INSTALL_PREFIX=/usr


### PR DESCRIPTION
This is just to simplify snapcraft.yaml and add common-id.

The removed plugs are already added thanks to the kde-neon-6 extension.

Common-id is for Gnome Software and Plasma Discover to know that the Snap version and the Flatpak version are the same app, instead of showing them separately.