### PR TITLE
fix: pre-grab screenshot on X11 to preserve popups and dropdowns

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -228,7 +228,28 @@ target_link_libraries(
         Qt${QT_VERSION_MAJOR}::Widgets
         QtColorWidgets
 )
-if (UNIX)
+if (UNIX AND NOT APPLE)
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(XI xi)
+pkg_check_modules(X11 x11)
+if (XI_FOUND AND X11_FOUND)
+    target_compile_definitions(flameshot PRIVATE USE_X11_SHORTCUT=1)
+    target_include_directories(flameshot PRIVATE ${XI_INCLUDE_DIRS} ${X11_INCLUDE_DIRS})
+    target_link_libraries(
+            flameshot
+            Qt${QT_VERSION_MAJOR}::DBus
+            ${XI_LIBRARIES}
+            ${X11_LIBRARIES}
+    )
+    message(STATUS "X11 global shortcut support enabled")
+else()
+    target_link_libraries(
+            flameshot
+            Qt${QT_VERSION_MAJOR}::DBus
+    )
+    message(STATUS "X11 global shortcut support disabled (missing xi or x11)")
+endif()
+elseif(UNIX)
 target_link_libraries(
         flameshot
         Qt${QT_VERSION_MAJOR}::DBus

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -30,3 +30,7 @@ endif ()
 if (WIN32)
     target_sources(flameshot PRIVATE globalshortcutfilter.h globalshortcutfilter.cpp)
 endif ()
+
+if (UNIX AND NOT APPLE AND XI_FOUND AND X11_FOUND)
+    target_sources(flameshot PRIVATE x11shortcutfilter.h x11shortcutfilter.cpp)
+endif ()

--- a/src/core/flameshot.cpp
+++ b/src/core/flameshot.cpp
@@ -82,7 +82,8 @@ Flameshot* Flameshot::instance()
     return &c;
 }
 
-CaptureWidget* Flameshot::gui(const CaptureRequest& req)
+CaptureWidget* Flameshot::gui(const CaptureRequest& req,
+                              const QPixmap& preGrabbedScreenshot)
 {
     if (!resolveAnyConfigErrors()) {
         return nullptr;
@@ -120,7 +121,8 @@ CaptureWidget* Flameshot::gui(const CaptureRequest& req)
             return nullptr;
         }
 
-        m_captureWindow = new CaptureWidget(req);
+        m_captureWindow =
+          new CaptureWidget(req, true, nullptr, preGrabbedScreenshot);
 
 #ifdef Q_OS_WIN
         m_captureWindow->show();

--- a/src/core/flameshot.h
+++ b/src/core/flameshot.h
@@ -45,7 +45,8 @@ public:
 
 public slots:
     CaptureWidget* gui(
-      const CaptureRequest& req = CaptureRequest::GRAPHICAL_MODE);
+      const CaptureRequest& req = CaptureRequest::GRAPHICAL_MODE,
+      const QPixmap& preGrabbedScreenshot = QPixmap());
     void screen(CaptureRequest req, int const screenNumber = -1);
     void full(const CaptureRequest& req);
     void launcher();

--- a/src/core/x11shortcutfilter.cpp
+++ b/src/core/x11shortcutfilter.cpp
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Flameshot Contributors
+
+#include "x11shortcutfilter.h"
+#include <X11/Xlib.h>
+#include <X11/extensions/XInput2.h>
+#include <X11/keysym.h>
+
+// Worker: runs in a dedicated thread with its own X11 connection
+
+X11ShortcutWorker::X11ShortcutWorker(QObject* parent)
+  : QObject(parent)
+  , m_running(false)
+{}
+
+void X11ShortcutWorker::stop()
+{
+    m_running = false;
+}
+
+void X11ShortcutWorker::run()
+{
+    Display* dpy = XOpenDisplay(nullptr);
+    if (!dpy) {
+        return;
+    }
+    int xiOpcode, eventBase, errorBase;
+    if (!XQueryExtension(
+          dpy, "XInputExtension", &xiOpcode, &eventBase, &errorBase)) {
+        XCloseDisplay(dpy);
+        return;
+    }
+    int printKeycode = XKeysymToKeycode(dpy, XK_Print);
+    if (printKeycode == 0) {
+        XCloseDisplay(dpy);
+        return;
+    }
+    // Register for raw key events on root window
+    unsigned char mask[XIMaskLen(XI_LASTEVENT)] = { 0 };
+    XIEventMask evmask;
+    evmask.deviceid = XIAllMasterDevices;
+    evmask.mask_len = sizeof(mask);
+    evmask.mask = mask;
+    XISetMask(mask, XI_RawKeyPress);
+    XISelectEvents(dpy, DefaultRootWindow(dpy), &evmask, 1);
+    XFlush(dpy);
+    m_running = true;
+    while (m_running) {
+        while (XPending(dpy) > 0) {
+            XEvent xev;
+            XNextEvent(dpy, &xev);
+            if (xev.xcookie.type == GenericEvent &&
+                xev.xcookie.extension == xiOpcode) {
+                if (XGetEventData(dpy, &xev.xcookie)) {
+                    if (xev.xcookie.evtype == XI_RawKeyPress) {
+                        auto* rawEvent =
+                          static_cast<XIRawEvent*>(xev.xcookie.data);
+                        if (rawEvent->detail == printKeycode) {
+                            emit printPressed();
+                        }
+                    }
+                    XFreeEventData(dpy, &xev.xcookie);
+                }
+            }
+        }
+        // Small sleep to avoid busy waiting
+        QThread::msleep(5);
+    }
+    XCloseDisplay(dpy);
+}
+
+// Filter: manages the worker thread
+
+X11ShortcutFilter::X11ShortcutFilter(QObject* parent)
+  : QObject(parent)
+  , m_worker(new X11ShortcutWorker())
+{
+    m_worker->moveToThread(&m_thread);
+    connect(&m_thread, &QThread::started, m_worker, &X11ShortcutWorker::run);
+    connect(
+      m_worker, &X11ShortcutWorker::printPressed,
+      this, &X11ShortcutFilter::printPressed,
+      Qt::QueuedConnection);
+    connect(&m_thread, &QThread::finished, m_worker, &QObject::deleteLater);
+    m_thread.start();
+}
+
+X11ShortcutFilter::~X11ShortcutFilter()
+{
+    m_worker->stop();
+    m_thread.quit();
+    m_thread.wait(2000);
+}

