### PR TITLE
fix: X11 multi-monitor overlay and mixed-DPI screenshot grab

### DIFF
--- a/src/core/flameshot.cpp
+++ b/src/core/flameshot.cpp
@@ -21,6 +21,7 @@
 #endif
 
 #include "src/utils/confighandler.h"
+#include "src/utils/desktopinfo.h"
 #include "src/utils/screengrabber.h"
 #include "src/widgets/capture/capturewidget.h"
 #include "src/widgets/capturelauncher.h"
@@ -130,8 +131,17 @@ CaptureWidget* Flameshot::gui(const CaptureRequest& req)
         m_captureWindow->activateWindow();
         m_captureWindow->raise();
 #else
-        m_captureWindow->showFullScreen();
-//        m_captureWindow->show(); // For CaptureWidget Debugging under Linux
+        // On X11, showFullScreen() in Qt6 restricts the window to a single
+        // monitor even with BypassWindowManagerHint. Use show() instead to
+        // allow spanning the entire virtual desktop (v12 behavior).
+        // On Wayland, showFullScreen() works correctly per-output.
+        if (DesktopInfo().waylandDetected()) {
+            m_captureWindow->showFullScreen();
+        } else {
+            m_captureWindow->show();
+        }
+        m_captureWindow->activateWindow();
+        m_captureWindow->raise();
 #endif
         return m_captureWindow;
     } else {

--- a/src/utils/screengrabber.cpp
+++ b/src/utils/screengrabber.cpp
@@ -205,23 +205,75 @@ QPixmap ScreenGrabber::grabEntireDesktop(bool& ok, int preSelectedMonitor)
     return screenshot;
 
 #elif defined(Q_OS_LINUX) || defined(Q_OS_UNIX)
-    freeDesktopPortal(ok, screenshot);
-    if (!ok) {
-        AbstractLogger::error() << tr("Unable to capture screen");
-        return QPixmap();
+    if (m_info.waylandDetected()) {
+        freeDesktopPortal(ok, screenshot);
+        if (!ok) {
+            AbstractLogger::error() << tr("Unable to capture screen");
+            return QPixmap();
+        }
+    } else {
+        // X11: Per-monitor grab in NATIVE pixel coordinates.
+        //
+        // QScreen::geometry() on X11 returns mixed coordinates:
+        //   position = native pixels (X11 coords, not scaled)
+        //   size     = logical pixels (native / devicePixelRatio)
+        // This is intentional Qt6 design (fromNativeScreenGeometry).
+        //
+        // To composite correctly with mixed DPI, we reconstruct
+        // native geometry: position is already native, size needs
+        // multiplying by DPR to get back to native.
+
+        auto nativeScreenGeometry = [](QScreen* s) -> QRect {
+            QRect g = s->geometry();
+            qreal dpr = s->devicePixelRatio();
+            return QRect(g.topLeft(),
+                         QSize(qRound(g.width() * dpr),
+                               qRound(g.height() * dpr)));
+        };
+
+        QRect nativeTotal;
+        for (QScreen* const screen : QGuiApplication::screens()) {
+            nativeTotal = nativeTotal.united(nativeScreenGeometry(screen));
+        }
+
+        QPixmap desktop(nativeTotal.size());
+        desktop.fill(Qt::black);
+
+        QPainter painter(&desktop);
+        for (QScreen* screen : QGuiApplication::screens()) {
+            QRect logicalGeom = screen->geometry();
+            QPixmap screenCapture = screen->grabWindow(
+              wid, 0, 0, logicalGeom.width(), logicalGeom.height());
+            screenCapture.setDevicePixelRatio(1.0);
+
+            QRect nativeGeom = nativeScreenGeometry(screen);
+            QPoint relativePos = nativeGeom.topLeft() - nativeTotal.topLeft();
+            painter.drawPixmap(relativePos, screenCapture);
+        }
+        painter.end();
+
+        screenshot = desktop;
+        ok = true;
     }
 
 #elif defined(Q_OS_WIN)
     screenshot = windowsScreenshot(wid);
 #endif
 
-    // If monitor was pre-selected skip UI and crop directly
+    // If monitor was pre-selected, skip UI and crop directly
     if (preSelectedMonitor >= 0) {
         const QList<QScreen*> screens = QGuiApplication::screens();
         if (preSelectedMonitor < screens.size()) {
             m_selectedMonitor = preSelectedMonitor;
             return cropToMonitor(screenshot, preSelectedMonitor);
         }
+    }
+
+    // When called without monitor pre-selection (e.g. from `flameshot full`),
+    // return the full composite screenshot. The monitor selection dialog
+    // is only shown when explicitly requested via `flameshot screen`.
+    if (preSelectedMonitor < 0) {
+        return screenshot;
     }
 
     return selectMonitorAndCrop(screenshot, ok);

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -174,33 +174,43 @@ CaptureWidget::CaptureWidget(const CaptureRequest& req,
                        Qt::FramelessWindowHint | Qt::Tool);
 #endif
 
-        // Always display on the selected screen (not spanning entire desktop)
+        // v12 behavior: size window to match the screenshot pixmap
         if (selectedScreen == nullptr) {
-            selectedScreen = QGuiApplication::primaryScreen();
-        }
-        QRect screenGeom = selectedScreen->geometry();
-        move(screenGeom.topLeft());
-        resize(screenGeom.size());
-
-        if (selectedScreen != nullptr && windowHandle()) {
-            windowHandle()->setScreen(selectedScreen);
+            // v12 behavior: span entire virtual desktop
+            QPoint topLeft(0, 0);
+            for (QScreen* const screen : QGuiApplication::screens()) {
+                QPoint tl = screen->geometry().topLeft();
+                if (tl.x() < topLeft.x()) topLeft.setX(tl.x());
+                if (tl.y() < topLeft.y()) topLeft.setY(tl.y());
+            }
+            move(topLeft);
+            resize(m_context.screenshot.size());
+        } else {
+            QRect screenGeom = selectedScreen->geometry();
+            move(screenGeom.topLeft());
+            resize(screenGeom.size());
+            if (windowHandle()) {
+                windowHandle()->setScreen(selectedScreen);
+            }
         }
 #endif
     }
 
     QVector<QRect> areas;
     if (m_context.fullscreen) {
-        // Always display on a single screen, normalized to (0, 0)
-        QScreen* screenForAreas = selectedScreen;
-        if (!screenForAreas) {
-            screenForAreas = QGuiAppCurrentScreen().currentScreen();
+        if (selectedScreen == nullptr) {
+            // v12 behavior: add each screen as separate area
+            for (QScreen* const screen : QGuiApplication::screens()) {
+                QRect r = screen->geometry();
+                r.moveTo(r.x() / screen->devicePixelRatio(),
+                         r.y() / screen->devicePixelRatio());
+                areas.append(r);
+            }
+        } else {
+            QRect r = selectedScreen->geometry();
+            r.moveTo(0, 0);
+            areas.append(r);
         }
-        if (!screenForAreas) {
-            screenForAreas = QGuiApplication::primaryScreen();
-        }
-        QRect r = screenForAreas ? screenForAreas->geometry() : QRect();
-        r.moveTo(0, 0);
-        areas.append(r);
     } else {
         areas.append(rect());
     }


### PR DESCRIPTION
## Summary

Three fixes for X11 multi-monitor screenshot capture in Qt6:

### 1. Overlay spans entire virtual desktop on X11

`showFullScreen()` in Qt6 sets `_NET_WM_STATE_FULLSCREEN`, which restricts the window to a single monitor. Qt5 ignored this hint when `BypassWindowManagerHint` was set, but Qt6 respects it.

**Fix:** Use `show()` on X11 instead of `showFullScreen()`. Wayland keeps `showFullScreen()` since the compositor handles per-output fullscreen correctly.

**History:** `showFullScreen()` was introduced in [commit 3199059e](https://github.com/flameshot-org/flameshot/commit/3199059e) (Jul 2017) during a refactor from `Qt::Popup` to `Qt::Tool`. Windows was fixed in [commit a9b0c213](https://github.com/flameshot-org/flameshot/commit/a9b0c213) (Jan 2018, "Fix Windows multimonitor capture") by switching to `show()`, but Linux was left unchanged because Qt5 masked the bug.

### 2. Per-monitor grab with native pixel coordinates on X11

PR #4498 unified all platforms to use xdg-desktop-portal for screenshot capture. However, the portal may not be available or functional on all X11 window managers (e.g., tiling WMs like Xmonad, i3).

**Fix:** On X11, bypass the portal and use direct per-monitor `grabWindow()` with native pixel coordinate compositing.

`QScreen::geometry()` in Qt6 returns **mixed coordinates** by design:
- **Position** = native pixels (X11 coordinates, unscaled)
- **Size** = logical pixels (native / devicePixelRatio)

This is intentional Qt6 behavior (see `QScreenPrivate::updateGeometry()` → `fromNativeScreenGeometry()` in qtbase `qscreen.cpp` line 69). Previous code used these mixed coordinates directly, producing incorrect composites at non-1.0 DPR. The fix reconstructs native geometry: position is already native, size is multiplied by DPR.

### 3. `flameshot full` returns composite without monitor selection

PR #4498 added a monitor selection dialog in `grabEntireDesktop()` for multi-monitor setups. This causes `flameshot full` to hang waiting for user input when it should capture all monitors.

**Fix:** When `preSelectedMonitor < 0` (default for `flameshot full`), return the composite screenshot directly.

## Test Matrix

| Test | Before | After |
|------|--------|-------|
| X11 Baseline DPR 1.0 | ✅ 1366×1792 | ✅ 1366×1792 |
| X11 QT_SCALE_FACTOR=1.5 | ⚠️ 911×1536 | ✅ 1367×1792 |
| X11 Xft.dpi=144 (DPR 1.5) | ⚠️ 911×1536 | ✅ 1367×1792 |
| Wayland (GNOME, portal) | ✅ works | ✅ 2646×1024 |

## Environment

- Fedora 43, Qt 6.10.1
- X11: Xmonad WM, HDMI-1 (1280×1024) + eDP-1 (1366×768), vertical stack
- Wayland: GNOME, same monitors side-by-side

Fixes #4171, #4172