### PR TITLE
Add Windows installation instructions for Scoop

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,7 @@ After following all those steps above, `flameshot` will open without problems in
 
 ### Windows
 
+- [Scoop](https://github.com/ScoopInstaller/Extras/blob/master/bucket/flameshot.json): `scoop install flameshot`
 - [Chocolatey](https://chocolatey.org/packages/flameshot)
 
 <details>

--- a/README.md
+++ b/README.md
@@ -387,7 +387,6 @@ After following all those steps above, `flameshot` will open without problems in
 ### Windows
 
 - [Scoop](https://github.com/ScoopInstaller/Extras/blob/master/bucket/flameshot.json): `scoop install flameshot`
-- [Chocolatey](https://chocolatey.org/packages/flameshot)
 
 <details>
   <summary>Expand this section to see what distros are using an up to date version of flameshot</summary>


### PR DESCRIPTION
I chose to put this before Chocolatey because that package hasn't been updated in years.