### PR TITLE
Update QtColorWidgets git tag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ else()
   FetchContent_Declare(
     qtColorWidgets
     GIT_REPOSITORY https://gitlab.com/mattbas/Qt-Color-Widgets.git
-    GIT_TAG 4f3c7e2af8e3138d89533475af66df42ccf08ef8
+    GIT_TAG 5d52e907e50dc88cf969b41cea44665ff6c475b1
   )
   #Workaround for duplicate GUID in windows WIX installer
   if(WIN32)


### PR DESCRIPTION
Following the comment in PR #4578: As there was an already merged fix in QtColorWidgets to reduce warning messages in the console, I'd propose to switch to that git tag to profit from this color widget optimization in Flameshot.

Kudos to @benignobjunior for the fix in QtColorWidgets
