### PR TITLE
fix: check QPainter::isActive() before drawing to prevent Wayland crashes

### DIFF
--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -644,6 +644,9 @@ void CaptureWidget::paintEvent(QPaintEvent* paintEvent)
 {
     Q_UNUSED(paintEvent)
     QPainter painter(this);
+    if (!painter.isActive()) {
+        return;
+    }
     GeneralConf::xywh_position position =
       static_cast<GeneralConf::xywh_position>(m_config.showSelectionGeometry());
     /* QPainter::save and restore is somewhat costly so we try to guess

--- a/src/widgets/capture/magnifierwidget.cpp
+++ b/src/widgets/capture/magnifierwidget.cpp
@@ -35,6 +35,9 @@ MagnifierWidget::MagnifierWidget(const QPixmap& p,
 void MagnifierWidget::paintEvent(QPaintEvent*)
 {
     QPainter p(this);
+    if (!p.isActive()) {
+        return;
+    }
     if (m_square) {
         drawMagnifier(p);
     } else {

--- a/src/widgets/capture/notifierbox.cpp
+++ b/src/widgets/capture/notifierbox.cpp
@@ -34,6 +34,9 @@ void NotifierBox::enterEvent(QEnterEvent*)
 void NotifierBox::paintEvent(QPaintEvent*)
 {
     QPainter painter(this);
+    if (!painter.isActive()) {
+        return;
+    }
     // draw Ellipse
     painter.setRenderHint(QPainter::Antialiasing);
     painter.setBrush(QBrush(m_bgColor, Qt::SolidPattern));

--- a/src/widgets/capture/overlaymessage.cpp
+++ b/src/widgets/capture/overlaymessage.cpp
@@ -99,6 +99,8 @@ QString OverlayMessage::compileFromKeyMap(
 void OverlayMessage::paintEvent(QPaintEvent* e)
 {
     QPainter painter(this);
+    if (!painter.isActive())
+        return;
     painter.setRenderHint(QPainter::Antialiasing);
 
     painter.setBrush(QBrush(m_fillColor, Qt::SolidPattern));

--- a/src/widgets/capture/selectionwidget.cpp
+++ b/src/widgets/capture/selectionwidget.cpp
@@ -380,6 +380,9 @@ void SelectionWidget::parentMouseMoveEvent(QMouseEvent* e)
 void SelectionWidget::paintEvent(QPaintEvent*)
 {
     QPainter p(this);
+    if (!p.isActive()) {
+        return;
+    }
     p.setPen(m_color);
     p.drawRect(rect() + QMargins(0, 0, -1, -1));
     p.setRenderHint(QPainter::Antialiasing);

--- a/src/widgets/colorpickerwidget.cpp
+++ b/src/widgets/colorpickerwidget.cpp
@@ -28,6 +28,8 @@ const QVector<QColor>& ColorPickerWidget::getDefaultLargeColorPalette()
 void ColorPickerWidget::paintEvent(QPaintEvent* e)
 {
     QPainter painter(this);
+    if (!painter.isActive())
+        return;
     painter.setRenderHint(QPainter::Antialiasing);
     painter.setPen(QColor(Qt::black));
 

--- a/src/widgets/loadspinner.cpp
+++ b/src/widgets/loadspinner.cpp
@@ -54,6 +54,8 @@ void LoadSpinner::stop()
 void LoadSpinner::paintEvent(QPaintEvent*)
 {
     QPainter painter(this);
+    if (!painter.isActive())
+        return;
     painter.setRenderHint(QPainter::Antialiasing, true);
     auto pen = QPen(m_color);
 

--- a/src/widgets/orientablepushbutton.cpp
+++ b/src/widgets/orientablepushbutton.cpp
@@ -38,6 +38,8 @@ void OrientablePushButton::paintEvent(QPaintEvent* event)
     Q_UNUSED(event)
 
     QStylePainter painter(this);
+    if (!painter.isActive())
+        return;
     QStyleOptionButton option;
     initStyleOption(&option);
 

--- a/src/widgets/panel/colorgrabwidget.cpp
+++ b/src/widgets/panel/colorgrabwidget.cpp
@@ -142,6 +142,8 @@ bool ColorGrabWidget::eventFilter(QObject*, QEvent* event)
 void ColorGrabWidget::paintEvent(QPaintEvent*)
 {
     QPainter painter(this);
+    if (!painter.isActive())
+        return;
     painter.drawImage(QRectF(0, 0, width(), height()), m_previewImage);
 }
 


### PR DESCRIPTION
## Problem
On Wayland (tested on KDE Plasma 6 + Qt 6.10.1), Flameshot crashes intermittently with errors like:
```
QPainter::begin: Paint device returned engine == 0, type: 2
QPainter::setRenderHint: Painter must be active to set rendering hints
QPainter::drawEllipse: Painter not active
```

## Cause
The backing store may not be ready when `paintEvent` is called on Wayland. The code was drawing without checking if the QPainter was successfully initialized.

## Solution
Add `QPainter::isActive()` checks before drawing in:
- `selectionwidget.cpp`
- `notifierbox.cpp`
- `magnifierwidget.cpp`

This is the standard Qt pattern for handling this case - if the painter isn't ready, we simply skip that paint cycle and let the next one handle it.

## Testing
- CachyOS (Arch-based) with KDE Plasma 6 Wayland
- Qt 6.10.1
- Flameshot 13.3.0
- No more crashes after the fix