### PR TITLE
Multimonitor fix

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -10,7 +10,6 @@ depends=('qt6-base' 'qt6-svg' 'hicolor-icon-theme' 'kguiaddons')
 makedepends=('qt6-tools' 'cmake' 'ninja')
 optdepends=(
     'gnome-shell-extension-appindicator: for system tray icon if you are using Gnome'
-    'grim: for wlroots wayland support'
     'xdg-desktop-portal: for wayland support, you will need the implementation for your wayland desktop environment'
     'qt6-imageformats: for additional export image formats (e.g. tiff, webp, and more)'
 )

--- a/docs/Sway and wlroots support.md
+++ b/docs/Sway and wlroots support.md
@@ -2,7 +2,7 @@
 Flameshot currently supports Sway and other wlroots based Wayland compositors through [xdg-desktop-portal-wlr](https://github.com/emersion/xdg-desktop-portal-wlr). However, due to the way dbus works, there may be some extra steps required for the integration to work properly.
 
 ## Basic steps
-The following packages need to be installed: `xdg-desktop-portal xdg-desktop-portal-wlr grim`. Please ensure your distro packages these, or install them manually.
+The following packages need to be installed: `xdg-desktop-portal xdg-desktop-portal-wlr`. Please ensure your distro packages these, or install them manually.
 
 Ensure that environment variables are set properly. If your distro does not set them automatically, use a launch script to export `XDG_CURRENT_DESKTOP=sway` or `XDG_CURRENT_DESKTOP=river` **before** Sway or River is launched.
 ```sh

--- a/flameshot.example.ini
+++ b/flameshot.example.ini
@@ -54,12 +54,6 @@
 ;; Whether the tray icon is disabled (bool)
 ;disabledTrayIcon=false
 ;
-;; Use grim-based wayland universal screenshot adapter (bool)
-;useGrimAdapter=false
-;
-;; Disable Grim Warning notification (bool)
-;disabledGrimWarning=true
-;
 ;; Automatically close daemon when it's not needed (bool)
 ;; (This option is not available on Windows)
 ;autoCloseIdleDaemon=false

--- a/src/config/generalconf.cpp
+++ b/src/config/generalconf.cpp
@@ -37,7 +37,6 @@ GeneralConf::GeneralConf(QWidget* parent)
     initAutoCloseIdleDaemon();
 #endif
     initShowTrayIcon();
-    initUseGrimAdapter();
     initShowDesktopNotification();
     initShowAbortNotification();
 #if !defined(DISABLE_UPDATE_CHECKER)
@@ -124,10 +123,6 @@ void GeneralConf::_updateComponents(bool allowEmptySavePath)
 #if defined(Q_OS_LINUX) || defined(Q_OS_UNIX)
     m_showTray->setChecked(!config.disabledTrayIcon());
 #endif
-
-#if defined(Q_OS_LINUX)
-    m_useGrimAdapter->setChecked(config.useGrimAdapter());
-#endif
 }
 
 void GeneralConf::updateComponents()
@@ -158,11 +153,6 @@ void GeneralConf::showDesktopNotificationChanged(bool checked)
 void GeneralConf::showAbortNotificationChanged(bool checked)
 {
     ConfigHandler().setShowAbortNotification(checked);
-}
-
-void GeneralConf::useGrimAdapter(bool checked)
-{
-    ConfigHandler().useGrimAdapter(checked);
 }
 
 #if !defined(DISABLE_UPDATE_CHECKER)
@@ -340,24 +330,6 @@ void GeneralConf::initShowTrayIcon()
     connect(m_showTray, &QCheckBox::clicked, this, [](bool checked) {
         ConfigHandler().setDisabledTrayIcon(!checked);
     });
-#endif
-}
-
-void GeneralConf::initUseGrimAdapter()
-{
-#if defined(Q_OS_LINUX)
-    m_useGrimAdapter =
-      new QCheckBox(tr("Use grim to capture screenshots"), this);
-    m_useGrimAdapter->setToolTip(
-      tr("Grim is a wayland only utility to capture screens based on the "
-         "screencopy protocol. Generally only enable on minimal wayland window "
-         "managers like sway, hyprland, etc."));
-    m_scrollAreaLayout->addWidget(m_useGrimAdapter);
-
-    connect(m_useGrimAdapter,
-            &QCheckBox::clicked,
-            this,
-            &GeneralConf::useGrimAdapter);
 #endif
 }
 

--- a/src/config/generalconf.h
+++ b/src/config/generalconf.h
@@ -38,7 +38,6 @@ private slots:
     void showSidePanelButtonChanged(bool checked);
     void showDesktopNotificationChanged(bool checked);
     void showAbortNotificationChanged(bool checked);
-    void useGrimAdapter(bool checked);
 #if !defined(DISABLE_UPDATE_CHECKER)
     void checkForUpdatesChanged(bool checked);
 #endif
@@ -89,7 +88,6 @@ private:
     void initShowSidePanelButton();
     void initShowStartupLaunchMessage();
     void initShowTrayIcon();
-    void initUseGrimAdapter();
     void initSquareMagnifier();
     void initUndoLimit();
     void initUploadWithoutConfirmation();
@@ -111,7 +109,6 @@ private:
     QCheckBox* m_sysNotifications;
     QCheckBox* m_abortNotifications;
     QCheckBox* m_showTray;
-    QCheckBox* m_useGrimAdapter;
     QCheckBox* m_helpMessage;
     QCheckBox* m_sidePanelButton;
 #if !defined(DISABLE_UPDATE_CHECKER)

--- a/src/core/capturerequest.cpp
+++ b/src/core/capturerequest.cpp
@@ -18,6 +18,8 @@ CaptureRequest::CaptureRequest(CaptureRequest::CaptureMode mode,
   , m_delay(delay)
   , m_tasks(tasks)
   , m_data(std::move(data))
+  , m_selectedMonitor(-1)
+  , m_hasSelectedMonitor(false)
 {
 
     ConfigHandler config;
@@ -85,4 +87,20 @@ void CaptureRequest::addPinTask(const QRect& pinWindowGeometry)
 void CaptureRequest::setInitialSelection(const QRect& selection)
 {
     m_initialSelection = selection;
+}
+
+void CaptureRequest::setSelectedMonitor(int monitorIndex)
+{
+    m_selectedMonitor = monitorIndex;
+    m_hasSelectedMonitor = true;
+}
+
+int CaptureRequest::selectedMonitor() const
+{
+    return m_selectedMonitor;
+}
+
+bool CaptureRequest::hasSelectedMonitor() const
+{
+    return m_hasSelectedMonitor;
 }

--- a/src/core/capturerequest.h
+++ b/src/core/capturerequest.h
@@ -49,6 +49,9 @@ public:
     void addSaveTask(const QString& path = QString());
     void addPinTask(const QRect& pinWindowGeometry);
     void setInitialSelection(const QRect& selection);
+    void setSelectedMonitor(int monitorIndex);
+    int selectedMonitor() const;
+    bool hasSelectedMonitor() const;
 
 private:
     CaptureMode m_mode;
@@ -57,6 +60,8 @@ private:
     ExportTask m_tasks;
     QVariant m_data;
     QRect m_pinWindowGeometry, m_initialSelection;
+    int m_selectedMonitor;
+    bool m_hasSelectedMonitor;
 
     CaptureRequest() {}
 };

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -14,6 +14,7 @@ target_sources(
   PRIVATE abstractlogger.cpp
           filenamehandler.cpp
           screengrabber.cpp
+          monitorpreview.cpp
           confighandler.cpp
           systemnotification.cpp
           valuehandler.cpp

--- a/src/utils/confighandler.cpp
+++ b/src/utils/confighandler.cpp
@@ -79,8 +79,6 @@ static QMap<class QString, QSharedPointer<ValueHandler>>
     OPTION("showDesktopNotification"     ,Bool               ( true          )),
     OPTION("showAbortNotification"       ,Bool               ( true          )),
     OPTION("disabledTrayIcon"            ,Bool               ( false         )),
-    OPTION("useGrimAdapter"              ,Bool               ( false         )),
-    OPTION("disabledGrimWarning"         ,Bool               ( false         )),
     OPTION("historyConfirmationToDelete" ,Bool               ( true          )),
 #if !defined(DISABLE_UPDATE_CHECKER)
     OPTION("checkForUpdates"             ,Bool               ( true          )),

--- a/src/utils/confighandler.h
+++ b/src/utils/confighandler.h
@@ -90,8 +90,6 @@ public:
     CONFIG_GETTER_SETTER(showAbortNotification, setShowAbortNotification, bool)
     CONFIG_GETTER_SETTER(filenamePattern, setFilenamePattern, QString)
     CONFIG_GETTER_SETTER(disabledTrayIcon, setDisabledTrayIcon, bool)
-    CONFIG_GETTER_SETTER(useGrimAdapter, useGrimAdapter, bool)
-    CONFIG_GETTER_SETTER(disabledGrimWarning, disabledGrimWarning, bool)
     CONFIG_GETTER_SETTER(drawThickness, setDrawThickness, int)
     CONFIG_GETTER_SETTER(drawFontSize, setDrawFontSize, int)
     CONFIG_GETTER_SETTER(drawCircleCounterSize, setDrawCircleCounterSize, int)

--- a/src/utils/monitorpreview.cpp
+++ b/src/utils/monitorpreview.cpp
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Jeremy Borgman & Contributors
+
+#include "monitorpreview.h"
+#include "src/utils/colorutils.h"
+#include "src/utils/confighandler.h"
+#include <QLabel>
+#include <QMouseEvent>
+#include <QScreen>
+#include <QVBoxLayout>
+
+MonitorPreview::MonitorPreview(int monitorIndex,
+                               QScreen* screen,
+                               const QPixmap& thumbnail,
+                               QWidget* parent)
+  : QWidget(parent)
+  , m_monitorIndex(monitorIndex)
+{
+    QVBoxLayout* layout = new QVBoxLayout(this);
+    layout->setContentsMargins(10, 10, 10, 10);
+    layout->setSpacing(10);
+
+    QLabel* imageLabel = new QLabel(this);
+    imageLabel->setAlignment(Qt::AlignCenter);
+    imageLabel->setPixmap(thumbnail);
+    imageLabel->setStyleSheet(
+      "QLabel { background-color: black; border-radius: 8px; }");
+    imageLabel->setScaledContents(false);
+
+    m_textLabel = new QLabel(tr("Monitor %1: %2\nClick to select")
+                               .arg(m_monitorIndex + 1)
+                               .arg(screen->name()),
+                             this);
+    m_textLabel->setAlignment(Qt::AlignCenter);
+
+    layout->addWidget(imageLabel);
+    layout->addWidget(m_textLabel);
+
+    m_uiColor = ConfigHandler().uiColor();
+    m_contrastColor = ColorUtils::contrastColor(m_uiColor);
+
+    // Apply initial themed background to text label only
+    QString normalStyle =
+      QString("QLabel { color: white; background-color: rgba(%1, %2, %3, 200); "
+              "padding: 5px; font-size: 12pt; border-radius: 3px; }")
+        .arg(m_uiColor.red())
+        .arg(m_uiColor.green())
+        .arg(m_uiColor.blue());
+    m_textLabel->setStyleSheet(normalStyle);
+}
+
+void MonitorPreview::mousePressEvent(QMouseEvent* event)
+{
+    Q_UNUSED(event)
+    emit monitorSelected(m_monitorIndex);
+}
+
+void MonitorPreview::enterEvent(QEnterEvent* event)
+{
+    Q_UNUSED(event)
+    QColor hoverBg = m_contrastColor;
+    QString hoverStyle =
+      QString("QLabel { color: white; background-color: rgba(%1, %2, %3, 220); "
+              "padding: 5px; font-size: 12pt; border-radius: 3px; }")
+        .arg(hoverBg.red())
+        .arg(hoverBg.green())
+        .arg(hoverBg.blue());
+    m_textLabel->setStyleSheet(hoverStyle);
+}
+
+void MonitorPreview::leaveEvent(QEvent* event)
+{
+    Q_UNUSED(event)
+    QString normalStyle =
+      QString("QLabel { color: white; background-color: rgba(%1, %2, %3, 200); "
+              "padding: 5px; font-size: 12pt; border-radius: 3px; }")
+        .arg(m_uiColor.red())
+        .arg(m_uiColor.green())
+        .arg(m_uiColor.blue());
+    m_textLabel->setStyleSheet(normalStyle);
+}

--- a/src/utils/monitorpreview.h
+++ b/src/utils/monitorpreview.h
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Jeremy Borgman & Contributors
+
+#pragma once
+
+#include <QWidget>
+
+class QScreen;
+class QPixmap;
+class QLabel;
+class QEnterEvent;
+
+class MonitorPreview : public QWidget
+{
+    Q_OBJECT
+public:
+    MonitorPreview(int monitorIndex,
+                   QScreen* screen,
+                   const QPixmap& thumbnail,
+                   QWidget* parent = nullptr);
+
+    int monitorIndex() const { return m_monitorIndex; }
+
+signals:
+    void monitorSelected(int index);
+
+protected:
+    void mousePressEvent(QMouseEvent* event) override;
+    void enterEvent(QEnterEvent* event) override;
+    void leaveEvent(QEvent* event) override;
+
+private:
+    int m_monitorIndex;
+    QColor m_uiColor;
+    QColor m_contrastColor;
+    QLabel* m_textLabel;
+};

--- a/src/utils/screengrabber.cpp
+++ b/src/utils/screengrabber.cpp
@@ -19,6 +19,7 @@
 #include <QScreen>
 #include <QTimer>
 #include <QWidget>
+#include <algorithm>
 
 #ifdef FLAMESHOT_DEBUG_CAPTURE
 #include <QDebug>
@@ -315,7 +316,17 @@ QWidget* ScreenGrabber::createMonitorPreviews(const QPixmap& fullScreenshot)
     containerLayout->setSpacing(20);
     containerLayout->setContentsMargins(20, 20, 20, 20);
 
+    // Build list of screen indices sorted by X position (left to right)
+    QList<int> sortedIndices;
     for (int i = 0; i < screens.size(); ++i) {
+        sortedIndices.append(i);
+    }
+    std::sort(
+      sortedIndices.begin(), sortedIndices.end(), [&screens](int a, int b) {
+          return screens[a]->geometry().x() < screens[b]->geometry().x();
+      });
+
+    for (int i : sortedIndices) {
         QScreen* screen = screens[i];
 
         QPixmap cropped = cropToMonitor(fullScreenshot, i);

--- a/src/utils/screengrabber.cpp
+++ b/src/utils/screengrabber.cpp
@@ -1,17 +1,28 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
-// SPDX-FileCopyrightText: 2017-2019 Alejandro Sirgo Rica & Contributors
 
 #include "screengrabber.h"
 #include "abstractlogger.h"
+#include "monitorpreview.h"
 #include "src/core/qguiappcurrentscreen.h"
 #include "src/utils/confighandler.h"
 #include "src/utils/filenamehandler.h"
 #include "src/utils/systemnotification.h"
 #include <QApplication>
+#include <QEventLoop>
 #include <QGuiApplication>
+#include <QHBoxLayout>
+#include <QImageReader>
+#include <QKeyEvent>
+#include <QLabel>
+#include <QMouseEvent>
 #include <QPixmap>
 #include <QProcess>
 #include <QScreen>
+#include <QTimer>
+#include <QWidget>
+
+#ifdef FLAMESHOT_DEBUG_CAPTURE
+#include <QDebug>
+#endif
 
 #if !(defined(Q_OS_MACOS) || defined(Q_OS_WIN))
 #include "request.h"
@@ -22,40 +33,18 @@
 #include <QUuid>
 #endif
 
+bool ScreenGrabber::m_monitorSelectionActive = false;
+
 ScreenGrabber::ScreenGrabber(QObject* parent)
   : QObject(parent)
-{}
-
-void ScreenGrabber::generalGrimScreenshot(bool& ok, QPixmap& res)
+  , m_selectedMonitor(-1)
+  , m_monitorSelectionLoop(nullptr)
+  , m_userCancelled(false)
 {
-#if !(defined(Q_OS_MACOS) || defined(Q_OS_WIN))
-    if (!ConfigHandler().useGrimAdapter()) {
-        return;
-    }
-
-    QString runDir =
-      QProcessEnvironment::systemEnvironment().value("XDG_RUNTIME_DIR");
-    QString imgPath = runDir + "/flameshot.ppm";
-    QProcess Process;
-    QString program = "grim";
-    QStringList arguments;
-    arguments << "-t"
-              << "ppm" << imgPath;
-    Process.start(program, arguments);
-    if (Process.waitForFinished()) {
-        res.load(imgPath, "ppm");
-        QFile imgFile(imgPath);
-        imgFile.remove();
-        adjustDevicePixelRatio(res);
-        ok = true;
-    } else {
-        ok = false;
-        AbstractLogger::error()
-          << tr("The universal wayland screen capture adapter requires Grim as "
-                "the screen capture component of wayland. If the screen "
-                "capture component is missing, please install it!");
-    }
-#endif
+    // Increase image allocation limit for large screenshots
+    // (multi-monitor/high-DPI) Default is 128MB, set to 1GB to handle 4K+
+    // multi-monitor setups
+    QImageReader::setAllocationLimit(1024);
 }
 
 void ScreenGrabber::freeDesktopPortal(bool& ok, QPixmap& res)
@@ -92,14 +81,14 @@ void ScreenGrabber::freeDesktopPortal(bool& ok, QPixmap& res)
       this);
 
     QEventLoop loop;
-    const auto gotSignal = [&res, &loop, this](uint status,
-                                               const QVariantMap& map) {
+
+    const auto onPortalResponse = [&res, &loop, this](uint status,
+                                                      const QVariantMap& map) {
         if (status == 0) {
             // Parse this as URI to handle unicode properly
             QUrl uri = map.value("uri").toString();
             QString uriString = uri.toLocalFile();
             res = QPixmap(uriString);
-            adjustDevicePixelRatio(res);
             QFile imgFile(uriString);
             imgFile.remove();
         }
@@ -108,7 +97,17 @@ void ScreenGrabber::freeDesktopPortal(bool& ok, QPixmap& res)
 
     // prevent racy situations and listen before calling screenshot
     QMetaObject::Connection conn = QObject::connect(
-      request, &org::freedesktop::portal::Request::Response, gotSignal);
+      request, &org::freedesktop::portal::Request::Response, onPortalResponse);
+
+    QTimer timeout;
+    timeout.setSingleShot(true);
+    timeout.setInterval(30000); // 30 second timeout
+    QObject::connect(&timeout, &QTimer::timeout, &loop, [&loop, this]() {
+        AbstractLogger::error()
+          << tr("Screenshot portal timed out after 30 seconds");
+        loop.quit();
+    });
+    timeout.start();
 
     screenshotInterface.call(
       QStringLiteral("Screenshot"),
@@ -117,123 +116,122 @@ void ScreenGrabber::freeDesktopPortal(bool& ok, QPixmap& res)
                                 { "interactive", QVariant(false) } }));
 
     loop.exec();
+    timeout.stop();
     QObject::disconnect(conn);
     request->Close().waitForFinished();
     request->deleteLater();
 
     if (res.isNull()) {
         ok = false;
+        return;
+    }
+
+#ifdef FLAMESHOT_DEBUG_CAPTURE
+    qDebug() << tr("FreeDesktop portal screenshot size: %1x%2, DPR: %3")
+                  .arg(res.width())
+                  .arg(res.height())
+                  .arg(res.devicePixelRatio());
+#endif
+#endif
+}
+
+QPixmap ScreenGrabber::selectMonitorAndCrop(const QPixmap& fullScreenshot,
+                                            bool& ok)
+{
+    ok = true;
+#if defined(Q_OS_MACOS)
+    // Avoid showing additional top-level monitor selection UI on macOS
+    // Only screenshot the monitor where the tray activated the screenshot
+    return cropToMonitor(fullScreenshot, 0);
+#else
+    // If there's only one monitor, skip selection
+    const QList<QScreen*> screens = QGuiApplication::screens();
+    if (screens.size() == 1) {
+        return cropToMonitor(fullScreenshot, 0);
+    }
+
+    if (m_monitorSelectionActive) {
+        AbstractLogger::error()
+          << tr("Screenshot already in progress, please wait for the current "
+                "screenshot to complete");
+        ok = false;
+        return QPixmap();
+    }
+
+    m_monitorSelectionActive = true;
+    m_selectedMonitor = -1;
+    m_userCancelled = false;
+    QWidget* container = createMonitorPreviews(fullScreenshot);
+
+    // Wait for user to select a monitor
+    QEventLoop loop;
+    m_monitorSelectionLoop = &loop;
+    loop.exec();
+    m_monitorSelectionLoop = nullptr;
+
+    delete container;
+    m_monitorSelectionActive = false;
+
+    if (m_selectedMonitor >= 0) {
+        return cropToMonitor(fullScreenshot, m_selectedMonitor);
+    } else {
+        ok = false;
+        if (m_userCancelled) {
+            AbstractLogger::info() << tr("Screenshot cancelled");
+        }
+        return fullScreenshot;
     }
 #endif
 }
 
-QPixmap ScreenGrabber::grabEntireDesktop(bool& ok)
+QPixmap ScreenGrabber::grabEntireDesktop(bool& ok, int preSelectedMonitor)
 {
     ok = true;
     int wid = 0;
+    QPixmap screenshot;
 
 #if defined(Q_OS_MACOS)
     QScreen* currentScreen = QGuiAppCurrentScreen().currentScreen();
-    QPixmap screenPixmap(
-      currentScreen->grabWindow(wid,
-                                currentScreen->geometry().x(),
-                                currentScreen->geometry().y(),
-                                currentScreen->geometry().width(),
-                                currentScreen->geometry().height()));
-    screenPixmap.setDevicePixelRatio(currentScreen->devicePixelRatio());
-    return screenPixmap;
-#elif defined(Q_OS_LINUX) || defined(Q_OS_UNIX)
-    if (m_info.waylandDetected()) {
-        QPixmap res;
-        // handle screenshot based on DE
-        switch (m_info.windowManager()) {
-            case DesktopInfo::GNOME:
-            case DesktopInfo::KDE:
-            case DesktopInfo::COSMIC:
-                freeDesktopPortal(ok, res);
-                break;
-            case DesktopInfo::QTILE:
-            case DesktopInfo::WLROOTS:
-            case DesktopInfo::HYPRLAND:
-            case DesktopInfo::OTHER: {
-                if (!ConfigHandler().useGrimAdapter()) {
-                    if (!ConfigHandler().disabledGrimWarning()) {
-                        AbstractLogger::warning() << tr(
-                          "If the useGrimAdapter setting is not enabled, the "
-                          "dbus protocol will be used. It should be noted that "
-                          "using the dbus protocol under wayland is not "
-                          "recommended. It is recommended to enable the "
-                          "useGrimAdapter setting in flameshot.ini to activate "
-                          "the grim-based general wayland screenshot adapter");
-                    }
-                    freeDesktopPortal(ok, res);
-                } else {
-                    if (!ConfigHandler().disabledGrimWarning()) {
-                        AbstractLogger::warning() << tr(
-                          "grim's screenshot component is implemented based on "
-                          "wlroots, it may not be used in GNOME or similar "
-                          "desktop environments");
-                    }
-                    generalGrimScreenshot(ok, res);
-                }
-                break;
-            }
-            default:
-                ok = false;
-                AbstractLogger::error()
-                  << tr("Unable to detect desktop environment (GNOME? KDE? "
-                        "Qile? Sway? ...)");
-                AbstractLogger::error()
-                  << tr("Hint: try setting the XDG_CURRENT_DESKTOP environment "
-                        "variable.");
-                break;
-        }
-        if (!ok) {
-            AbstractLogger::error() << tr("Unable to capture screen");
-        }
-        return res;
+    if (!currentScreen) {
+        AbstractLogger::error() << tr("Unable to get current screen");
+        ok = false;
+        return QPixmap();
     }
-#endif
-#if defined(Q_OS_LINUX) || defined(Q_OS_UNIX) || defined(Q_OS_WIN)
-    QRect geometry = desktopGeometry();
+    const QRect geom = currentScreen->geometry();
+    screenshot = currentScreen->grabWindow(
+      wid, geom.x(), geom.y(), geom.width(), geom.height());
+    screenshot.setDevicePixelRatio(currentScreen->devicePixelRatio());
+    return screenshot;
 
-    // Qt6 fix: Create a composite image from all screens to handle
-    // multi-monitor setups where screens have different positions/heights.
-    // This fixes the dual monitor offset bug and handles edge cases where
-    // the desktop bounding box includes virtual space.
-    QScreen* primaryScreen = QGuiApplication::primaryScreen();
-    QRect r = primaryScreen->geometry();
-    QPixmap desktop(geometry.size());
-    desktop.fill(Qt::black); // Fill with black background
-    desktop =
-      primaryScreen->grabWindow(wid,
-                                -r.x() / primaryScreen->devicePixelRatio(),
-                                -r.y() / primaryScreen->devicePixelRatio(),
-                                geometry.width(),
-                                geometry.height());
-    return desktop;
+#elif defined(Q_OS_LINUX) || defined(Q_OS_UNIX)
+    freeDesktopPortal(ok, screenshot);
+    if (!ok) {
+        AbstractLogger::error() << tr("Unable to capture screen");
+        return QPixmap();
+    }
+
+#elif defined(Q_OS_WIN)
+    screenshot = windowsScreenshot(wid);
 #endif
+
+    // If monitor was pre-selected skip UI and crop directly
+    if (preSelectedMonitor >= 0) {
+        const QList<QScreen*> screens = QGuiApplication::screens();
+        if (preSelectedMonitor < screens.size()) {
+            m_selectedMonitor = preSelectedMonitor;
+            return cropToMonitor(screenshot, preSelectedMonitor);
+        }
+    }
+
+    return selectMonitorAndCrop(screenshot, ok);
 }
 
 QRect ScreenGrabber::screenGeometry(QScreen* screen)
 {
-    QRect geometry;
+    QRect geometry = screen->geometry();
     if (m_info.waylandDetected()) {
         QPoint topLeft(0, 0);
-#ifdef Q_OS_WIN
-        for (QScreen* const screen : QGuiApplication::screens()) {
-            QPoint topLeftScreen = screen->geometry().topLeft();
-            if (topLeft.x() > topLeftScreen.x() ||
-                topLeft.y() > topLeftScreen.y()) {
-                topLeft = topLeftScreen;
-            }
-        }
-#endif
-        geometry = screen->geometry();
         geometry.moveTo(geometry.topLeft() - topLeft);
-    } else {
-        QScreen* currentScreen = QGuiAppCurrentScreen().currentScreen();
-        geometry = currentScreen->geometry();
     }
     return geometry;
 }
@@ -242,16 +240,21 @@ QPixmap ScreenGrabber::grabScreen(QScreen* screen, bool& ok)
 {
     QPixmap p;
     QRect geometry = screenGeometry(screen);
-    if (m_info.waylandDetected()) {
-        p = grabEntireDesktop(ok);
-        if (ok) {
-            return p.copy(geometry);
-        }
-    } else {
-        ok = true;
-        return screen->grabWindow(
-          0, geometry.x(), geometry.y(), geometry.width(), geometry.height());
+#if defined(Q_OS_LINUX)
+    p = grabEntireDesktop(ok);
+    if (ok) {
+        // Both X11 and Wayland: Use cropToMonitor for consistent handling
+        // of misaligned monitors and mixed DPI
+        const QList<QScreen*> screens = QGuiApplication::screens();
+        int screenIndex = screens.indexOf(screen);
+
+        return cropToMonitor(p, screenIndex);
     }
+#else
+    ok = true;
+    return screen->grabWindow(
+      0, geometry.x(), geometry.y(), geometry.width(), geometry.height());
+#endif
     return p;
 }
 
@@ -261,38 +264,322 @@ QRect ScreenGrabber::desktopGeometry()
 
     for (QScreen* const screen : QGuiApplication::screens()) {
         QRect scrRect = screen->geometry();
-        // Qt6 fix: Don't divide by devicePixelRatio for multi-monitor setups
-        // This was causing coordinate offset issues in dual monitor
-        // configurations
-        // But it still has a screen position in real pixels, not logical ones
+#if !defined(Q_OS_WIN)
+        // https://doc.qt.io/qt-6/highdpi.html#device-independent-screen-geometry
         qreal dpr = screen->devicePixelRatio();
         scrRect.moveTo(QPointF(scrRect.x() / dpr, scrRect.y() / dpr).toPoint());
+#endif
         geometry = geometry.united(scrRect);
     }
     return geometry;
 }
 
-QRect ScreenGrabber::logicalDesktopGeometry()
+QScreen* ScreenGrabber::getSelectedScreen() const
 {
-    QRect geometry;
-    for (QScreen* const screen : QGuiApplication::screens()) {
-        QRect scrRect = screen->geometry();
-        scrRect.moveTo(scrRect.x(), scrRect.y());
-        geometry = geometry.united(scrRect);
+    const QList<QScreen*> screens = QGuiApplication::screens();
+
+    if ((m_selectedMonitor < 0) || (m_selectedMonitor >= screens.size())) {
+        return nullptr;
     }
-    return geometry;
+
+    return screens[m_selectedMonitor];
 }
 
-void ScreenGrabber::adjustDevicePixelRatio(QPixmap& pixmap)
+QWidget* ScreenGrabber::createMonitorPreviews(const QPixmap& fullScreenshot)
 {
-    QRect physicalGeo = desktopGeometry();
-    QRect logicalGeo = logicalDesktopGeometry();
-    if (pixmap.size() == physicalGeo.size()) {
-        // Pixmap is physical size and Qt's DPR is correct
-        pixmap.setDevicePixelRatio(qApp->devicePixelRatio());
-    } else if (pixmap.size() != logicalGeo.size()) {
-        // Pixmap is physical size but Qt's DPR is incorrect, calculate actual
-        pixmap.setDevicePixelRatio(pixmap.height() * 1.0f /
-                                   logicalGeo.height());
+    const QList<QScreen*> screens = QGuiApplication::screens();
+
+#ifdef FLAMESHOT_DEBUG_CAPTURE
+    qDebug() << tr("=== All Screen Information ===");
+    for (int i = 0; i < screens.size(); ++i) {
+        QScreen* s = screens[i];
+        qDebug() << tr("Screen %1: %2").arg(i).arg(s->name());
+        qDebug() << tr("  Logical geometry: %1x%2+%3+%4")
+                      .arg(s->geometry().width())
+                      .arg(s->geometry().height())
+                      .arg(s->geometry().x())
+                      .arg(s->geometry().y());
+        qDebug() << tr("  DPR: %1").arg(s->devicePixelRatio());
     }
+#endif
+
+    QWidget* monitorPreviews = new QWidget(
+      nullptr, Qt::Window | Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint);
+    monitorPreviews->setAttribute(Qt::WA_TranslucentBackground);
+    monitorPreviews->setStyleSheet(
+      "QWidget { background-color: transparent; }");
+    monitorPreviews->installEventFilter(this); // For ESC key handling
+    monitorPreviews->setFocusPolicy(Qt::StrongFocus);
+
+    QHBoxLayout* containerLayout = new QHBoxLayout(monitorPreviews);
+    containerLayout->setSpacing(20);
+    containerLayout->setContentsMargins(20, 20, 20, 20);
+
+    for (int i = 0; i < screens.size(); ++i) {
+        QScreen* screen = screens[i];
+
+        QPixmap cropped = cropToMonitor(fullScreenshot, i);
+        QPixmap thumbnail = cropped.scaled(
+          400, 250, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+        thumbnail.setDevicePixelRatio(1.0);
+
+        MonitorPreview* preview =
+          new MonitorPreview(i, screen, thumbnail, monitorPreviews);
+
+        connect(
+          preview, &MonitorPreview::monitorSelected, this, [this](int index) {
+              m_selectedMonitor = index;
+              if (m_monitorSelectionLoop) {
+                  m_monitorSelectionLoop->quit();
+              }
+          });
+
+        containerLayout->addWidget(preview);
+    }
+
+    monitorPreviews->setLayout(containerLayout);
+    monitorPreviews->adjustSize();
+
+    QScreen* primaryScreen = QGuiApplication::primaryScreen();
+    QRect screenGeometry = primaryScreen->geometry();
+    QPoint center = screenGeometry.center();
+    monitorPreviews->move(center.x() - monitorPreviews->width() / 2,
+                          center.y() - monitorPreviews->height() / 2);
+
+    monitorPreviews->show();
+    return monitorPreviews;
+}
+
+bool ScreenGrabber::eventFilter(QObject* obj, QEvent* event)
+{
+    if (event->type() == QEvent::KeyPress) {
+        QKeyEvent* keyEvent = static_cast<QKeyEvent*>(event);
+        if (keyEvent->key() == Qt::Key_Escape) {
+            // User cancelled selection
+            m_selectedMonitor = -1;
+            m_userCancelled = true;
+            if (m_monitorSelectionLoop) {
+                m_monitorSelectionLoop->quit();
+            }
+            return true;
+        }
+    }
+    return QObject::eventFilter(obj, event);
+}
+
+QPixmap ScreenGrabber::cropToMonitor(const QPixmap& fullScreenshot,
+                                     int monitorIndex)
+{
+    const QList<QScreen*> screens = QGuiApplication::screens();
+    if (monitorIndex >= screens.size()) {
+        return fullScreenshot;
+    }
+
+    QScreen* targetScreen = screens[monitorIndex];
+    QRect targetGeometry = targetScreen->geometry();
+    qreal targetDpr = targetScreen->devicePixelRatio();
+
+    // Calculate total logical dimensions and minimum coordinates
+    int minX = 0, minY = 0;
+    int maxX = 0, maxY = 0;
+
+    for (QScreen* screen : screens) {
+        QRect geo = screen->geometry();
+        minX = qMin(minX, geo.x());
+        minY = qMin(minY, geo.y());
+        maxX = qMax(maxX, geo.x() + geo.width());
+        maxY = qMax(maxY, geo.y() + geo.height());
+    }
+
+    int totalLogicalWidth = maxX - minX;
+    int totalLogicalHeight = maxY - minY;
+
+#ifdef FLAMESHOT_DEBUG_CAPTURE
+    qDebug() << tr("Total logical dimensions: %1x%2 (min: %3,%4)")
+                  .arg(totalLogicalWidth)
+                  .arg(totalLogicalHeight)
+                  .arg(minX)
+                  .arg(minY);
+    qDebug() << tr("Screenshot dimensions: %1x%2")
+                  .arg(fullScreenshot.width())
+                  .arg(fullScreenshot.height());
+#endif
+
+    int cropX, cropY, cropWidth, cropHeight;
+
+#if defined(Q_OS_LINUX)
+    // Linux (both X11 and Wayland via freedesktop portal):
+    // Use logical coordinate-based cropping since portal returns full
+    // desktop
+    qreal screenshotScaleX = (qreal)fullScreenshot.width() / totalLogicalWidth;
+    qreal screenshotScaleY =
+      (qreal)fullScreenshot.height() / totalLogicalHeight;
+
+#ifdef FLAMESHOT_DEBUG_CAPTURE
+    qDebug() << tr("Screenshot scale factors: X=%1 Y=%2")
+                  .arg(screenshotScaleX)
+                  .arg(screenshotScaleY);
+#endif
+
+    cropX = qRound((targetGeometry.x() - minX) * screenshotScaleX);
+    cropY = qRound((targetGeometry.y() - minY) * screenshotScaleY);
+    cropWidth = qRound(targetGeometry.width() * screenshotScaleX);
+    cropHeight = qRound(targetGeometry.height() * screenshotScaleY);
+#else
+    // Windows: Calculate physical pixel positions for mixed DPI
+    cropX = 0;
+    cropY = 0;
+
+    for (QScreen* screen : screens) {
+        QRect geom = screen->geometry();
+        qreal dpr = screen->devicePixelRatio();
+
+        // Sum physical widths of screens completely to the left
+        if (geom.x() + geom.width() <= targetGeometry.x()) {
+            cropX += qRound(geom.width() * dpr);
+        }
+
+        // Sum physical heights of screens completely above
+        if (geom.y() + geom.height() <= targetGeometry.y()) {
+            cropY += qRound(geom.height() * dpr);
+        }
+    }
+
+    cropWidth = qRound(targetGeometry.width() * targetDpr);
+    cropHeight = qRound(targetGeometry.height() * targetDpr);
+
+#ifdef FLAMESHOT_DEBUG_CAPTURE
+    qDebug() << tr("Calculated crop position for mixed DPI: X=%1 Y=%2")
+                  .arg(cropX)
+                  .arg(cropY);
+#endif
+#endif
+
+    QRect cropRect(cropX, cropY, cropWidth, cropHeight);
+
+#ifdef FLAMESHOT_DEBUG_CAPTURE
+    qDebug() << tr("Screen %1: %2").arg(monitorIndex).arg(targetScreen->name());
+    qDebug() << tr("  Logical geometry: %1x%2+%3+%4 DPR: %5")
+                  .arg(targetGeometry.width())
+                  .arg(targetGeometry.height())
+                  .arg(targetGeometry.x())
+                  .arg(targetGeometry.y())
+                  .arg(targetDpr);
+    qDebug() << tr("  Crop rect in screenshot: %1x%2+%3+%4")
+                  .arg(cropRect.width())
+                  .arg(cropRect.height())
+                  .arg(cropRect.x())
+                  .arg(cropRect.y());
+#endif
+
+    // Ensure crop rect is within bounds
+    cropRect = cropRect.intersected(
+      QRect(0, 0, fullScreenshot.width(), fullScreenshot.height()));
+
+    if (cropRect.isEmpty()) {
+        AbstractLogger::warning()
+          << tr("Crop rect is empty, returning full screenshot");
+        return fullScreenshot;
+    }
+
+    QPixmap cropped = fullScreenshot.copy(cropRect);
+
+#if defined(Q_OS_LINUX)
+    // Linux: May need rescaling if scale factors don't match
+    if (qAbs(screenshotScaleX - targetDpr) > 0.01) {
+        int targetPhysicalWidth = qRound(targetGeometry.width() * targetDpr);
+        int targetPhysicalHeight = qRound(targetGeometry.height() * targetDpr);
+        cropped = cropped.scaled(targetPhysicalWidth,
+                                 targetPhysicalHeight,
+                                 Qt::IgnoreAspectRatio,
+                                 Qt::SmoothTransformation);
+    }
+#ifdef FLAMESHOT_DEBUG_CAPTURE
+    qDebug() << tr("Scaling screenshot to: %1 %2")
+                  .arg(targetPhysicalWidth)
+                  .arg(targetPhysicalHeight);
+#endif
+
+#endif
+    // Cropped region should be at target monitor's native DPR
+    cropped.setDevicePixelRatio(targetDpr);
+
+    return cropped;
+}
+
+QPixmap ScreenGrabber::windowsScreenshot(int wid)
+{
+    const QList<QScreen*> screens = QGuiApplication::screens();
+    QRect geometry = desktopGeometry();
+
+    int canvasWidth = 0;
+    int canvasHeight = 0;
+
+    // Build a map tracking where each screen should be positioned in
+    // physical pixels
+    struct ScreenInfo
+    {
+        QRect physicalRect; // Where to draw in the canvas
+        QPixmap pixmap;
+    };
+    QMap<QScreen*, ScreenInfo> screenInfos;
+
+    int minLogicalX = geometry.x();
+    int minLogicalY = geometry.y();
+
+    for (QScreen* screen : screens) {
+        QRect screenGeom = screen->geometry();
+        qreal screenDpr = screen->devicePixelRatio();
+
+        QPixmap screenPixmap = screen->grabWindow(wid);
+        screenPixmap.setDevicePixelRatio(1.0);
+
+        int logicalX = screenGeom.x() - minLogicalX;
+        int logicalY = screenGeom.y() - minLogicalY;
+
+        int physicalWidth = screenPixmap.width();
+        int physicalHeight = screenPixmap.height();
+
+        int physicalX = 0;
+        int physicalY = 0;
+
+        for (QScreen* otherScreen : screens) {
+            QRect otherGeom = otherScreen->geometry();
+            qreal otherDpr = otherScreen->devicePixelRatio();
+
+            // If this screen is entirely to the left of current screen
+            if (otherGeom.x() + otherGeom.width() <= screenGeom.x()) {
+                physicalX += qRound(otherGeom.width() * otherDpr);
+            }
+
+            // If this screen is entirely above the current screen
+            if (otherGeom.y() + otherGeom.height() <= screenGeom.y()) {
+                physicalY += qRound(otherGeom.height() * otherDpr);
+            }
+        }
+
+        ScreenInfo info;
+        info.physicalRect =
+          QRect(physicalX, physicalY, physicalWidth, physicalHeight);
+        info.pixmap = screenPixmap;
+        screenInfos[screen] = info;
+
+        canvasWidth = qMax(canvasWidth, physicalX + physicalWidth);
+        canvasHeight = qMax(canvasHeight, physicalY + physicalHeight);
+    }
+
+    // Composite all screens onto canvas
+    QPixmap desktop(canvasWidth, canvasHeight);
+    desktop.fill(Qt::black);
+
+    QPainter painter(&desktop);
+    painter.setCompositionMode(QPainter::CompositionMode_Source);
+
+    for (QScreen* screen : screens) {
+        const ScreenInfo& info = screenInfos[screen];
+        painter.drawPixmap(info.physicalRect.topLeft(), info.pixmap);
+    }
+    painter.end();
+
+    return desktop;
 }

--- a/src/utils/screengrabber.h
+++ b/src/utils/screengrabber.h
@@ -4,23 +4,43 @@
 #pragma once
 
 #include "src/utils/desktopinfo.h"
+#include <QEvent>
+#include <QList>
 #include <QObject>
+#include <QPixmap>
 #include <QScreen>
+
+class QEventLoop;
+class QWidget;
 
 class ScreenGrabber : public QObject
 {
     Q_OBJECT
 public:
     explicit ScreenGrabber(QObject* parent = nullptr);
-    QPixmap grabEntireDesktop(bool& ok);
+    QPixmap grabEntireDesktop(bool& ok, int preSelectedMonitor = -1);
     QRect screenGeometry(QScreen* screen);
     QPixmap grabScreen(QScreen* screenNumber, bool& ok);
     void freeDesktopPortal(bool& ok, QPixmap& res);
-    void generalGrimScreenshot(bool& ok, QPixmap& res);
     QRect desktopGeometry();
     QRect logicalDesktopGeometry();
+    int getSelectedMonitor() const { return m_selectedMonitor; }
+    QScreen* getSelectedScreen() const;
+    QPixmap selectMonitorAndCrop(const QPixmap& fullScreenshot, bool& ok);
+
+protected:
+    bool eventFilter(QObject* obj, QEvent* event) override;
 
 private:
     void adjustDevicePixelRatio(QPixmap& pixmap);
+    QWidget* createMonitorPreviews(const QPixmap& fullScreenshot);
+    QPixmap cropToMonitor(const QPixmap& fullScreenshot, int monitorIndex);
+    QPixmap windowsScreenshot(int wid);
+
     DesktopInfo m_info;
+    QPixmap Screenshot;
+    int m_selectedMonitor;
+    QEventLoop* m_monitorSelectionLoop;
+    bool m_userCancelled;
+    static bool m_monitorSelectionActive;
 };

--- a/src/widgets/capturelauncher.h
+++ b/src/widgets/capturelauncher.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <QDialog>
+#include <QTimer>
 
 QT_BEGIN_NAMESPACE
 namespace Ui {
@@ -21,8 +22,11 @@ public:
 
 private:
     Ui::CaptureLauncher* ui;
+    QTimer* m_countdownTimer;
+    int m_remainingSeconds;
     void connectCaptureSlots() const;
     void disconnectCaptureSlots() const;
+    void updateCountdown();
 
 private slots:
     void startCapture();

--- a/src/widgets/capturelauncher.ui
+++ b/src/widgets/capturelauncher.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>807</width>
-    <height>213</height>
+    <width>452</width>
+    <height>250</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -15,35 +15,11 @@
   </property>
   <layout class="QHBoxLayout" name="horizontalLayout_4">
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_3">
-     <item>
-      <widget class="ImageLabel" name="imagePreview">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>420</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="text">
-        <string>TextLabel</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item>
     <layout class="QVBoxLayout" name="verticalLayout_2">
      <item>
       <widget class="QLabel" name="modeLabel">
        <property name="font">
         <font>
-         <weight>75</weight>
          <bold>true</bold>
         </font>
        </property>
@@ -51,7 +27,7 @@
         <string>Capture Mode</string>
        </property>
        <property name="alignment">
-        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+        <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
        </property>
        <property name="margin">
         <number>-1</number>
@@ -80,6 +56,16 @@
           <string>Delay:</string>
          </property>
         </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="QLabel" name="monitorLabel">
+         <property name="text">
+          <string>Monitor:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="1">
+        <widget class="QComboBox" name="monitorSelection"/>
        </item>
        <item row="4" column="0">
         <widget class="QLabel" name="sizeLabel">
@@ -153,7 +139,14 @@
        </item>
       </layout>
      </item>
-     <item alignment="Qt::AlignHCenter">
+     <item alignment="Qt::AlignmentFlag::AlignHCenter">
+      <widget class="QLabel" name="countdownLabel">
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item alignment="Qt::AlignmentFlag::AlignHCenter">
       <widget class="QPushButton" name="launchButton">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -170,13 +163,6 @@
    </item>
   </layout>
  </widget>
- <customwidgets>
-  <customwidget>
-   <class>ImageLabel</class>
-   <extends>QLabel</extends>
-   <header>imagelabel.h</header>
-  </customwidget>
- </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/src/widgets/trayicon.h
+++ b/src/widgets/trayicon.h
@@ -18,15 +18,19 @@ public:
 private:
     void initTrayIcon();
     void initMenu();
+    void initScreenMenu();
     void updateCaptureActionShortcut();
 #if !defined(DISABLE_UPDATE_CHECKER)
     void updateCheckUpdatesMenuVisibility();
 #endif
 
     void startGuiCapture();
+    void startGuiCaptureOnScreen(int screenIndex);
 
     QMenu* m_menu;
+    QMenu* m_screenMenu;
     QAction* m_captureAction;
+    QAction* m_launcherAction;
     QAction* m_infoAction;
 #if !defined(DISABLE_UPDATE_CHECKER)
     QAction* m_appUpdates;


### PR DESCRIPTION
This (should) universally fix issues related to dpi, monitor placement, monitor orientation, etc. It changes X11, Wayland, and windows clients to match the MacOS behavior of screenshoting one monitor at a time. I've additionally unified the backend to use xdg-portal everywhere now that it consistently works. This cleans up a good bit of code. 

I also fixed a bug related to DPI and the placement of the toolbar / help screen.

In addition to the examples below I have also tested KDE/Waylaid and Cosmic on Arch. I've also tested on MacOS.

Here are some examples

Hyprland / wlroots:
[hyprland.webm](https://github.com/user-attachments/assets/832cf2ba-6648-441c-b8e6-b9bb40e4f73f)

Ubuntu 22.04 Gnome on X11:
[ubuntu_x11.webm](https://github.com/user-attachments/assets/43b16b7e-d900-410c-8345-e32a831ed015)

Windows 10:
[Windows10.webm](https://github.com/user-attachments/assets/427e76d8-1767-4460-ba20-8c4af0d0106e)

Need to fix before merging:

- [x] CLI screen command 
- [x] Launcher should not prompt for monitor on launch
- [x] Do not allow multiple captures to be started before one is finished
- [x] Quitting monitor selection should not throw an error
- [x] fix region issue relating to pin presenting on the wrong screen
- [x] Delay option is delaying the monitor preview not the actual screenshot.

Need to investigate before merging (not blocking issues it may require larger rework)
- [x] last-region option behaves strange with multi monitor
- [x] Consider moving X11 to portal backend to unify all of linux
- [x] Add menu item to select which screen to capture and bypass preview


Known Issues:
- The cli needs a bit of cleanup related to the ```screen``` command
- When using mixed DPI, sometimes the xdg-portal returns a blurry screenshot for the monitor of higher DPI. There's nothing I can do about this, its returned by the underlying system that way. 

@mmahmoudian  and @ElTh0r0  it would be great to have you also test this before I merge it.
