### PR TITLE
Sort monitor previews by screen position

### DIFF
--- a/src/utils/screengrabber.cpp
+++ b/src/utils/screengrabber.cpp
@@ -19,6 +19,7 @@
 #include <QScreen>
 #include <QTimer>
 #include <QWidget>
+#include <algorithm>
 
 #ifdef FLAMESHOT_DEBUG_CAPTURE
 #include <QDebug>
@@ -315,7 +316,17 @@ QWidget* ScreenGrabber::createMonitorPreviews(const QPixmap& fullScreenshot)
     containerLayout->setSpacing(20);
     containerLayout->setContentsMargins(20, 20, 20, 20);
 
+    // Build list of screen indices sorted by X position (left to right)
+    QList<int> sortedIndices;
     for (int i = 0; i < screens.size(); ++i) {
+        sortedIndices.append(i);
+    }
+    std::sort(
+      sortedIndices.begin(), sortedIndices.end(), [&screens](int a, int b) {
+          return screens[a]->geometry().x() < screens[b]->geometry().x();
+      });
+
+    for (int i : sortedIndices) {
         QScreen* screen = screens[i];
 
         QPixmap cropped = cropToMonitor(fullScreenshot, i);


### PR DESCRIPTION
## Summary

- The monitor selection dialog displayed previews in Qt's default screen order (by connector name, e.g. DP-1 before DP-2), which can differ from the physical arrangement configured in display settings (e.g. KDE's kscreen)
- This sorts the preview widgets by their X geometry position so they match the user's actual left-to-right monitor layout

## Test plan

- [ ] Configure two or more monitors where the physical left-to-right order differs from the connector name order (e.g. DP-2 is physically left of DP-1)
- [ ] Trigger a screenshot and verify the monitor selection previews match the physical arrangement