### PR TITLE
Add custom colors for key action buttons (Save, Copy, Exit) for increased usability

### DIFF
--- a/src/widgets/capture/capturetoolbutton.cpp
+++ b/src/widgets/capture/capturetoolbutton.cpp
@@ -23,6 +23,29 @@ CaptureToolButton::CaptureToolButton(const CaptureTool::Type t, QWidget* parent)
   , m_emergeAnimation(nullptr)
 {
     initButton();
+
+     // 🎨 Custom colors for important action buttons
+    switch (m_buttonType) {
+    case CaptureTool::TYPE_SAVE:
+        setColor(QColor("#4CAF50")); // green
+        break;
+
+    case CaptureTool::TYPE_COPY:
+        setColor(QColor("#2196F3")); // blue
+        break;
+
+    case CaptureTool::TYPE_EXIT:
+        setColor(QColor("#F44336")); // red
+        break;
+
+    case CaptureTool::TYPE_ACCEPT:
+        setColor(QColor("#4CAF50")); // green confirm
+        break;
+
+    default:
+        break; // all other tools keep normal color
+    }
+
     updateIcon();
 }
 


### PR DESCRIPTION
Basically what the title says. I noticed a good first contribution error that stated the difficulty differentiating the important buttons with the less important ones when the capture screen was small. Therefore I changed the colors of the buttons Save, Copy, and Exit to make it clearer for users.