### PR TITLE
Add captureAllMonitors option to skip monitor selection popup

### DIFF
--- a/flameshot.example.ini
+++ b/flameshot.example.ini
@@ -113,6 +113,10 @@
 ;; Use larger color palette as the default one (bool)
 ;predefinedColorPaletteLarge=false
 ;
+;; Capture all monitors at once without showing the monitor selection popup (bool)
+;; Warning: this may cause display issues on multi-monitor setups with mixed DPI scaling
+;captureAllMonitors=false
+;
 ;; Set JPEG Quality (int in range 0-100)
 ;jpegQuality=75
 ;

--- a/src/config/generalconf.cpp
+++ b/src/config/generalconf.cpp
@@ -55,6 +55,7 @@ GeneralConf::GeneralConf(QWidget* parent)
     initAntialiasingPinZoom();
     initUndoLimit();
     initInsecurePixelate();
+    initCaptureAllMonitors();
 #ifdef ENABLE_IMGUR
     initCopyAndCloseAfterUpload();
     initUploadWithoutConfirmation();
@@ -105,6 +106,7 @@ void GeneralConf::_updateComponents(bool allowEmptySavePath)
     m_squareMagnifier->setChecked(config.squareMagnifier());
     m_saveLastRegion->setChecked(config.saveLastRegion());
     m_reverseArrow->setChecked(config.reverseArrow());
+    m_captureAllMonitors->setChecked(config.captureAllMonitors());
 
 #if !defined(Q_OS_WIN)
     m_autoCloseIdleDaemon->setChecked(config.autoCloseIdleDaemon());
@@ -907,4 +909,24 @@ void GeneralConf::setReverseArrow(bool checked)
 void GeneralConf::setInsecurePixelate(bool checked)
 {
     ConfigHandler().setInsecurePixelate(checked);
+}
+
+void GeneralConf::initCaptureAllMonitors()
+{
+    m_captureAllMonitors =
+      new QCheckBox(tr("Capture all monitors at once"), this);
+    m_captureAllMonitors->setToolTip(
+      tr("Capture all monitors without showing the monitor selection popup.\n"
+         "Warning: this may cause display issues on multi-monitor setups with "
+         "mixed DPI scaling."));
+    m_scrollAreaLayout->addWidget(m_captureAllMonitors);
+    connect(m_captureAllMonitors,
+            &QCheckBox::clicked,
+            this,
+            &GeneralConf::captureAllMonitorsChanged);
+}
+
+void GeneralConf::captureAllMonitorsChanged(bool checked)
+{
+    ConfigHandler().setCaptureAllMonitors(checked);
 }

--- a/src/config/generalconf.h
+++ b/src/config/generalconf.h
@@ -61,6 +61,7 @@ private slots:
     void setJpegQuality(int v);
     void setReverseArrow(bool checked);
     void setInsecurePixelate(bool checked);
+    void captureAllMonitorsChanged(bool checked);
 
 private:
     const QString chooseFolder(const QString& currentPath = "");
@@ -99,6 +100,7 @@ private:
     void initJpegQuality();
     void initReverseArrow();
     void initInsecurePixelate();
+    void initCaptureAllMonitors();
 
     void _updateComponents(bool allowEmptySavePath);
 
@@ -147,4 +149,5 @@ private:
     QSpinBox* m_jpegQuality;
     QCheckBox* m_reverseArrow;
     QCheckBox* m_insecurePixelate;
+    QCheckBox* m_captureAllMonitors;
 };

--- a/src/utils/confighandler.cpp
+++ b/src/utils/confighandler.cpp
@@ -136,6 +136,7 @@ static QMap<class QString, QSharedPointer<ValueHandler>>
     OPTION("jpegQuality"                 , BoundedInt        ( 0,100,75      )),
     OPTION("reverseArrow"                ,Bool               ( false         )),
     OPTION("insecurePixelate"            ,Bool               ( false         )),