--- a/src/core/x11shortcutfilter.h
+++ b/src/core/x11shortcutfilter.h
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Flameshot Contributors
+
+#pragma once
+
+#include <QObject>
+#include <QThread>
+#include <atomic>
+
+class X11ShortcutWorker : public QObject
+{
+    Q_OBJECT
+public:
+    explicit X11ShortcutWorker(QObject* parent = nullptr);
+
+public slots:
+    void run();
+    void stop();
+
+signals:
+    void printPressed();
+
+private:
+    std::atomic<bool> m_running;
+};
+
+class X11ShortcutFilter : public QObject
+{
+    Q_OBJECT
+public:
+    explicit X11ShortcutFilter(QObject* parent = nullptr);
+    ~X11ShortcutFilter() override;
+
+signals:
+    void printPressed();
+
+private:
+    QThread m_thread;
+    X11ShortcutWorker* m_worker;
+};

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -50,7 +50,8 @@
 
 CaptureWidget::CaptureWidget(const CaptureRequest& req,
                              bool fullScreen,
-                             QWidget* parent)
+                             QWidget* parent,
+                             const QPixmap& preGrabbedScreenshot)
   : QWidget(parent)
   , m_toolSizeByKeyboard(0)
   , m_mouseIsClicked(false)
@@ -108,7 +109,11 @@ CaptureWidget::CaptureWidget(const CaptureRequest& req,
     if (fullScreen) {
         // Grab Screenshot
         bool ok = true;
-        m_context.screenshot = ScreenGrabber().grabEntireDesktop(ok);
+        if (!preGrabbedScreenshot.isNull()) {
+            m_context.screenshot = preGrabbedScreenshot;
+        } else {
+            m_context.screenshot = ScreenGrabber().grabEntireDesktop(ok);
+        }
         if (!ok) {
             AbstractLogger::error() << tr("Unable to capture screen");
             this->close();

--- a/src/widgets/capture/capturewidget.h
+++ b/src/widgets/capture/capturewidget.h
@@ -49,7 +49,8 @@ class CaptureWidget : public QWidget
 public:
     explicit CaptureWidget(const CaptureRequest& req,
                            bool fullScreen = true,
-                           QWidget* parent = nullptr);
+                           QWidget* parent = nullptr,
+                           const QPixmap& preGrabbedScreenshot = QPixmap());
     ~CaptureWidget();
 
     QPixmap pixmap();


### PR DESCRIPTION
## Summary

- On X11 with non-KDE desktop environments (Cinnamon, MATE, XFCE, etc.), pressing Print Screen to take a screenshot causes open popups, dropdowns, and menus to close before the screenshot is captured
- This introduces an XInput2-based raw key event listener that detects Print Screen without causing any focus changes
- The screen is grabbed immediately before creating the capture widget, preserving the current UI state including open popups

## Root cause

Both the window manager's keybinding handler and X11 key grabs (`xcb_grab_key`) generate `FocusOut` events that cause transient UI elements (dropdowns, popups, menus) to close before the screenshot can be captured.

## Approach

1. A dedicated thread with its own X11 connection listens for `XI_RawKeyPress` events via XInput2. Raw events are delivered without causing any focus changes.
2. When Print Screen is detected, the screen is grabbed immediately (before any widget is created).
3. The pre-grabbed screenshot is passed to `CaptureWidget`, which uses it instead of performing its own grab.

## Build notes

- The feature requires `libxi-dev` and `libx11-dev` at build time
- Dependencies are **optional**: if not found, the feature is simply disabled and behavior is unchanged
- Controlled by the `USE_X11_SHORTCUT` compile definition
- No effect on Wayland, macOS, or Windows builds