### PR TITLE
fix(nix): ensure Qt6LinguistTools is available in devShell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -10,7 +10,11 @@
   };
 
   outputs =
-    inputs@{ flake-parts, systems, ... }:
+    inputs@{
+      flake-parts,
+      systems,
+      ...
+    }:
     flake-parts.lib.mkFlake { inherit inputs; } {
       systems = import systems;
       imports = [
@@ -114,13 +118,11 @@
           devShells.default = pkgs.mkShell {
             name = "flameshot-dev";
 
-            buildInputs =
-              with pkgs;
-              [
-                cmake
-                gdb
-              ]
-              ++ buildInputs;
+            inputsFrom = [ flameshot ];
+
+            buildInputs = with pkgs; [
+              gdb
+            ];
           };
 
           treefmt = {


### PR DESCRIPTION
## Description
This PR fixes an issue where the nix develop environment was missing Qt6LinguistTools, causing local builds to fail during the configuration step.

### Reproduction

On NixOS, executing the following command inside `nix develop` previously resulted in an error:
```bash
cmake -DCMAKE_BUILD_TYPE:STRING=Debug \
      -DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=TRUE \
      -DQT_DEBUG_FIND_PACKAGE:STRING=ON \
      --no-warn-unused-cli \
      -S . -B build
```

<details>
<summary><b>Output</b></summary>

```
-- Could NOT find Qt6LinguistTools (missing: Qt6LinguistTools_DIR)
CMake Error at src/CMakeLists.txt:1 (find_package):
  Found package configuration file:

    /nix/store/...-qtbase-6.10.0/lib/cmake/Qt6/Qt6Config.cmake

  but it set Qt6_FOUND to FALSE so package "Qt6" is considered to be NOT
  FOUND.  Reason given by package:

  Failed to find required Qt component "LinguistTools".

  Expected Config file at
  "/nix/store/...-qtbase-6.10.0/lib/cmake/Qt6LinguistTools/Qt6LinguistToolsConfig.cmake"
  does NOT exist

-- Configuring incomplete, errors occurred!
```
</details>

## Solution

I updated the flake to use `inputsFrom` inheriting from the main `flameshot` package derivation. 

This ensures the development shell automatically includes all build dependencies defined in the package (specifically `qt6.qttools` in this case), preventing the shell from drifting apart from the actual package build requirements.

```
-- KDSingleApplication is used!
Flameshot predefined color palette large: false
git found: /etc/profiles/per-user/marco/bin/git in version      2.51.2
FLAMESHOT_GIT_HASH: 56faa17e
-- Configuring done (2.0s)
-- Generating done (0.2s)
-- Build files have been written to: /home/marco/projects/flameshot/build
```