### PR TITLE
fix(macos): fix clipboard copy failing from tray and GUI

### DIFF
--- a/src/core/flameshotdaemon.cpp
+++ b/src/core/flameshotdaemon.cpp
@@ -141,12 +141,7 @@ void FlameshotDaemon::createPin(const QPixmap& capture, QRect geometry)
 
 void FlameshotDaemon::copyToClipboard(const QPixmap& capture)
 {
-#if defined(Q_OS_MACOS) && defined(USE_KDSINGLEAPPLICATION)
-    auto kdsa = KDSingleApplication(QStringLiteral("org.flameshot.Flameshot"));
-    if (kdsa.isPrimaryInstance() && instance()) {
-#else
     if (instance()) {
-#endif
         instance()->attachScreenshotToClipboard(capture);
         return;
     }
@@ -156,9 +151,7 @@ void FlameshotDaemon::copyToClipboard(const QPixmap& capture)
 
 #if defined(USE_KDSINGLEAPPLICATION) &&                                        \
   (defined(Q_OS_MACOS) || defined(Q_OS_WIN))
-#if defined(Q_OS_WIN)
     auto kdsa = KDSingleApplication(QStringLiteral("org.flameshot.Flameshot"));
-#endif
     stream << QStringLiteral("attachScreenshotToClipboard") << capture;
     kdsa.sendMessage(data);
 #else
@@ -174,21 +167,14 @@ void FlameshotDaemon::copyToClipboard(const QPixmap& capture)
 void FlameshotDaemon::copyToClipboard(const QString& text,
                                       const QString& notification)
 {
-#if defined(Q_OS_MACOS) && defined(USE_KDSINGLEAPPLICATION)
-    auto kdsa = KDSingleApplication(QStringLiteral("org.flameshot.Flameshot"));
-    if (kdsa.isPrimaryInstance() && instance()) {
-#else
     if (instance()) {
-#endif
         instance()->attachTextToClipboard(text, notification);
         return;
     }
 
 #if defined(USE_KDSINGLEAPPLICATION) &&                                        \
   (defined(Q_OS_MACOS) || defined(Q_OS_WIN))
-#if defined(Q_OS_WIN)
     auto kdsa = KDSingleApplication(QStringLiteral("org.flameshot.Flameshot"));
-#endif
     QByteArray data;
     QDataStream stream(&data, QIODevice::WriteOnly);
     stream << QStringLiteral("attachTextToClipboard") << text << notification;

--- a/src/utils/screenshotsaver.cpp
+++ b/src/utils/screenshotsaver.cpp
@@ -111,45 +111,6 @@ QString ShowSaveFileDialog(const QString& title, const QString& directory)
     }
 }
 
-void saveJpegToClipboardMacOS(const QPixmap& capture)
-{
-    // Convert QPixmap to JPEG data
-    QByteArray jpegData;
-    QBuffer buffer(&jpegData);
-    buffer.open(QIODevice::WriteOnly);
-
-    QImageWriter imageWriter(&buffer, "jpeg");
-
-    // Set JPEG quality to whatever is in settings
-    imageWriter.setQuality(ConfigHandler().jpegQuality());
-    if (!imageWriter.write(capture.toImage())) {
-        qWarning() << "Failed to write image to JPEG format.";
-        return;
-    }
-
-    // Save JPEG data to a temporary file
-    QTemporaryFile tempFile;
-    if (!tempFile.open()) {
-        qWarning() << "Failed to open temporary file for writing.";
-        return;
-    }
-    tempFile.write(jpegData);
-    tempFile.close();
-
-    // Use osascript to copy the contents of the file to clipboard
-    QProcess process;
-    QString script =
-      QString("set the clipboard to (read (POSIX file \"%1\") as «class PNGf»)")
-        .arg(tempFile.fileName());
-    process.start("osascript", QStringList() << "-e" << script);
-    if (!process.waitForFinished()) {
-        qWarning() << "Failed to execute AppleScript.";
-    }
-
-    // Clean up
-    tempFile.remove();
-}
-
 void saveToClipboardMime(const QPixmap& capture, const QString& imageType)
 {
     QByteArray array;
@@ -169,7 +130,14 @@ void saveToClipboardMime(const QPixmap& capture, const QString& imageType)
 
         auto* mimeData = new QMimeData();
 
-#ifdef USE_WAYLAND_CLIPBOARD
+#if defined(Q_OS_MACOS)
+        // setImageData provides the image in a native pasteboard format
+        // (public.tiff) that macOS can always access. Also include the
+        // original format bytes for apps that prefer PNG/JPEG.
+        mimeData->setImageData(formattedPixmap.toImage());
+        mimeData->setData("image/" + imageType, array);
+        QApplication::clipboard()->setMimeData(mimeData);
+#elif defined(USE_WAYLAND_CLIPBOARD)
         if (QGuiApplication::platformName() == "wayland") {
             mimeData->setImageData(formattedPixmap.toImage());
             mimeData->setData(QStringLiteral("x-kde-force-image-copy"),
@@ -205,14 +173,15 @@ void saveToClipboard(const QPixmap& capture)
     } else {
         AbstractLogger() << QObject::tr("Capture saved to clipboard.");
     }
-    if (ConfigHandler().useJpgForClipboard()) {
-#ifdef Q_OS_MACOS
-        saveJpegToClipboardMacOS(capture);
+#if defined(Q_OS_MACOS)
+    // On macOS, setPixmap uses lazy clipboard which fails when the
+    // process exits ("Cannot keep promise"). Always use serialized bytes.
+    saveToClipboardMime(capture,
+                        ConfigHandler().useJpgForClipboard() ? "jpeg" : "png");
 #else
+    if (ConfigHandler().useJpgForClipboard()) {
         saveToClipboardMime(capture, "jpeg");
-#endif
     } else {
-        // Need to send message before copying to clipboard
 #if defined(Q_OS_LINUX) || defined(Q_OS_UNIX)
         if (DesktopInfo().waylandDetected()) {
             saveToClipboardMime(capture, "png");
@@ -223,6 +192,7 @@ void saveToClipboard(const QPixmap& capture)
         QApplication::clipboard()->setPixmap(capture);
 #endif
     }
+#endif
 }
 
 class ClipboardWatcherMimeData : public QMimeData


### PR DESCRIPTION
## Problem

Copying screenshots to clipboard on macOS was broken in two ways:

1. **3-second delay + clipboard empty**: `copyToClipboard()` created a
   `KDSingleApplication` instance and called `isPrimaryInstance()`, which
   always returned `false` because the daemon already holds the socket.
   This triggered IPC message delivery instead of using the in-process
   daemon directly. The IPC timed out after ~3 seconds and clipboard was
   never set.

2. **Lazy clipboard data lost on exit**: `setData("image/png")` puts a
   lazy reference on the macOS pasteboard — if the process exits before
   paste, data is lost ("Cannot keep promise"). The separate
   `saveJpegToClipboardMacOS()` workaround used osascript with a temp
   file and incorrectly declared JPEG data as PNG UTI (`«class PNGf»`).

## Fix

- Remove the `isPrimaryInstance()` check on macOS — use `instance()` to
  check if the daemon singleton exists in-process, matching non-macOS
  behavior. IPC fallback is preserved for true secondary processes (CLI).
- Add macOS branch in `saveToClipboardMime()` using `setImageData(QImage)`
  for native pasteboard persistence (`public.tiff`) plus `setData()` for
  exact format availability (PNG or JPEG).
- Delete `saveJpegToClipboardMacOS()` entirely — the fixed
  `saveToClipboardMime()` now handles both formats correctly.

All changes are guarded with `#if defined(Q_OS_MACOS)`. The Linux, Windows,
and Wayland clipboard paths are unchanged.

## Testing

Tested on macOS 26.4 (Tahoe), Apple Silicon, Qt 6.11.0:
- Tray menu Ctrl+C: clipboard set instantly (was 3s delay + empty)
- CLI `flameshot full --clipboard`: works via IPC fallback
- Both JPEG and PNG modes verified with `osascript -e 'clipboard info'

closes #4630