### PR TITLE
fix(macos): use CGRequestScreenCaptureAccess instead of grabWindow for permission request

### DIFF
--- a/src/core/flameshot.cpp
+++ b/src/core/flameshot.cpp
@@ -7,6 +7,10 @@
 #include "qhotkey.h"
 #endif
 
+#if defined(Q_OS_MACOS)
+#include <CoreGraphics/CoreGraphics.h>
+#endif
+
 #include "config/configresolver.h"
 #include "config/configwindow.h"
 #include "core/qguiappcurrentscreen.h"
@@ -54,11 +58,10 @@ Flameshot::Flameshot()
     qApp->setStyleSheet(StyleSheet);
 
 #if defined(Q_OS_MACOS)
-    // Try to take a test screenshot, MacOS will request a "Screen Recording"
-    // permissions on the first run. Otherwise it will be hidden under the
-    // CaptureWidget
-    QScreen* currentScreen = QGuiAppCurrentScreen().currentScreen();
-    currentScreen->grabWindow(0, 0, 0, 1, 1);
+    // Request Screen Recording permission via the proper CoreGraphics API
+    if (!CGPreflightScreenCaptureAccess()) {
+        CGRequestScreenCaptureAccess();
+    }
 #endif
 #if (defined(Q_OS_MACOS) || defined(Q_OS_WIN))
     // Set global shortcuts for MacOS or Windows


### PR DESCRIPTION
## Problem

On modern macOS (especially 15+), Flameshot re-triggers the Screen Recording permission dialog on every launch. The user grants the permission, but the next time the app starts it prompts again.

## Root cause

The current code uses `QScreen::grabWindow()` as a hack to trigger the TCC permission prompt. This performs an actual screen capture on every launch, which modern macOS interprets as a new capture attempt rather than a no-op — re-triggering the permission dialog even when already granted.

## Fix

Replace the `grabWindow()` hack with the proper CoreGraphics APIs:
- `CGPreflightScreenCaptureAccess()` — checks if permission is already granted (no prompt)
- `CGRequestScreenCaptureAccess()` — shows the system dialog only if not yet granted

These APIs have been available since macOS 10.15 (Catalina) and are the documented way to handle Screen Recording permissions.