+    OPTION("captureAllMonitors"          ,Bool               ( false         )),
 };
 
 static QMap<QString, QSharedPointer<KeySequence>> recognizedShortcuts = {

--- a/src/utils/confighandler.h
+++ b/src/utils/confighandler.h
@@ -136,6 +136,7 @@ public:
     CONFIG_GETTER_SETTER(jpegQuality, setJpegQuality, int)
     CONFIG_GETTER_SETTER(reverseArrow, setReverseArrow, bool)
     CONFIG_GETTER_SETTER(insecurePixelate, setInsecurePixelate, bool)
+    CONFIG_GETTER_SETTER(captureAllMonitors, setCaptureAllMonitors, bool)
     CONFIG_GETTER_SETTER(showSelectionGeometryHideTime,
                          showSelectionGeometryHideTime,
                          int)

--- a/src/utils/screengrabber.cpp
+++ b/src/utils/screengrabber.cpp
@@ -152,6 +152,10 @@ QPixmap ScreenGrabber::selectMonitorAndCrop(const QPixmap& fullScreenshot,
         return cropToMonitor(fullScreenshot, 0);
     }
 
+    if (ConfigHandler().captureAllMonitors()) {
+        return fullScreenshot;
+    }
+
     if (m_monitorSelectionActive) {
         AbstractLogger::error()
           << tr("Screenshot already in progress, please wait for the current "
@@ -340,17 +344,25 @@ QWidget* ScreenGrabber::createMonitorPreviews(const QPixmap& fullScreenshot)
     }
 #endif
 
-    QWidget* monitorPreviews = new QWidget(
-      nullptr, Qt::Window | Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint);
-    monitorPreviews->setAttribute(Qt::WA_TranslucentBackground);
-    monitorPreviews->setStyleSheet(
-      "QWidget { background-color: transparent; }");
-    monitorPreviews->installEventFilter(this); // For ESC key handling
-    monitorPreviews->setFocusPolicy(Qt::StrongFocus);
+    QWidget* overlay =
+      new QWidget(nullptr,
+                  Qt::Window | Qt::FramelessWindowHint |
+                    Qt::WindowStaysOnTopHint | Qt::BypassWindowManagerHint);
+    overlay->setStyleSheet(
+      "QWidget#overlay { background-color: rgba(0, 0, 0, 160); }");
+    overlay->setObjectName("overlay");
+    overlay->installEventFilter(this);
+    overlay->setFocusPolicy(Qt::StrongFocus);
+    overlay->setMouseTracking(true);
 
-    QHBoxLayout* containerLayout = new QHBoxLayout(monitorPreviews);
+    QRect totalGeom = desktopGeometry();
+    overlay->move(totalGeom.topLeft());
+    overlay->resize(totalGeom.size());
+
+    QHBoxLayout* containerLayout = new QHBoxLayout(overlay);
     containerLayout->setSpacing(20);
-    containerLayout->setContentsMargins(20, 20, 20, 20);
+    containerLayout->setContentsMargins(0, 0, 0, 0);
+    containerLayout->setAlignment(Qt::AlignCenter);
 
     // Build list of screen indices sorted by X position (left to right)
     QList<int> sortedIndices;
@@ -371,7 +383,7 @@ QWidget* ScreenGrabber::createMonitorPreviews(const QPixmap& fullScreenshot)
         thumbnail.setDevicePixelRatio(1.0);
 
         MonitorPreview* preview =
-          new MonitorPreview(i, screen, thumbnail, monitorPreviews);
+          new MonitorPreview(i, screen, thumbnail, overlay);
 
         connect(
           preview, &MonitorPreview::monitorSelected, this, [this](int index) {
@@ -384,17 +396,12 @@ QWidget* ScreenGrabber::createMonitorPreviews(const QPixmap& fullScreenshot)
         containerLayout->addWidget(preview);
     }
 
-    monitorPreviews->setLayout(containerLayout);
-    monitorPreviews->adjustSize();
-
-    QScreen* primaryScreen = QGuiApplication::primaryScreen();
-    QRect screenGeometry = primaryScreen->geometry();
-    QPoint center = screenGeometry.center();
-    monitorPreviews->move(center.x() - monitorPreviews->width() / 2,
-                          center.y() - monitorPreviews->height() / 2);
-
-    monitorPreviews->show();
-    return monitorPreviews;
+    overlay->setLayout(containerLayout);
+    overlay->show();
+    overlay->activateWindow();
+    overlay->setFocus();
+    overlay->grabKeyboard();
+    return overlay;
 }
 
 bool ScreenGrabber::eventFilter(QObject* obj, QEvent* event)
@@ -402,13 +409,27 @@ bool ScreenGrabber::eventFilter(QObject* obj, QEvent* event)
     if (event->type() == QEvent::KeyPress) {
         QKeyEvent* keyEvent = static_cast<QKeyEvent*>(event);
         if (keyEvent->key() == Qt::Key_Escape) {
-            // User cancelled selection
             m_selectedMonitor = -1;
             m_userCancelled = true;
             if (m_monitorSelectionLoop) {
                 m_monitorSelectionLoop->quit();
             }
             return true;
+        }
+    }
+    if (event->type() == QEvent::MouseButtonPress) {
+        QMouseEvent* mouseEvent = static_cast<QMouseEvent*>(event);
+        QWidget* widget = qobject_cast<QWidget*>(obj);
+        if (widget && widget->objectName() == "overlay") {
+            QWidget* child = widget->childAt(mouseEvent->pos());
+            if (!child) {
+                m_selectedMonitor = -1;
+                m_userCancelled = true;
+                if (m_monitorSelectionLoop) {
+                    m_monitorSelectionLoop->quit();
+                }
+                return true;
+            }
         }
     }
     return QObject::eventFilter(obj, event);

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -174,33 +174,45 @@ CaptureWidget::CaptureWidget(const CaptureRequest& req,
                        Qt::FramelessWindowHint | Qt::Tool);
 #endif
 
-        // Always display on the selected screen (not spanning entire desktop)
-        if (selectedScreen == nullptr) {
-            selectedScreen = QGuiApplication::primaryScreen();
-        }
-        QRect screenGeom = selectedScreen->geometry();
-        move(screenGeom.topLeft());
-        resize(screenGeom.size());
-
-        if (selectedScreen != nullptr && windowHandle()) {
-            windowHandle()->setScreen(selectedScreen);
+        if (ConfigHandler().captureAllMonitors()) {
+            QRect fullGeom = grabber.desktopGeometry();
+            move(fullGeom.topLeft());
+            resize(fullGeom.size());
+        } else {
+            if (selectedScreen == nullptr) {
+                selectedScreen = QGuiApplication::primaryScreen();
+            }
+            QRect screenGeom = selectedScreen->geometry();
+            move(screenGeom.topLeft());
+            resize(screenGeom.size());
+            if (selectedScreen != nullptr && windowHandle()) {
+                windowHandle()->setScreen(selectedScreen);
+            }
         }
 #endif
     }
 
     QVector<QRect> areas;
     if (m_context.fullscreen) {
-        // Always display on a single screen, normalized to (0, 0)
-        QScreen* screenForAreas = selectedScreen;
-        if (!screenForAreas) {
-            screenForAreas = QGuiAppCurrentScreen().currentScreen();
+        if (ConfigHandler().captureAllMonitors()) {
+            QRect fullGeom = grabber.desktopGeometry();
+            for (QScreen* const screen : QGuiApplication::screens()) {
+                QRect r = screen->geometry();
+                r.translate(-fullGeom.topLeft());
+                areas.append(r);
+            }
+        } else {
+            QScreen* screenForAreas = selectedScreen;
+            if (!screenForAreas) {
+                screenForAreas = QGuiAppCurrentScreen().currentScreen();
+            }
+            if (!screenForAreas) {
+                screenForAreas = QGuiApplication::primaryScreen();
+            }
+            QRect r = screenForAreas ? screenForAreas->geometry() : QRect();
+            r.moveTo(0, 0);
+            areas.append(r);
         }
-        if (!screenForAreas) {
-            screenForAreas = QGuiApplication::primaryScreen();
-        }
-        QRect r = screenForAreas ? screenForAreas->geometry() : QRect();
-        r.moveTo(0, 0);
-        areas.append(r);
     } else {
         areas.append(rect());
     }


### PR DESCRIPTION
## Summary

PR #4498 changed `flameshot gui` to show a monitor selection popup on multi-monitor setups. While this fixes many DPI/scaling issues, some users miss the ability to capture all monitors at once (see comments in #4498).

This PR adds a `captureAllMonitors` configuration option (default: `false`) that, when enabled, restores the previous behavior — capturing all monitors without the selection popup.

### Changes
- New `captureAllMonitors` boolean option in `ConfigHandler` (default `false`)
- Checkbox in General settings with a **warning tooltip**: *"May cause display issues on multi-monitor setups with mixed DPI scaling"*
- When enabled, `ScreenGrabber::selectMonitorAndCrop` returns the full desktop screenshot
- `CaptureWidget` spans across all screens instead of a single one
- Documented in `flameshot.example.ini`

### What it does NOT change
- Default behavior remains the per-monitor selection popup from #4498
- No changes to the monitor selection UI itself
- No changes to `flameshot screen` or `flameshot full` commands

### Disclaimer
As noted in the tooltip, this option may cause display issues on setups with mixed DPI scaling. This is the same limitation that existed before #4498 and is the reason why per-monitor capture was introduced. Users enable this at their own risk.

Addresses feedback from: @franzitrone, @saalmi098, @CrazyWolf13, @mostafa-abdelbrr in #4498