### PR TITLE
Removing arbitrary delay from desktop actions

### DIFF
--- a/data/desktopEntry/package/org.flameshot.Flameshot.desktop
+++ b/data/desktopEntry/package/org.flameshot.Flameshot.desktop
@@ -81,6 +81,7 @@ Name[nl_NL]=Schermfoto maken
 Name[es]=Tomar captura de pantalla
 Name[de]=Bildschirmfoto aufnehmen
 Name[pt_BR]=Capturar tela
+Exec=flameshot gui
 
 [Desktop Action Launcher]
 Name=Open launcher


### PR DESCRIPTION
This delay was added a very long time ago to address a unity specific issue. For the upcoming beta I would like to remove it and see if it causes any issues. If not, it will speed up flameshot for users who start it with the desktop file. 