### PR TITLE
Add QR code scan tool

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,13 @@ if(ENABLE_IMGUR)
   add_compile_definitions(ENABLE_IMGUR)
 endif()
 
+option(ENABLE_QRCODE "Enable QR code scanning via ZXing" OFF)
+
+if(ENABLE_QRCODE)
+  find_package(ZXing REQUIRED)
+  add_compile_definitions(ENABLE_QRCODE)
+endif()
+
 if(DISABLE_UPDATE_CHECKER)
   add_compile_definitions(DISABLE_UPDATE_CHECKER)
 endif()

--- a/data/graphics.qrc
+++ b/data/graphics.qrc
@@ -101,5 +101,7 @@
         <file>img/material/black/image.svg</file>
         <file>img/material/white/apps.svg</file>
         <file>img/material/white/image.svg</file>
+        <file>img/material/black/qr-code.svg</file>
+        <file>img/material/white/qr-code.svg</file>
     </qresource>
 </RCC>

--- a/data/img/material/black/qr-code.svg
+++ b/data/img/material/black/qr-code.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
+  <path fill="#000" d="M3 11h2v2H3v-2zm0-4h2v2H3V7zm4 4h2v2H7v-2zm0-4h2v2H7V7zm-4-4h6v6H3V3zm2 4h2V5H5v2zm8-4h6v6h-6V3zm2 4h2V5h-2v2zM3 13h6v6H3v-6zm2 4h2v-2H5v2zm8 0h2v2h-2v-2zm0-4h2v2h-2v-2zm4 4h2v2h-2v-2zm0-4h2v2h-2v-2zm-4-4h2v2h-2V9zm4 0h2v2h-2V9zm0 8h2v2h-2v-2zm-4 0h2v2h-2v-2z"/>
+</svg>

--- a/data/img/material/white/qr-code.svg
+++ b/data/img/material/white/qr-code.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
+  <path fill="#fff" d="M3 11h2v2H3v-2zm0-4h2v2H3V7zm4 4h2v2H7v-2zm0-4h2v2H7V7zm-4-4h6v6H3V3zm2 4h2V5H5v2zm8-4h6v6h-6V3zm2 4h2V5h-2v2zM3 13h6v6H3v-6zm2 4h2v-2H5v2zm8 0h2v2h-2v-2zm0-4h2v2h-2v-2zm4 4h2v2h-2v-2zm0-4h2v2h-2v-2zm-4-4h2v2h-2V9zm4 0h2v2h-2V9zm0 8h2v2h-2v-2zm-4 0h2v2h-2v-2z"/>
+</svg>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -219,6 +219,11 @@ target_include_directories(
          $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/>
          )
 
