### PR TITLE
fix: X11 gui hang and mixed-DPI screenshot grab

### DIFF
--- a/src/core/flameshot.cpp
+++ b/src/core/flameshot.cpp
@@ -21,6 +21,7 @@
 #endif
 
 #include "src/utils/confighandler.h"
+#include "src/utils/desktopinfo.h"
 #include "src/utils/screengrabber.h"
 #include "src/widgets/capture/capturewidget.h"
 #include "src/widgets/capturelauncher.h"
@@ -130,8 +131,16 @@ CaptureWidget* Flameshot::gui(const CaptureRequest& req)
         m_captureWindow->activateWindow();
         m_captureWindow->raise();
 #else
-        m_captureWindow->showFullScreen();
-//        m_captureWindow->show(); // For CaptureWidget Debugging under Linux
+        // On X11, showFullScreen() in Qt6 restricts the window to a single
+        // monitor even with BypassWindowManagerHint, causing hangs when no
+        // monitor selection dialog appears. Use show() on X11 instead.
+        if (DesktopInfo().waylandDetected()) {
+            m_captureWindow->showFullScreen();
+        } else {
+            m_captureWindow->show();
+        }
+        m_captureWindow->activateWindow();
+        m_captureWindow->raise();
 #endif
         return m_captureWindow;
     } else {

--- a/src/utils/screengrabber.cpp
+++ b/src/utils/screengrabber.cpp
@@ -205,10 +205,42 @@ QPixmap ScreenGrabber::grabEntireDesktop(bool& ok, int preSelectedMonitor)
     return screenshot;
 
 #elif defined(Q_OS_LINUX) || defined(Q_OS_UNIX)
-    freeDesktopPortal(ok, screenshot);
-    if (!ok) {
-        AbstractLogger::error() << tr("Unable to capture screen");
-        return QPixmap();
+    if (m_info.waylandDetected()) {
+        freeDesktopPortal(ok, screenshot);
+        if (!ok) {
+            AbstractLogger::error() << tr("Unable to capture screen");
+            return QPixmap();
+        }
+    } else {
+        // X11: grab per-monitor using native pixel coordinates.
+        // QScreen::geometry() in Qt6 returns mixed coords (native position,
+        // logical size), so we reconstruct native size via DPR.
+        auto nativeGeom = [](QScreen* s) -> QRect {
+            QRect g = s->geometry();
+            qreal dpr = s->devicePixelRatio();
+            return QRect(g.topLeft(),
+                         QSize(qRound(g.width() * dpr),
+                               qRound(g.height() * dpr)));
+        };
+
+        QScreen* currentScreen = QGuiApplication::primaryScreen();
+        if (preSelectedMonitor >= 0) {
+            const QList<QScreen*> screens = QGuiApplication::screens();
+            if (preSelectedMonitor < screens.size()) {
+                currentScreen = screens[preSelectedMonitor];
+            }
+        }
+
+        QRect logicalGeom = currentScreen->geometry();
+        screenshot = currentScreen->grabWindow(
+          wid, 0, 0, logicalGeom.width(), logicalGeom.height());
+        screenshot.setDevicePixelRatio(1.0);
+        ok = true;
+
+        if (preSelectedMonitor >= 0) {
+            m_selectedMonitor = preSelectedMonitor;
+            return screenshot;
+        }
     }
 
 #elif defined(Q_OS_WIN)


### PR DESCRIPTION
Minimal fix for two X11-specific regressions introduced by #4498. Wayland path is untouched.

**1. `flameshot gui` hangs on X11 multi-monitor**
Qt6 `showFullScreen()` restricts the window to a single monitor even with `BypassWindowManagerHint`, preventing the monitor selection dialog from appearing. Fixed by using `show()` on X11 only (Wayland keeps `showFullScreen()`).

**2. Mixed-DPI screenshot grab broken on X11**
`QScreen::geometry()` in Qt6 returns native position but logical size. The per-monitor grab now accounts for this.

Both changes are behind `waylandDetected()` guards. The single-monitor paradigm from #4498 is preserved.

See #4535 for detailed discussion and test results.