### PR TITLE
fix: use runtime detection for Wayland clipboard

### DIFF
--- a/src/utils/screenshotsaver.cpp
+++ b/src/utils/screenshotsaver.cpp
@@ -171,11 +171,16 @@ void saveToClipboardMime(const QPixmap& capture, const QString& imageType)
         auto* mimeData = new QMimeData();
 
 #ifdef USE_WAYLAND_CLIPBOARD
-        mimeData->setImageData(formattedPixmap.toImage());
-        mimeData->setData(QStringLiteral("x-kde-force-image-copy"),
-                          QByteArray());
-        KSystemClipboard::instance()->setMimeData(mimeData,
-                                                  QClipboard::Clipboard);
+        if (QGuiApplication::platformName() == "wayland") {
+            mimeData->setImageData(formattedPixmap.toImage());
+            mimeData->setData(QStringLiteral("x-kde-force-image-copy"),
+                              QByteArray());
+            KSystemClipboard::instance()->setMimeData(mimeData,
+                                                      QClipboard::Clipboard);
+        } else {
+            mimeData->setData("image/" + imageType, array);
+            QApplication::clipboard()->setMimeData(mimeData);
+        }
 #else
         mimeData->setData("image/" + imageType, array);
         QApplication::clipboard()->setMimeData(mimeData);


### PR DESCRIPTION
## Problem
When compiled with `USE_WAYLAND_CLIPBOARD=ON`, the clipboard only works on Wayland sessions. Running the same binary on X11 (e.g., via XWayland or `QT_QPA_PLATFORM=xcb`) results in clipboard not working.

## Solution
Add runtime detection for the platform name:
- `wayland` → uses KSystemClipboard (KF6 GuiAddons)
- otherwise → uses QApplication::clipboard() (standard Qt)

## Benefits
- Distros can ship a single binary that works on both Wayland and X11
- No separate builds needed for different display servers
- Zero impact on builds without `USE_WAYLAND_CLIPBOARD`

## Testing
Tested on CachyOS (Arch-based) with KDE Plasma 6:
- ✅ Wayland native: clipboard works
- ✅ X11 via `QT_QPA_PLATFORM=xcb`: clipboard works