+if(ENABLE_QRCODE)
+  target_include_directories(flameshot PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/tools/qrscan>)
+endif()
+
 target_link_libraries(
         flameshot
         project_warnings
@@ -228,6 +233,9 @@ target_link_libraries(
         Qt${QT_VERSION_MAJOR}::Widgets
         QtColorWidgets
 )
+if(ENABLE_QRCODE)
+  target_link_libraries(flameshot ZXing::ZXing)
+endif()
 if (UNIX)
 target_link_libraries(
         flameshot

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -57,6 +57,10 @@ target_sources(
           text/textwidget.cpp)
 target_sources(flameshot PRIVATE undo/undotool.h undo/undotool.cpp)
 
+if(ENABLE_QRCODE)
+  target_sources(flameshot PRIVATE qrscan/qrscantool.h qrscan/qrscantool.cpp)
+endif()
+
 target_sources(
   flameshot
   PRIVATE abstractactiontool.cpp

--- a/src/tools/capturetool.h
+++ b/src/tools/capturetool.h
@@ -50,6 +50,7 @@ public:
         TYPE_INVERT = 22,
         TYPE_ACCEPT = 23,
         TYPE_CANCEL = 24,
+        TYPE_QR_SCAN = 25,
     };
     Q_ENUM(Type);
 

--- a/src/tools/qrscan/qrscantool.cpp
+++ b/src/tools/qrscan/qrscantool.cpp
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2017-2019 Alejandro Sirgo Rica & Contributors
+
+#include "qrscantool.h"
+#include <QApplication>
+#include <QClipboard>
+#include <QCursor>
+#include <QImage>
+#include <QLabel>
+#include <QTimer>
+#include <ZXing/ReadBarcode.h>
+
+QrScanTool::QrScanTool(QObject* parent)
+  : AbstractActionTool(parent)
+{}
+
+bool QrScanTool::closeOnButtonPressed() const
+{
+    return false;
+}
+
+QIcon QrScanTool::icon(const QColor& background, bool inEditor) const
+{
+    Q_UNUSED(inEditor)
+    return QIcon(iconPath(background) + "qr-code.svg");
+}
+
+QString QrScanTool::name() const
+{
+    return tr("QR Scan");
+}
+
+CaptureTool::Type QrScanTool::type() const
+{
+    return CaptureTool::TYPE_QR_SCAN;
+}
+
+QString QrScanTool::description() const
+{
+    return tr("Scan QR code and copy text to clipboard");
+}
+
+CaptureTool* QrScanTool::copy(QObject* parent)
+{
+    return new QrScanTool(parent);
+}
+
+void QrScanTool::pressed(CaptureContext& context)
+{
+    QPixmap selectedArea = context.selectedScreenshotArea();
+    QImage image = selectedArea.toImage().convertToFormat(QImage::Format_RGB888);
+
+    ZXing::ReaderOptions options;
+    options.setFormats(ZXing::BarcodeFormat::QRCode);
+
+    ZXing::ImageView imageView(
+        image.constBits(),
+        image.width(),
+        image.height(),
+        ZXing::ImageFormat::RGB,
+        static_cast<int>(image.bytesPerLine()));
+
+    ZXing::Barcode result = ZXing::ReadBarcode(imageView, options);
+
+    QString message;
+    if (result.isValid()) {
+        QString text = QString::fromStdString(result.text());
+        QApplication::clipboard()->setText(text);
+        message = tr("QR code copied to clipboard");
+    } else {
+        message = tr("No QR code found");
+    }
+
+    auto* label = new QLabel(message);
+    label->setWindowFlags(Qt::ToolTip);
+    label->setStyleSheet(
+        "QLabel {"
+        "  background-color: #333333;"
+        "  color: white;"
+        "  padding: 8px 12px;"
+        "  border-radius: 4px;"
+        "  font-size: 14px;"
+        "}");
+    label->adjustSize();
+    QPoint pos = QCursor::pos();
+    label->move(pos.x() + 10, pos.y() + 10);
+    label->show();
+    QTimer::singleShot(3000, label, &QLabel::deleteLater);
+}

--- a/src/tools/qrscan/qrscantool.h
+++ b/src/tools/qrscan/qrscantool.h
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2017-2019 Alejandro Sirgo Rica & Contributors
+
+#pragma once
+
+#include "src/tools/abstractactiontool.h"
+
+class QrScanTool : public AbstractActionTool
+{
+    Q_OBJECT
+public:
+    explicit QrScanTool(QObject* parent = nullptr);
+
+    bool closeOnButtonPressed() const override;
+
+    QIcon icon(const QColor& background, bool inEditor) const override;
+    QString name() const override;
+    QString description() const override;
+
+    CaptureTool* copy(QObject* parent = nullptr) override;
+
+protected:
+    CaptureTool::Type type() const override;
+
+public slots:
+    void pressed(CaptureContext& context) override;
+};

--- a/src/tools/toolfactory.cpp
+++ b/src/tools/toolfactory.cpp
@@ -11,6 +11,9 @@
 #ifdef ENABLE_IMGUR
 #include "imgupload/imguploadertool.h"
 #endif
+#ifdef ENABLE_QRCODE
+#include "qrscan/qrscantool.h"
+#endif
 #include "invert/inverttool.h"
 #include "launcher/applaunchertool.h"
 #include "line/linetool.h"
@@ -66,6 +69,9 @@ CaptureTool* ToolFactory::CreateTool(CaptureTool::Type t, QObject* parent)
         if_TYPE_return_TOOL(TYPE_SIZEDECREASE, SizeDecreaseTool);
         if_TYPE_return_TOOL(TYPE_INVERT, InvertTool);
         if_TYPE_return_TOOL(TYPE_ACCEPT, AcceptTool);
+#ifdef ENABLE_QRCODE
+        if_TYPE_return_TOOL(TYPE_QR_SCAN, QrScanTool);
+#endif
         default:
             return nullptr;
     }

--- a/src/widgets/capture/capturetoolbutton.cpp
+++ b/src/widgets/capture/capturetoolbutton.cpp
@@ -154,6 +154,9 @@ static std::map<CaptureTool::Type, int> buttonTypeOrder
 
       { CaptureTool::TYPE_SIZEINCREASE, 22 },
       { CaptureTool::TYPE_SIZEDECREASE, 23 },
+#ifdef ENABLE_QRCODE
+      { CaptureTool::TYPE_QR_SCAN, 24 },
+#endif
 };
 
 int CaptureToolButton::getPriorityByButton(CaptureTool::Type b)
@@ -181,4 +184,7 @@ QList<CaptureTool::Type> CaptureToolButton::iterableButtonTypes = {
 #endif
     CaptureTool::TYPE_PIN,           CaptureTool::TYPE_SIZEINCREASE,
     CaptureTool::TYPE_SIZEDECREASE,  CaptureTool::TYPE_ACCEPT,
+#ifdef ENABLE_QRCODE
+    CaptureTool::TYPE_QR_SCAN,
+#endif
 };


### PR DESCRIPTION
## Summary

- Adds a new toolbar button that decodes QR codes from the selected screenshot area and copies decoded text to clipboard
- Uses ZXing-C++ as an optional dependency, enabled via `-DENABLE_QRCODE=ON`
- Follows the existing `AbstractActionTool` pattern with a 3-second notification label for feedback

## Details

- New files: `src/tools/qrscan/qrscantool.h`, `qrscantool.cpp`, QR icon SVGs (black/white)
- Registration: `capturetool.h` enum, `toolfactory.cpp`, `capturetoolbutton.cpp`
- All QR-related code is guarded by `#ifdef ENABLE_QRCODE` — builds without ZXing are unaffected
- Scans the selected area (or full screenshot if no selection) for QR codes
- Shows "QR code copied to clipboard" or "No QR code found" as a styled label for 3 seconds

## Test plan

- [ ] Build with `-DENABLE_QRCODE=ON` and verify QR scan button appears with icon
- [ ] Capture area containing a QR code, click QR button — verify text is copied to clipboard
- [ ] Capture area without QR code — verify "No QR code found" message appears
- [ ] Build without `-DENABLE_QRCODE` — verify QR button does not appear
- [ ] Verify notification label stays visible for ~3 seconds