### PR TITLE
fix(macos): make fullscreen capture overlay configurable

### DIFF
--- a/src/config/generalconf.cpp
+++ b/src/config/generalconf.cpp
@@ -59,6 +59,9 @@ GeneralConf::GeneralConf(QWidget* parent)
 #if !defined(Q_OS_MACOS)
     initCaptureActiveMonitor();
 #endif
+#if defined(Q_OS_MACOS)
+    initUseNativeFullscreen();
+#endif
 #if defined(Q_OS_LINUX)
     initUseX11LegacyScreenshot();
 #endif
@@ -132,6 +135,9 @@ void GeneralConf::_updateComponents(bool allowEmptySavePath)
 #endif
 #if !defined(Q_OS_MACOS)
     m_captureActiveMonitor->setChecked(config.captureActiveMonitor());
+#endif
+#if defined(Q_OS_MACOS)
+    m_useNativeFullscreen->setChecked(config.useNativeFullscreen());
 #endif
 #if defined(Q_OS_LINUX)
     m_useX11LegacyScreenshot->setChecked(config.useX11LegacyScreenshot());
@@ -942,6 +948,29 @@ void GeneralConf::initCaptureActiveMonitor()
 void GeneralConf::captureActiveMonitorChanged(bool checked)
 {
     ConfigHandler().setCaptureActiveMonitor(checked);
+}
+#endif
+
+#if defined(Q_OS_MACOS)
+void GeneralConf::initUseNativeFullscreen()
+{
+    m_useNativeFullscreen =
+      new QCheckBox(tr("Use native fullscreen for capture overlay"), this);
+    m_useNativeFullscreen->setToolTip(
+      tr("Use macOS native fullscreen mode for the capture overlay. "
+         "When disabled (default), the overlay avoids the fullscreen "
+         "desktop animation."));
+    m_scrollAreaLayout->addWidget(m_useNativeFullscreen);
+
+    connect(m_useNativeFullscreen,
+            &QCheckBox::clicked,
+            this,
+            &GeneralConf::useNativeFullscreenChanged);
+}
+
+void GeneralConf::useNativeFullscreenChanged(bool checked)
+{
+    ConfigHandler().setUseNativeFullscreen(checked);
 }
 #endif
 

--- a/src/config/generalconf.h
+++ b/src/config/generalconf.h
@@ -64,6 +64,9 @@ private slots:
 #if !defined(Q_OS_MACOS)
     void captureActiveMonitorChanged(bool checked);
 #endif
+#if defined(Q_OS_MACOS)
+    void useNativeFullscreenChanged(bool checked);
+#endif
 #if defined(Q_OS_LINUX)
     void useX11LegacyScreenshotChanged(bool checked);
 #endif
@@ -107,6 +110,9 @@ private:
     void initInsecurePixelate();
 #if !defined(Q_OS_MACOS)
     void initCaptureActiveMonitor();
+#endif
+#if defined(Q_OS_MACOS)
+    void initUseNativeFullscreen();
 #endif
 #if defined(Q_OS_LINUX)
     void initUseX11LegacyScreenshot();
@@ -161,6 +167,9 @@ private:
     QCheckBox* m_insecurePixelate;
 #if !defined(Q_OS_MACOS)
     QCheckBox* m_captureActiveMonitor;
+#endif
+#if defined(Q_OS_MACOS)
+    QCheckBox* m_useNativeFullscreen;
 #endif
 #if defined(Q_OS_LINUX)
     QCheckBox* m_useX11LegacyScreenshot;

--- a/src/core/flameshot.cpp
+++ b/src/core/flameshot.cpp
@@ -128,8 +128,11 @@ CaptureWidget* Flameshot::gui(const CaptureRequest& req)
 #ifdef Q_OS_WIN
         m_captureWindow->show();
 #elif defined(Q_OS_MACOS)
-        // In "Emulate fullscreen mode"
-        m_captureWindow->showFullScreen();
+        if (ConfigHandler().useNativeFullscreen()) {
+            m_captureWindow->showFullScreen();
+        } else {
+            m_captureWindow->show();
+        }
         m_captureWindow->activateWindow();
         m_captureWindow->raise();
 #else

--- a/src/utils/confighandler.cpp
+++ b/src/utils/confighandler.cpp
@@ -96,6 +96,9 @@ static QMap<class QString, QSharedPointer<ValueHandler>>
     OPTION("copyPathAfterSave"           ,Bool               ( false         )),
     OPTION("antialiasingPinZoom"         ,Bool               ( true          )),
     OPTION("useJpgForClipboard"          ,Bool               ( false         )),
+#if defined(Q_OS_MACOS)
+    OPTION("useNativeFullscreen"         ,Bool               ( false         )),
+#endif
     OPTION("uploadWithoutConfirmation"   ,Bool               ( false         )),
     OPTION("saveAfterCopy"               ,Bool               ( false         )),
     OPTION("savePath"                    ,ExistingDir        (               )),

--- a/src/utils/confighandler.h
+++ b/src/utils/confighandler.h
@@ -120,6 +120,9 @@ public:
     CONFIG_GETTER_SETTER(saveAsFileExtension, setSaveAsFileExtension, QString)
     CONFIG_GETTER_SETTER(antialiasingPinZoom, setAntialiasingPinZoom, bool)
     CONFIG_GETTER_SETTER(useJpgForClipboard, setUseJpgForClipboard, bool)
+#if defined(Q_OS_MACOS)
+    CONFIG_GETTER_SETTER(useNativeFullscreen, setUseNativeFullscreen, bool)
+#endif
     CONFIG_GETTER_SETTER(uploadWithoutConfirmation,
                          setUploadWithoutConfirmation,
                          bool)

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -164,6 +164,10 @@ CaptureWidget::CaptureWidget(const CaptureRequest& req,
             windowHandle()->setScreen(selectedScreen);
         }
 #elif defined(Q_OS_MACOS)
+        if (!ConfigHandler().useNativeFullscreen()) {
+            setWindowFlags(Qt::WindowStaysOnTopHint | Qt::FramelessWindowHint |
+                           Qt::Tool);
+        }
         QScreen* currentScreen = QGuiAppCurrentScreen().currentScreen();
         move(currentScreen->geometry().x(), currentScreen->geometry().y());
         resize(currentScreen->size());


### PR DESCRIPTION
## Problem

On macOS, `showFullScreen()` triggers a native fullscreen space transition
animation when taking a screenshot, briefly switching the desktop.

## Fix

Replace `showFullScreen()` with `show()` using `FramelessWindowHint`,
`WindowStaysOnTopHint`, and `Qt::Tool` flags to avoid the animation.

Add a `useNativeFullscreen` config option (default: off) in
Settings > General so users who prefer the native fullscreen behavior
can re-enable it.

All changes are guarded with `#if defined(Q_OS_MACOS)`. Non-macOS
platforms are unchanged.

## Testing

Tested on macOS 26.4 (Tahoe), Apple Silicon, Qt 6.11.0:
- Default (off): capture overlay appears instantly, no desktop animation
- Toggle on: original fullscreen space transition behavior restored
- Setting persists across restarts