### PR TITLE
fix(macos): prevent config tab content from rendering behind tab bar

### DIFF
--- a/src/config/configwindow.cpp
+++ b/src/config/configwindow.cpp
@@ -32,6 +32,11 @@ ConfigWindow::ConfigWindow(QWidget* parent)
     auto* layout = new QVBoxLayout(this);
     m_tabWidget = new QTabWidget(this);
     m_tabWidget->tabBar()->setUsesScrollButtons(false);
+#if defined(Q_OS_MACOS)
+    // Fix Qt6 macOS bug where tab pane content renders behind the tab bar
+    m_tabWidget->setStyleSheet(
+      "QTabWidget::pane { border-top: 2px solid palette(mid); }");
+#endif
     layout->addWidget(m_tabWidget);
 
     setAttribute(Qt::WA_DeleteOnClose);


### PR DESCRIPTION
## Problem

On macOS with Qt6, the Configuration window's tab content (toggles, shortcuts table) renders behind/under the tab bar header. The content pane overlaps with the tab bar, making the top portion of each tab's content hidden.

This is a known Qt6 macOS rendering issue where `QTabWidget::pane` geometry overlaps the tab bar area.

## Fix

Add a `border-top` style to `QTabWidget::pane` on macOS only, which forces Qt to correctly separate the pane from the tab bar:

```cpp
#if defined(Q_OS_MACOS)
    m_tabWidget->setStyleSheet(
      "QTabWidget::pane { border-top: 2px solid palette(mid); }");
#endif
```

Guarded with `#if defined(Q_OS_MACOS)` so Linux and Windows are unaffected.

## Before / After

_Screenshots to be attached_

## Testing

Tested on macOS 26.4 (Tahoe), Apple Silicon, Qt 6.11.0. All four tabs (General, Interface, Filename Editor, Shortcuts) render correctly with content below the tab bar.