### PR TITLE
fix: remove duplicate layout parent in SidePanelWidget

### DIFF
--- a/src/widgets/panel/sidepanelwidget.cpp
+++ b/src/widgets/panel/sidepanelwidget.cpp
@@ -81,7 +81,7 @@ SidePanelWidget::SidePanelWidget(QPixmap* p, QWidget* parent)
     m_layout->addWidget(m_colorWheel);
     m_layout->addWidget(m_colorHex);
 
-    QHBoxLayout* gridHBoxLayout = new QHBoxLayout(this);
+    QHBoxLayout* gridHBoxLayout = new QHBoxLayout();
     m_gridCheck = new QCheckBox(tr("Display grid"), this);
     m_gridSizeSpin = new QSpinBox(this);
     m_gridSizeSpin->setRange(5, 50);


### PR DESCRIPTION
The widget's layout is already set in the member initializer list (line 25) via `m_layout(new QVBoxLayout(this))`. Passing `this` to the `QHBoxLayout` constructor at line 84 tries to set a second layout on the same widget, which Qt rejects with a warning on every capture:

```
QLayout: Attempting to add QLayout "" to SidePanelWidget "", which already has a layout
```

The parent argument is unnecessary since the layout is added to `m_layout` via `addLayout()` at line 94.

Note: The remaining QPainter warnings in the log originate from the bundled Qt-Color-Widgets library (`ColorWheel::render_ring` called during zero-size resize). Fix submitted upstream: https://gitlab.com/mattbas/Qt-Color-Widgets/-/merge_requests/29