### PR TITLE
Option to disable tray icon on Windows

### DIFF
--- a/src/config/generalconf.cpp
+++ b/src/config/generalconf.cpp
@@ -34,9 +34,7 @@ GeneralConf::GeneralConf(QWidget* parent)
     initScrollArea();
 
     initAutostart();
-#if !defined(Q_OS_WIN)
     initAutoCloseIdleDaemon();
-#endif
     initShowTrayIcon();
     initShowDesktopNotification();
     initShowAbortNotification();
@@ -112,11 +110,7 @@ void GeneralConf::_updateComponents(bool allowEmptySavePath)
     m_squareMagnifier->setChecked(config.squareMagnifier());
     m_saveLastRegion->setChecked(config.saveLastRegion());
     m_reverseArrow->setChecked(config.reverseArrow());
-
-#if !defined(Q_OS_WIN)
     m_autoCloseIdleDaemon->setChecked(config.autoCloseIdleDaemon());
-#endif
-
     m_predefinedColorPaletteLarge->setChecked(
       config.predefinedColorPaletteLarge());
     m_showStartupLaunchMessage->setChecked(config.showStartupLaunchMessage());
@@ -127,9 +121,9 @@ void GeneralConf::_updateComponents(bool allowEmptySavePath)
     if (allowEmptySavePath || !config.savePath().isEmpty()) {
         m_savePath->setText(config.savePath());
     }
-#if defined(Q_OS_LINUX) || defined(Q_OS_UNIX)
+
     m_showTray->setChecked(!config.disabledTrayIcon());
-#endif
+
 #if !defined(Q_OS_MACOS)
     m_captureActiveMonitor->setChecked(config.captureActiveMonitor());
 #endif
@@ -335,7 +329,6 @@ void GeneralConf::initShowAbortNotification()
 
 void GeneralConf::initShowTrayIcon()
 {
-#if defined(Q_OS_LINUX) || defined(Q_OS_UNIX)
     m_showTray = new QCheckBox(tr("Show tray icon"), this);
     m_showTray->setToolTip(tr("Show icon in the system tray"));
     m_scrollAreaLayout->addWidget(m_showTray);
@@ -343,7 +336,6 @@ void GeneralConf::initShowTrayIcon()
     connect(m_showTray, &QCheckBox::clicked, this, [](bool checked) {
         ConfigHandler().setDisabledTrayIcon(!checked);
     });
-#endif
 }
 
 void GeneralConf::initHistoryConfirmationToDelete()

--- a/src/core/flameshotdaemon.cpp
+++ b/src/core/flameshotdaemon.cpp
@@ -51,9 +51,7 @@
  *   quits.
  *
  * If the `autoCloseIdleDaemon` option is true, the daemon will close as soon as
- * it is not needed to host pinned screenshots and the clipboard. On Windows,
- * this option is disabled and the daemon always persists, because the system
- * tray is currently the only way to interact with flameshot there.
+ * it is not needed to host pinned screenshots and the clipboard.
  *
  * Both the daemon and non-daemon flameshot processes use the same public API,
  * which is implemented as static methods. In the daemon process, this class is
@@ -85,9 +83,7 @@ FlameshotDaemon::FlameshotDaemon()
           m_hostingClipboard = false;
           quitIfIdle();
       });
-#ifdef Q_OS_WIN
-    m_persist = true;
-#else
+
     m_persist = !ConfigHandler().autoCloseIdleDaemon();
     connect(ConfigHandler::getInstance(),
             &ConfigHandler::fileChanged,
@@ -97,7 +93,6 @@ FlameshotDaemon::FlameshotDaemon()
                 enableTrayIcon(!config.disabledTrayIcon());
                 m_persist = !config.autoCloseIdleDaemon();
             });
-#endif
 
 #if !defined(DISABLE_UPDATE_CHECKER)
     if (ConfigHandler().checkForUpdates()) {
@@ -385,13 +380,10 @@ void FlameshotDaemon::attachTextToClipboard(const QString& text,
 
 void FlameshotDaemon::initTrayIcon()
 {
-#if defined(Q_OS_LINUX) || defined(Q_OS_UNIX)
     if (!ConfigHandler().disabledTrayIcon()) {
         enableTrayIcon(true);
     }
-#elif defined(Q_OS_WIN)
-    enableTrayIcon(true);
-
+#if defined(Q_OS_WIN)
     GlobalShortcutFilter* nativeFilter = new GlobalShortcutFilter(this);
     qApp->installNativeEventFilter(nativeFilter);
 #endif

--- a/src/utils/confighandler.cpp
+++ b/src/utils/confighandler.cpp
@@ -86,9 +86,7 @@ static QMap<class QString, QSharedPointer<ValueHandler>>
     OPTION("allowMultipleGuiInstances"   ,Bool               ( false         )),
     OPTION("showMagnifier"               ,Bool               ( false         )),
     OPTION("squareMagnifier"             ,Bool               ( false         )),
-#if !defined(Q_OS_WIN)
     OPTION("autoCloseIdleDaemon"         ,Bool               ( false         )),
-#endif
     OPTION("startupLaunch"               ,Bool               ( false         )),
     OPTION("showStartupLaunchMessage"    ,Bool               ( true          )),
     OPTION("showQuitPrompt"              ,Bool               ( false         )),


### PR DESCRIPTION
Since Flameshot has CLI support on Windows in the meantime, we could allow Windows users to disable the tray icon (in 2022 PR #2820 was rejected because of missing CLI support)

Fixing #2774