### PR TITLE
Hide monitor selection in launcher for single-screen setups

### DIFF
--- a/src/widgets/capturelauncher.cpp
+++ b/src/widgets/capturelauncher.cpp
@@ -62,6 +62,11 @@ CaptureLauncher::CaptureLauncher(QDialog* parent)
 #ifdef Q_OS_MACOS
     ui->monitorLabel->setVisible(false);
     ui->monitorSelection->setVisible(false);
+#else
+    if (screens.size() <= 1) {
+        ui->monitorLabel->setVisible(false);
+        ui->monitorSelection->setVisible(false);
+    }
 #endif
 
     ui->delayTime->setSpecialValueText(tr("No Delay"));
@@ -119,6 +124,11 @@ CaptureLauncher::CaptureLauncher(QDialog* parent)
     ui->screenshotWidth->setText(QString::number(lastRegion.width()));
     ui->screenshotHeight->setText(QString::number(lastRegion.height()));
 
+    ui->screenshotWidth->setMaximumWidth(70);
+    ui->screenshotHeight->setMaximumWidth(70);
+    ui->screenshotX->setMaximumWidth(70);
+    ui->screenshotY->setMaximumWidth(70);
+    adjustSize();
     show();
     // Call show() first, otherwise the correct geometry cannot be fetched
     // for centering the window on the screen

--- a/src/widgets/capturelauncher.ui
+++ b/src/widgets/capturelauncher.ui
@@ -6,16 +6,21 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>452</width>
-    <height>250</height>
+    <width>0</width>
+    <height>0</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Capture Launcher</string>
   </property>
   <layout class="QHBoxLayout" name="horizontalLayout_4">
+   <property name="leftMargin"><number>4</number></property>
+   <property name="topMargin"><number>4</number></property>
+   <property name="rightMargin"><number>4</number></property>
+   <property name="bottomMargin"><number>4</number></property>
    <item>
     <layout class="QVBoxLayout" name="verticalLayout_2">
+     <property name="spacing"><number>4</number></property>
      <item>
       <widget class="QLabel" name="modeLabel">
        <property name="font">
@@ -45,6 +50,9 @@
        </item>
        <item row="1" column="1">
         <widget class="QComboBox" name="captureType">
+         <property name="sizeAdjustPolicy">
+          <enum>QComboBox::SizeAdjustPolicy::AdjustToContents</enum>
+         </property>
          <property name="currentText">
           <string/>
          </property>


### PR DESCRIPTION
## Summary
- Hide the monitor label and combobox in the capture launcher when only one screen is connected (no need to choose)
- Make the launcher UI more compact: reduced margins, tighter spacing, coordinate fields capped at 70px width, combobox sized to its content