### PR TITLE
Preserve clipboard image bytes on Wayland

### DIFF
--- a/src/utils/screenshotsaver.cpp
+++ b/src/utils/screenshotsaver.cpp
@@ -140,6 +140,9 @@ void saveToClipboardMime(const QPixmap& capture, const QString& imageType)
 #elif defined(USE_WAYLAND_CLIPBOARD)
         if (QGuiApplication::platformName() == "wayland") {
             mimeData->setImageData(formattedPixmap.toImage());
+            // Keep the encoded bytes alongside the Qt image data so Wayland
+            // clients that prefer the native image format can consume them.
+            mimeData->setData("image/" + imageType, array);
             mimeData->setData(QStringLiteral("x-kde-force-image-copy"),
                               QByteArray());
             KSystemClipboard::instance()->setMimeData(mimeData,


### PR DESCRIPTION
## Summary
- keep encoded image bytes in the clipboard MIME payload on Wayland
- preserve the existing Qt image data and KDE force-copy hint
- address broken image pastes reported under Wayland clipboard flows

Fixes #3329

## Validation
- git diff --check
- cmake -S . -B build -DCMAKE_BUILD_TYPE=Release (blocked: Qt6Config.cmake not installed locally)