### PR TITLE
feature(macos): show dock icon when config window is open

### DIFF
--- a/src/core/flameshot.cpp
+++ b/src/core/flameshot.cpp
@@ -7,6 +7,40 @@
 #include "qhotkey.h"
 #endif
 
+#if defined(Q_OS_MACOS)
+#include <QWindow>
+#include <objc/message.h>
+
+namespace {
+
+constexpr long NSApplicationActivationPolicyRegular = 0;
+constexpr long NSApplicationActivationPolicyAccessory = 1;
+
+void setActivationPolicy(long policy)
+{
+    auto sharedApp = reinterpret_cast<id (*)(id, SEL)>(objc_msgSend);
+    auto setPolicy = reinterpret_cast<void (*)(id, SEL, long)>(objc_msgSend);
+    id nsApp = sharedApp(reinterpret_cast<id>(objc_getClass("NSApplication")),
+                         sel_registerName("sharedApplication"));
+    setPolicy(nsApp, sel_registerName("setActivationPolicy:"), policy);
+}
+
+void setActivationPolicyRegular()
+{
+    setActivationPolicy(NSApplicationActivationPolicyRegular);
+}
+
+void setActivationPolicyAccessory()
+{
+    setActivationPolicy(NSApplicationActivationPolicyAccessory);
+}
+
+constexpr const char* visibleInDockProperty = "_visibleInDock";
+
+} // namespace
+
+#endif
+
 #include "config/configresolver.h"
 #include "config/configwindow.h"
 #include "core/qguiappcurrentscreen.h"
@@ -224,8 +258,7 @@ void Flameshot::launcher()
     }
     m_launcherWindow->show();
 #if defined(Q_OS_MACOS)
-    m_launcherWindow->activateWindow();
-    m_launcherWindow->raise();
+    showDockIcon(m_launcherWindow);
 #endif
 }
 
@@ -245,8 +278,7 @@ void Flameshot::config()
         position.moveCenter(currentScreen->availableGeometry().center());
         m_configWindow->move(position.topLeft());
 #if defined(Q_OS_MACOS)
-        m_configWindow->activateWindow();
-        m_configWindow->raise();
+        showDockIcon(m_configWindow);
 #endif
     }
 }
@@ -256,8 +288,7 @@ void Flameshot::info()
     if (m_infoWindow == nullptr) {
         m_infoWindow = new InfoWindow();
 #if defined(Q_OS_MACOS)
-        m_infoWindow->activateWindow();
-        m_infoWindow->raise();
+        showDockIcon(m_infoWindow);
 #endif
     }
 }
@@ -283,9 +314,46 @@ void Flameshot::history()
     historyWidget->move(position.topLeft());
 
 #if defined(Q_OS_MACOS)
-    historyWidget->activateWindow();
-    historyWidget->raise();
+    showDockIcon(historyWidget);
 #endif
+}
+#endif
+
+#if defined(Q_OS_MACOS)
+void Flameshot::onWindowVisibilityChanged(QWindow::Visibility newVisibility)
+{
+    auto* qw = qobject_cast<QWindow*>(sender());
+    if (!qw) {
+        return;
+    }
+
+    if (newVisibility == QWindow::Hidden) {
+        qw->setProperty(visibleInDockProperty, false);
+        --m_dockIconVisibleCount;
+        if (m_dockIconVisibleCount == 0) {
+            setActivationPolicyAccessory();
+        }
+    } else {
+        bool windowTrackedInDock = qw->property(visibleInDockProperty).toBool();
+        if (!windowTrackedInDock) {
+            qw->setProperty(visibleInDockProperty, true);
+            ++m_dockIconVisibleCount;
+            setActivationPolicyRegular();
+        }
+    }
+}
+
+void Flameshot::showDockIcon(QWidget* w)
+{
+    QWindow* qw = w->windowHandle();
+    if (!qw) {
+        return;
+    }
+
+    connect(qw,
+            &QWindow::visibilityChanged,
+            this,
+            &Flameshot::onWindowVisibilityChanged);
 }
 #endif
 

--- a/src/core/flameshot.h
+++ b/src/core/flameshot.h
@@ -8,11 +8,13 @@
 #include <QObject>
 #include <QPointer>
 #include <QVersionNumber>
+#include <QWindow>
 
 class CaptureWidget;
 class ConfigWindow;
 class InfoWindow;
 class CaptureLauncher;
+class QWidget;
 #ifdef ENABLE_IMGUR
 class UploadHistory;
 #endif
@@ -90,6 +92,15 @@ private:
     QPointer<InfoWindow> m_infoWindow;
     QPointer<CaptureLauncher> m_launcherWindow;
     QPointer<ConfigWindow> m_configWindow;
+
+#if defined(Q_OS_MACOS)
+public:
+    void showDockIcon(QWidget* window);
+
+private:
+    void onWindowVisibilityChanged(QWindow::Visibility newVisibility);
+    int m_dockIconVisibleCount = 0;
+#endif
 
 #if (defined(Q_OS_MACOS) || defined(Q_OS_WIN))
     QHotkey* m_HotkeyScreenshotCapture;


### PR DESCRIPTION
## Summary

On macOS with `LSUIElement=true`, Flameshot runs as an agent app with no dock icon. This makes it impossible to Cmd+Tab to open windows or see the app in the dock.

This PR adds a dock icon that appears while any user-facing window is visible and disappears when the last one is closed or hidden.

## Supported windows

- Settings (ConfigWindow)
- About (InfoWindow)
- Capture Launcher (CaptureLauncher)
- Upload History (UploadHistory)

## Implementation

- `Flameshot::showDockIcon(QWidget*)` — public one-liner for any window. Call after `show()`.
- Uses `QWindow::visibilityChanged` signal to track window visibility.
- Per-window dynamic property (`_visibleInDock`) prevents double-counting on minimize/maximize transitions.
- Reference counter toggles `NSApplicationActivationPolicy` between Regular (dock icon) and Accessory (no dock icon).
- Adding a new window requires just one line: `showDockIcon(myWidget)`.

## Testing

Tested on macOS 26.4 (Tahoe), Apple Silicon, Qt 6.11.0:
- Open/close each window type — dock icon appears/disappears correctly
- Multiple windows open — dock icon stays until last one closes
- CaptureLauncher hide (start capture) + close settings — dock icon disappears
- Minimize/restore — dock icon persists correctly