### PR TITLE
Fix KDE Plasma keyboard shortcut config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ These shortcuts are available in GUI mode:
 
 #### On KDE Plasma desktop
 
-To make configuration easier, there's a [file](docs/shortcuts-config/flameshot-shortcuts-kde.khotkeys) in the repository that more or less automates this process. This file will assign the following hotkeys by default:
+To make configuration easier, there's a [file](docs/shortcuts-config/flameshot-shortcuts-kde.kksrc) in the repository that more or less automates this process. This file will assign the following hotkeys by default:
 
 |  Keys                                                  |  Description                                                                       |
 |---                                                     |---                                                                                 |


### PR DESCRIPTION
With PR #4454 the KDE Plasma keyboard shortcut config file was replaced, but the link in the Readme was forgotten to update.
Fix for #4636

@mmahmoudian there is a pending PR from the initial author of #4454 for updating the website accordingly as well: flameshot-org/flameshot-org.github.io#202