### PR TITLE
Fix pin position on Windows for scaled screen

### DIFF
--- a/src/tools/pin/pinwidget.cpp
+++ b/src/tools/pin/pinwidget.cpp
@@ -60,17 +60,16 @@ PinWidget::PinWidget(const QPixmap& pixmap,
     new QShortcut(Qt::Key_Escape, this, SLOT(close()));
 
     qreal devicePixelRatio = 1;
-#if defined(Q_OS_MACOS) || defined(Q_OS_LINUX)
     QScreen* currentScreen = QGuiAppCurrentScreen().currentScreen();
     if (currentScreen != nullptr) {
         devicePixelRatio = currentScreen->devicePixelRatio();
     }
-#endif
+
     const int margin =
       static_cast<int>(static_cast<double>(MARGIN) * devicePixelRatio);
     QRect adjusted_pos = geometry + QMargins(margin, margin, margin, margin);
     setGeometry(adjusted_pos);
-#if defined(Q_OS_MACOS) || defined(Q_OS_LINUX)
+
     if (currentScreen != nullptr) {
         QPoint topLeft = currentScreen->geometry().topLeft();
         adjusted_pos.setX((adjusted_pos.x() - topLeft.x()) / devicePixelRatio +
@@ -83,7 +82,7 @@ PinWidget::PinWidget(const QPixmap& pixmap,
         resize(0, 0);
         move(adjusted_pos.x(), adjusted_pos.y());
     }
-#endif
+
     grabGesture(Qt::PinchGesture);
 
     this->setContextMenuPolicy(Qt::CustomContextMenu);


### PR DESCRIPTION
Potential fix for #4610
Seems the implementation for macOS and Linux is working on Windows as well! My available test setup is very simple and limited; I would appreciate it if some Windows users could test this and confirm that it is working on their machines with scaling enabled!