### PR TITLE
fix cosmic to use freedesktopportal

### DIFF
--- a/src/utils/desktopinfo.cpp
+++ b/src/utils/desktopinfo.cpp
@@ -44,7 +44,7 @@ DesktopInfo::WM DesktopInfo::windowManager()
         if (desktop.contains(QLatin1String("kde-plasma"))) {
             return DesktopInfo::KDE;
         }
-        if (desktop.contains(QLatin1String("cosmic"))) {
+        if (desktop.contains(QLatin1String("cosmic"), Qt::CaseInsensitive)) {
             return DesktopInfo::COSMIC;
         }
     }

--- a/src/utils/screengrabber.cpp
+++ b/src/utils/screengrabber.cpp
@@ -170,6 +170,7 @@ QPixmap ScreenGrabber::grabEntireDesktop(bool& ok)
         switch (m_info.windowManager()) {
             case DesktopInfo::GNOME:
             case DesktopInfo::KDE:
+            case DesktopInfo::COSMIC:
                 freeDesktopPortal(ok, res);
                 break;
             case DesktopInfo::QTILE:


### PR DESCRIPTION
This removes the warning about grim in cosmic. I tested this on arch where I also have KDE plasma installed, but maybe in a setup with just cosmic there could be an issue or missing dependency. 