### PR TITLE
Add persistent history for dismissed pins

### DIFF
--- a/src/config/CMakeLists.txt
+++ b/src/config/CMakeLists.txt
@@ -11,6 +11,8 @@ target_sources(
           extendedslider.cpp
           filenameeditor.cpp
           generalconf.cpp
+          pinhistoryconf.h
+          pinhistoryconf.cpp
           setshortcutwidget.cpp
           shortcutswidget.cpp
           strftimechooserwidget.cpp

--- a/src/config/configwindow.cpp
+++ b/src/config/configwindow.cpp
@@ -5,6 +5,7 @@
 #include "config/configresolver.h"
 #include "config/filenameeditor.h"
 #include "config/generalconf.h"
+#include "config/pinhistoryconf.h"
 #include "config/shortcutswidget.h"
 #include "config/visualseditor.h"
 #include "utils/colorutils.h"
@@ -81,6 +82,15 @@ ConfigWindow::ConfigWindow(QWidget* parent)
                         QIcon(modifier + "name_edition.svg"),
                         tr("Filename Editor"));
 
+    // pin history
+    m_pinHistoryConf = new PinHistoryConf();
+    m_pinHistoryConfTab = new QWidget();
+    auto* pinHistoryLayout = new QVBoxLayout(m_pinHistoryConfTab);
+    m_pinHistoryConfTab->setLayout(pinHistoryLayout);
+    pinHistoryLayout->addWidget(m_pinHistoryConf);
+    m_tabWidget->addTab(
+      m_pinHistoryConfTab, QIcon(modifier + "config.svg"), tr("Pin History"));
+
     // shortcuts
     m_shortcuts = new ShortcutsWidget();
     m_shortcutsTab = new QWidget();
@@ -103,11 +113,16 @@ ConfigWindow::ConfigWindow(QWidget* parent)
             &ConfigWindow::updateChildren,
             m_generalConfig,
             &GeneralConf::updateComponents);
+    connect(this,
+            &ConfigWindow::updateChildren,
+            m_pinHistoryConf,
+            &PinHistoryConf::updateComponents);
 
     // Error indicator (this must come last)
     initErrorIndicator(m_visualsTab, m_visuals);
     initErrorIndicator(m_filenameEditorTab, m_filenameEditor);
     initErrorIndicator(m_generalConfigTab, m_generalConfig);
+    initErrorIndicator(m_pinHistoryConfTab, m_pinHistoryConf);
     initErrorIndicator(m_shortcutsTab, m_shortcuts);
 }
 

--- a/src/config/configwindow.h
+++ b/src/config/configwindow.h
@@ -8,6 +8,7 @@
 class FileNameEditor;
 class ShortcutsWidget;
 class GeneralConf;
+class PinHistoryConf;
 class QFileSystemWatcher;
 class VisualsEditor;
 class QWidget;
@@ -38,6 +39,9 @@ private:
 
     VisualsEditor* m_visuals;
     QWidget* m_visualsTab;
+
+    PinHistoryConf* m_pinHistoryConf;
+    QWidget* m_pinHistoryConfTab;
 
     void initErrorIndicator(QWidget* tab, QWidget* widget);
 };

--- a/src/config/pinhistoryconf.cpp
+++ b/src/config/pinhistoryconf.cpp
@@ -1,0 +1,234 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Manuel Martins & Contributors
+
+#include "pinhistoryconf.h"
+
+#include "utils/confighandler.h"
+#include "utils/pinhistorystore.h"
+
+#include <QCheckBox>
+#include <QComboBox>
+#include <QDesktopServices>
+#include <QGroupBox>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QMessageBox>
+#include <QPushButton>
+#include <QSpinBox>
+#include <QUrl>
+#include <QVBoxLayout>
+
+namespace {
+
+struct AgeOption
+{
+    int days;
+    const char* label;
+};
+
+const std::array<AgeOption, 5> kAgeOptions{ {
+  { 0, QT_TRANSLATE_NOOP("PinHistoryConf", "Never") },
+  { 7, QT_TRANSLATE_NOOP("PinHistoryConf", "7 days") },
+  { 30, QT_TRANSLATE_NOOP("PinHistoryConf", "30 days") },
+  { 90, QT_TRANSLATE_NOOP("PinHistoryConf", "90 days") },
+  { 365, QT_TRANSLATE_NOOP("PinHistoryConf", "1 year") },
+} };
+
+QString formatBytes(qint64 bytes)
+{
+    constexpr double kKiB = 1024.0;
+    constexpr double kMiB = kKiB * 1024.0;
+    constexpr double kGiB = kMiB * 1024.0;
+    if (bytes < kKiB) {
+        return QStringLiteral("%1 B").arg(bytes);
+    }
+    if (bytes < kMiB) {
+        return QStringLiteral("%1 KB").arg(bytes / kKiB, 0, 'f', 1);
+    }
+    if (bytes < kGiB) {
+        return QStringLiteral("%1 MB").arg(bytes / kMiB, 0, 'f', 1);
+    }
+    return QStringLiteral("%1 GB").arg(bytes / kGiB, 0, 'f', 2);
+}
+
+} // namespace
+
+PinHistoryConf::PinHistoryConf(QWidget* parent)
+  : QWidget(parent)
+{
+    initUi();
+    updateComponents();
+}
+
+void PinHistoryConf::initUi()
+{
+    m_layout = new QVBoxLayout(this);
+    m_layout->setAlignment(Qt::AlignTop);
+
+    m_unavailableBanner = new QLabel(this);
+    m_unavailableBanner->setWordWrap(true);
+    m_unavailableBanner->setStyleSheet(QStringLiteral(
+      "QLabel { color: palette(highlight); font-weight: bold; }"));
+    m_unavailableBanner->hide();
+    m_layout->addWidget(m_unavailableBanner);
+
+    m_enabled = new QCheckBox(tr("Enable pin history"), this);
+    m_enabled->setToolTip(
+      tr("When disabled, dismissed pins are not retained. Existing history is "
+         "kept and will be reaccessible if you re-enable the feature."));
+    connect(
+      m_enabled, &QCheckBox::toggled, this, &PinHistoryConf::enabledChanged);
+    m_layout->addWidget(m_enabled);
+
+    auto* retentionGroup = new QGroupBox(tr("Retention"), this);
+    auto* retentionLayout = new QVBoxLayout(retentionGroup);
+
+    auto* entriesRow = new QHBoxLayout();
+    entriesRow->addWidget(new QLabel(tr("Maximum entries:"), retentionGroup));
+    m_maxEntries = new QSpinBox(retentionGroup);
+    m_maxEntries->setRange(1, 1000);
+    connect(m_maxEntries,
+            QOverload<int>::of(&QSpinBox::valueChanged),
+            this,
+            &PinHistoryConf::maxEntriesChanged);
+    entriesRow->addWidget(m_maxEntries);
+    entriesRow->addStretch();
+    retentionLayout->addLayout(entriesRow);
+
+    auto* ageRow = new QHBoxLayout();
+    ageRow->addWidget(new QLabel(tr("Maximum age:"), retentionGroup));
+    m_maxAge = new QComboBox(retentionGroup);
+    for (const auto& opt : kAgeOptions) {
+        m_maxAge->addItem(tr(opt.label), opt.days);
+    }
+    connect(m_maxAge,
+            QOverload<int>::of(&QComboBox::currentIndexChanged),
+            this,
+            &PinHistoryConf::maxAgeChanged);
+    ageRow->addWidget(m_maxAge);
+    ageRow->addStretch();
+    retentionLayout->addLayout(ageRow);
+
+    m_layout->addWidget(retentionGroup);
+
+    auto* storageGroup = new QGroupBox(tr("Storage"), this);
+    auto* storageLayout = new QVBoxLayout(storageGroup);
+
+    m_pathLabel = new QLabel(storageGroup);
+    m_pathLabel->setWordWrap(true);
+    m_pathLabel->setTextInteractionFlags(Qt::TextSelectableByMouse);
+    storageLayout->addWidget(m_pathLabel);
+
+    m_statsLabel = new QLabel(storageGroup);
+    storageLayout->addWidget(m_statsLabel);
+
+    auto* buttonRow = new QHBoxLayout();
+    m_revealButton =
+      new QPushButton(tr("Reveal in file manager"), storageGroup);
+    connect(m_revealButton,
+            &QPushButton::clicked,
+            this,
+            &PinHistoryConf::revealStorage);
+    buttonRow->addWidget(m_revealButton);
+
+    m_clearButton = new QPushButton(tr("Clear history now"), storageGroup);
+    connect(
+      m_clearButton, &QPushButton::clicked, this, &PinHistoryConf::clearNow);
+    buttonRow->addWidget(m_clearButton);
+    buttonRow->addStretch();
+    storageLayout->addLayout(buttonRow);
+
+    m_layout->addWidget(storageGroup);
+    m_layout->addStretch();
+}
+
+void PinHistoryConf::updateComponents()
+{
+    ConfigHandler cfg;
+    const QSignalBlocker b1(m_enabled);
+    const QSignalBlocker b2(m_maxEntries);
+    const QSignalBlocker b3(m_maxAge);
+
+    m_enabled->setChecked(cfg.pinHistoryEnabled());
+    m_maxEntries->setValue(cfg.pinHistoryMaxEntries());
+
+    const int currentAge = cfg.pinHistoryMaxAgeDays();
+    int idx = 0;
+    for (int i = 0; i < static_cast<int>(kAgeOptions.size()); ++i) {
+        if (kAgeOptions[i].days == currentAge) {
+            idx = i;
+            break;
+        }
+    }
+    m_maxAge->setCurrentIndex(idx);
+
+    refreshStats();
+}
+
+void PinHistoryConf::refreshStats()
+{
+    PinHistoryStore store;
+    m_pathLabel->setText(tr("Location: %1").arg(store.path()));
+    const int count = store.entries().size();
+    const qint64 bytes = store.diskUsage();
+    m_statsLabel->setText(
+      tr("%1 entries · %2").arg(count).arg(formatBytes(bytes)));
+
+    const bool available = store.isAvailable();
+    m_revealButton->setEnabled(available);
+    m_clearButton->setEnabled(available && count > 0);
+    m_enabled->setEnabled(available);
+    m_maxEntries->setEnabled(available);
+    m_maxAge->setEnabled(available);
+
+    if (available) {
+        m_unavailableBanner->hide();
+    } else {
+        m_unavailableBanner->setText(
+          tr("Pin history storage is not writable (%1). The feature is "
+             "disabled for this session.")
+            .arg(store.path()));
+        m_unavailableBanner->show();
+    }
+}
+
+void PinHistoryConf::enabledChanged(bool checked)
+{
+    ConfigHandler().setPinHistoryEnabled(checked);
+}
+
+void PinHistoryConf::maxEntriesChanged(int value)
+{
+    ConfigHandler().setPinHistoryMaxEntries(value);
+}
+
+void PinHistoryConf::maxAgeChanged(int index)
+{
+    if (index < 0 || index >= static_cast<int>(kAgeOptions.size())) {
+        return;
+    }
+    ConfigHandler().setPinHistoryMaxAgeDays(kAgeOptions[index].days);
+}
+
+void PinHistoryConf::revealStorage()
+{
+    PinHistoryStore store;
+    QDesktopServices::openUrl(QUrl::fromLocalFile(store.path()));
+}
+
+void PinHistoryConf::clearNow()
+{
+    const QMessageBox::StandardButton answer =
+      QMessageBox::warning(this,
+                           tr("Clear pin history?"),
+                           tr("This will permanently delete all retained pins. "
+                              "This cannot be undone."),
+                           QMessageBox::Yes | QMessageBox::Cancel,
+                           QMessageBox::Cancel);
+    if (answer != QMessageBox::Yes) {
+        return;
+    }
+    PinHistoryStore store;
+    store.clear();
+    refreshStats();
+}

--- a/src/config/pinhistoryconf.h
+++ b/src/config/pinhistoryconf.h
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Manuel Martins & Contributors
+
+#pragma once
+
+#include <QWidget>
+
+class QCheckBox;
+class QComboBox;
+class QLabel;
+class QPushButton;
+class QSpinBox;
+class QVBoxLayout;
+
+class PinHistoryConf : public QWidget
+{
+    Q_OBJECT
+public:
+    explicit PinHistoryConf(QWidget* parent = nullptr);
+
+public slots:
+    void updateComponents();
+
+private slots:
+    void enabledChanged(bool checked);
+    void maxEntriesChanged(int value);
+    void maxAgeChanged(int index);
+    void revealStorage();
+    void clearNow();
+
+private:
+    void initUi();
+    void refreshStats();
+
+    QVBoxLayout* m_layout;
+    QLabel* m_unavailableBanner;
+    QCheckBox* m_enabled;
+    QSpinBox* m_maxEntries;
+    QComboBox* m_maxAge;
+    QLabel* m_pathLabel;
+    QLabel* m_statsLabel;
+    QPushButton* m_revealButton;
+    QPushButton* m_clearButton;
+};

--- a/src/core/flameshot.cpp
+++ b/src/core/flameshot.cpp
@@ -52,6 +52,7 @@ constexpr const char* visibleInDockProperty = "_visibleInDock";
 #include "widgets/capture/capturewidget.h"
 #include "widgets/capturelauncher.h"
 #include "widgets/infowindow.h"
+#include "widgets/pinhistorydialog.h"
 
 #ifdef ENABLE_IMGUR
 #include "tools/imgupload/imguploadermanager.h"
@@ -318,6 +319,33 @@ void Flameshot::history()
 #endif
 }
 #endif
+
+void Flameshot::pinHistory()
+{
+    FlameshotDaemon* daemon = FlameshotDaemon::instance();
+    if (!daemon || !daemon->pinHistory()) {
+        return;
+    }
+
+    static QPointer<PinHistoryDialog> dialog;
+    if (!dialog) {
+        dialog = new PinHistoryDialog(daemon->pinHistory());
+    }
+
+    dialog->show();
+    dialog->raise();
+    dialog->activateWindow();
+
+    QRect position = dialog->frameGeometry();
+    if (QScreen* currentScreen = QGuiAppCurrentScreen().currentScreen()) {
+        position.moveCenter(currentScreen->availableGeometry().center());
+        dialog->move(position.topLeft());
+    }
+
+#if defined(Q_OS_MACOS)
+    showDockIcon(dialog);
+#endif
+}
 
 #if defined(Q_OS_MACOS)
 void Flameshot::onWindowVisibilityChanged(QWindow::Visibility newVisibility)

--- a/src/core/flameshot.h
+++ b/src/core/flameshot.h
@@ -60,6 +60,8 @@ public slots:
     void history();
 #endif
 
+    void pinHistory();
+
     void openSavePath();
 
     QVersionNumber getVersion();

--- a/src/core/flameshotdaemon.cpp
+++ b/src/core/flameshotdaemon.cpp
@@ -4,6 +4,7 @@
 #include "utils/abstractlogger.h"
 #include "utils/confighandler.h"
 #include "utils/globalvalues.h"
+#include "utils/pinhistorymanager.h"
 #include "utils/screenshotsaver.h"
 #include "widgets/capture/capturewidget.h"
 #include "widgets/trayicon.h"
@@ -68,6 +69,7 @@ FlameshotDaemon::FlameshotDaemon()
   , m_hostingClipboard(false)
   , m_clipboardSignalBlocked(false)
   , m_trayIcon(nullptr)
+  , m_pinHistory(new PinHistoryManager(this))
 #if !defined(DISABLE_UPDATE_CHECKER)
   , m_appLatestVersion(QStringLiteral(APP_VERSION).replace("v", ""))
   , m_showManualCheckAppUpdateStatus(false)
@@ -297,14 +299,21 @@ void FlameshotDaemon::quitIfIdle()
 
 // SERVICE METHODS
 
-void FlameshotDaemon::attachPin(const QPixmap& pixmap, QRect geometry)
+void FlameshotDaemon::attachPin(const QPixmap& pixmap,
+                                QRect geometry,
+                                qreal zoom,
+                                qreal opacity)
 {
-    auto* pinWidget = new PinWidget(pixmap, geometry);
+    auto* pinWidget = new PinWidget(pixmap, geometry, nullptr, zoom, opacity);
     m_widgets.append(pinWidget);
     connect(pinWidget, &QObject::destroyed, this, [=, this]() {
         m_widgets.removeOne(pinWidget);
         quitIfIdle();
     });
+    connect(pinWidget,
+            &PinWidget::dismissed,
+            m_pinHistory,
+            &PinHistoryManager::recordDismissal);
 
     pinWidget->show();
     pinWidget->activateWindow();

--- a/src/core/flameshotdaemon.h
+++ b/src/core/flameshotdaemon.h
@@ -13,6 +13,7 @@ class QDBusMessage;
 class QDBusConnection;
 class TrayIcon;
 class CaptureWidget;
+class PinHistoryManager;
 
 #if !defined(DISABLE_UPDATE_CHECKER)
 class QNetworkAccessManager;
@@ -36,6 +37,13 @@ public:
       const QString& text,
       const QString& title = QStringLiteral("Flameshot Info"),
       const int timeout = 5000);
+
+    PinHistoryManager* pinHistory() const { return m_pinHistory; }
+
+    void attachPin(const QPixmap& pixmap,
+                   QRect geometry,
+                   qreal zoom = 1.0,
+                   qreal opacity = 1.0);
 
 #if defined(USE_KDSINGLEAPPLICATION) &&                                        \
   (defined(Q_OS_MACOS) || defined(Q_OS_WIN))
@@ -61,7 +69,6 @@ signals:
 private:
     FlameshotDaemon();
     void quitIfIdle();
-    void attachPin(const QPixmap& pixmap, QRect geometry);
     void attachScreenshotToClipboard(const QPixmap& pixmap);
 
     void attachPin(const QByteArray& data);
@@ -83,6 +90,7 @@ private:
     bool m_clipboardSignalBlocked;
     QList<QWidget*> m_widgets;
     TrayIcon* m_trayIcon;
+    PinHistoryManager* m_pinHistory;
 
 #if !defined(DISABLE_UPDATE_CHECKER)
     QString m_appLatestUrl;

--- a/src/tools/pin/pinwidget.cpp
+++ b/src/tools/pin/pinwidget.cpp
@@ -7,6 +7,7 @@
 #include "utils/globalvalues.h"
 #include "utils/screenshotsaver.h"
 
+#include <QCloseEvent>
 #include <QGraphicsDropShadowEffect>
 #include <QGraphicsOpacityEffect>
 #include <QLabel>
@@ -27,12 +28,17 @@ constexpr qreal MIN_SIZE = 100.0;
 
 PinWidget::PinWidget(const QPixmap& pixmap,
                      const QRect& geometry,
-                     QWidget* parent)
+                     QWidget* parent,
+                     qreal zoom,
+                     qreal opacity)
   : QWidget(parent)
   , m_pixmap(pixmap)
   , m_layout(new QVBoxLayout(this))
   , m_label(new QLabel())
   , m_shadowEffect(new QGraphicsDropShadowEffect(this))
+  , m_scaleFactor(zoom > 0 ? zoom : 1.0)
+  , m_opacity(opacity > 0 ? opacity : 1.0)
+  , m_sizeChanged(zoom != 1.0)
 {
     setWindowIcon(QIcon(GlobalValues::iconPath()));
     setWindowFlags(Qt::WindowStaysOnTopHint | Qt::FramelessWindowHint |
@@ -97,6 +103,18 @@ void PinWidget::closePin()
 {
     update();
     close();
+}
+
+void PinWidget::closeEvent(QCloseEvent* event)
+{
+    QString screenName;
+    if (QWindow* handle = windowHandle()) {
+        if (QScreen* screen = handle->screen()) {
+            screenName = screen->name();
+        }
+    }
+    emit dismissed(m_pixmap, geometry(), m_scaleFactor, m_opacity, screenName);
+    QWidget::closeEvent(event);
 }
 bool PinWidget::scrollEvent(QWheelEvent* event)
 {

--- a/src/tools/pin/pinwidget.h
+++ b/src/tools/pin/pinwidget.h
@@ -10,6 +10,7 @@ class QVBoxLayout;
 class QGestureEvent;
 class QPinchGesture;
 class QGraphicsDropShadowEffect;
+class QCloseEvent;
 
 class PinWidget : public QWidget
 {
@@ -17,7 +18,16 @@ class PinWidget : public QWidget
 public:
     explicit PinWidget(const QPixmap& pixmap,
                        const QRect& geometry,
-                       QWidget* parent = nullptr);
+                       QWidget* parent = nullptr,
+                       qreal zoom = 1.0,
+                       qreal opacity = 1.0);
+
+signals:
+    void dismissed(const QPixmap& pixmap,
+                   const QRect& geometry,
+                   qreal zoom,
+                   qreal opacity,
+                   const QString& screenName);
 
 protected:
     void mouseDoubleClickEvent(QMouseEvent*) override;
@@ -26,6 +36,7 @@ protected:
     void keyPressEvent(QKeyEvent*) override;
     void enterEvent(QEnterEvent*) override;
     void leaveEvent(QEvent*) override;
+    void closeEvent(QCloseEvent*) override;
 
     bool event(QEvent* event) override;
     void paintEvent(QPaintEvent* event) override;
@@ -49,11 +60,11 @@ private:
     QColor m_baseColor, m_hoverColor;
 
     bool m_expanding{ false };
-    qreal m_scaleFactor{ 1 };
-    qreal m_opacity{ 1 };
+    qreal m_scaleFactor;
+    qreal m_opacity;
     unsigned int m_rotateFactor{ 0 };
     qreal m_currentStepScaleFactor{ 1 };
-    bool m_sizeChanged{ false };
+    bool m_sizeChanged;
 
 private slots:
     void showContextMenu(const QPoint& pos);

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -7,6 +7,9 @@ target_sources(
           systemnotification.h
           valuehandler.h
           strfparse.h
+          pinhistoryentry.h
+          pinhistorystore.h
+          pinhistorymanager.h
 )
 
 target_sources(
@@ -26,6 +29,9 @@ target_sources(
           colorutils.cpp
           history.cpp
           strfparse.cpp
+          pinhistoryentry.cpp
+          pinhistorystore.cpp
+          pinhistorymanager.cpp
 )
 
 IF (UNIX AND NOT APPLE)

--- a/src/utils/confighandler.cpp
+++ b/src/utils/confighandler.cpp
@@ -55,15 +55,12 @@ bool verifyLaunchFile()
  *             misbehave.
  */
 #define OPTION(KEY, TYPE)                                                      \
-    {                                                                          \
-        QStringLiteral(KEY), QSharedPointer<ValueHandler>(new TYPE)            \
-    }
+    { QStringLiteral(KEY), QSharedPointer<ValueHandler>(new TYPE) }
 
 #define SHORTCUT(NAME, DEFAULT_VALUE)                                          \
-    {                                                                          \
-        QStringLiteral(NAME), QSharedPointer<KeySequence>(new KeySequence(     \
-                                QKeySequence(QLatin1String(DEFAULT_VALUE))))   \
-    }
+    { QStringLiteral(NAME),                                                    \
+      QSharedPointer<KeySequence>(                                             \
+        new KeySequence(QKeySequence(QLatin1String(DEFAULT_VALUE)))) }
 
 /**
  * This map contains all the information that is needed to parse, verify and
@@ -101,6 +98,9 @@ static QMap<class QString, QSharedPointer<ValueHandler>>
     OPTION("saveAsFileExtension"         ,SaveFileExtension  (               )),
     OPTION("saveLastRegion"              ,Bool               ( false         )),
     OPTION("uploadHistoryMax"            ,LowerBoundedInt    ( 0, 25         )),
+    OPTION("pinHistoryEnabled"           ,Bool               ( true          )),
+    OPTION("pinHistoryMaxEntries"        ,BoundedInt         ( 1, 1000, 50   )),
+    OPTION("pinHistoryMaxAgeDays"        ,LowerBoundedInt    ( 0, 30         )),
     OPTION("undoLimit"                   ,BoundedInt         ( 0, 999, 100   )),
     // Interface tab
     OPTION("uiLanguage"                  ,String             ( "auto"        )),
@@ -230,7 +230,7 @@ ConfigHandler::ConfigHandler()
         QObject::connect(m_configWatcher.data(),
                          &QFileSystemWatcher::fileChanged,
                          [](const QString& fileName) {
-                             emit getInstance()->fileChanged();
+                             emit getInstance() -> fileChanged();
 
                              if (QFile(fileName).exists()) {
                                  m_configWatcher->addPath(fileName);
@@ -730,12 +730,12 @@ void ConfigHandler::setErrorState(bool error) const
     if (!hadError && m_hasError) {
         QString msg = errorMessage();
         AbstractLogger::error() << msg;
-        emit getInstance()->error();
+        emit getInstance() -> error();
     } else if (hadError && !m_hasError) {
         auto msg =
           tr("You have successfully resolved the configuration error.");
         AbstractLogger::info() << msg;
-        emit getInstance()->errorResolved();
+        emit getInstance() -> errorResolved();
     }
 }
 

--- a/src/utils/confighandler.h
+++ b/src/utils/confighandler.h
@@ -115,6 +115,9 @@ public:
                          setHistoryConfirmationToDelete,
                          bool)
     CONFIG_GETTER_SETTER(uploadHistoryMax, setUploadHistoryMax, int)
+    CONFIG_GETTER_SETTER(pinHistoryEnabled, setPinHistoryEnabled, bool)
+    CONFIG_GETTER_SETTER(pinHistoryMaxEntries, setPinHistoryMaxEntries, int)
+    CONFIG_GETTER_SETTER(pinHistoryMaxAgeDays, setPinHistoryMaxAgeDays, int)
     CONFIG_GETTER_SETTER(saveAfterCopy, setSaveAfterCopy, bool)
     CONFIG_GETTER_SETTER(copyPathAfterSave, setCopyPathAfterSave, bool)
     CONFIG_GETTER_SETTER(saveAsFileExtension, setSaveAsFileExtension, QString)

--- a/src/utils/pinhistoryentry.cpp
+++ b/src/utils/pinhistoryentry.cpp
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Manuel Martins & Contributors
+
+#include "pinhistoryentry.h"
+
+#include <QJsonObject>
+
+QJsonObject PinHistoryEntry::toJson() const
+{
+    QJsonObject geom;
+    geom.insert(QStringLiteral("x"), geometry.x());
+    geom.insert(QStringLiteral("y"), geometry.y());
+    geom.insert(QStringLiteral("w"), geometry.width());
+    geom.insert(QStringLiteral("h"), geometry.height());
+
+    QJsonObject obj;
+    obj.insert(QStringLiteral("id"), id);
+    obj.insert(QStringLiteral("pixmap"), pixmapFile);
+    obj.insert(QStringLiteral("thumb"), thumbFile);
+    obj.insert(QStringLiteral("createdAt"),
+               createdAt.toUTC().toString(Qt::ISODate));
+    obj.insert(QStringLiteral("dismissedAt"),
+               dismissedAt.toUTC().toString(Qt::ISODate));
+    obj.insert(QStringLiteral("geometry"), geom);
+    obj.insert(QStringLiteral("screen"), screenName);
+    obj.insert(QStringLiteral("zoom"), zoom);
+    obj.insert(QStringLiteral("rotation"), rotation);
+    obj.insert(QStringLiteral("opacity"), opacity);
+    obj.insert(QStringLiteral("width"), width);
+    obj.insert(QStringLiteral("height"), height);
+    return obj;
+}
+
+PinHistoryEntry PinHistoryEntry::fromJson(const QJsonObject& obj)
+{
+    PinHistoryEntry e;
+    e.id = obj.value(QStringLiteral("id")).toString();
+    e.pixmapFile = obj.value(QStringLiteral("pixmap")).toString();
+    e.thumbFile = obj.value(QStringLiteral("thumb")).toString();
+    e.createdAt = QDateTime::fromString(
+      obj.value(QStringLiteral("createdAt")).toString(), Qt::ISODate);
+    e.dismissedAt = QDateTime::fromString(
+      obj.value(QStringLiteral("dismissedAt")).toString(), Qt::ISODate);
+
+    const QJsonObject geom = obj.value(QStringLiteral("geometry")).toObject();
+    e.geometry = QRect(geom.value(QStringLiteral("x")).toInt(),
+                       geom.value(QStringLiteral("y")).toInt(),
+                       geom.value(QStringLiteral("w")).toInt(),
+                       geom.value(QStringLiteral("h")).toInt());
+
+    e.screenName = obj.value(QStringLiteral("screen")).toString();
+    e.zoom = obj.value(QStringLiteral("zoom")).toDouble(1.0);
+    e.rotation = obj.value(QStringLiteral("rotation")).toInt(0);
+    e.opacity = obj.value(QStringLiteral("opacity")).toDouble(1.0);
+    e.width = obj.value(QStringLiteral("width")).toInt();
+    e.height = obj.value(QStringLiteral("height")).toInt();
+    return e;
+}

--- a/src/utils/pinhistoryentry.h
+++ b/src/utils/pinhistoryentry.h
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Manuel Martins & Contributors
+
+#pragma once
+
+#include <QDateTime>
+#include <QJsonObject>
+#include <QRect>
+#include <QString>
+
+struct PinHistoryEntry
+{
+    QString id;
+    QString pixmapFile;
+    QString thumbFile;
+    QDateTime createdAt;
+    QDateTime dismissedAt;
+    QRect geometry;
+    QString screenName;
+    qreal zoom{ 1.0 };
+    int rotation{ 0 };
+    qreal opacity{ 1.0 };
+    int width{ 0 };
+    int height{ 0 };
+
+    bool isValid() const { return !id.isEmpty() && !pixmapFile.isEmpty(); }
+
+    QJsonObject toJson() const;
+    static PinHistoryEntry fromJson(const QJsonObject& obj);
+};

--- a/src/utils/pinhistorymanager.cpp
+++ b/src/utils/pinhistorymanager.cpp
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Manuel Martins & Contributors
+
+#include "pinhistorymanager.h"
+
+#include "abstractlogger.h"
+#include "confighandler.h"
+#include "core/flameshotdaemon.h"
+
+#include <QApplication>
+#include <QDateTime>
+#include <QPixmap>
+#include <QScreen>
+
+PinHistoryManager::PinHistoryManager(QObject* parent)
+  : QObject(parent)
+{
+    if (!m_store.isAvailable()) {
+        AbstractLogger::warning() << QStringLiteral(
+          "Pin history disabled for this session: storage path unavailable.");
+        return;
+    }
+    applyRetention();
+}
+
+bool PinHistoryManager::isEnabled() const
+{
+    if (!m_store.isAvailable()) {
+        return false;
+    }
+    return ConfigHandler().pinHistoryEnabled();
+}
+
+void PinHistoryManager::applyRetention()
+{
+    ConfigHandler cfg;
+    m_store.applyRetention(cfg.pinHistoryMaxEntries(),
+                           cfg.pinHistoryMaxAgeDays());
+}
+
+void PinHistoryManager::recordDismissal(const QPixmap& pixmap,
+                                        const QRect& geometry,
+                                        qreal zoom,
+                                        qreal opacity,
+                                        const QString& screenName)
+{
+    if (!isEnabled() || pixmap.isNull()) {
+        return;
+    }
+    PinHistoryEntry entry;
+    entry.geometry = geometry;
+    entry.screenName = screenName;
+    entry.zoom = zoom;
+    entry.opacity = opacity;
+    entry.dismissedAt = QDateTime::currentDateTimeUtc();
+    entry.createdAt = entry.dismissedAt;
+
+    if (!m_store.insert(pixmap, entry)) {
+        if (FlameshotDaemon* daemon = FlameshotDaemon::instance()) {
+            daemon->sendTrayNotification(
+              tr("Failed to save pin to history. Check available disk space."),
+              QStringLiteral("Flameshot"));
+        }
+        return;
+    }
+    applyRetention();
+    emit changed();
+}
+
+bool PinHistoryManager::restore(const QString& id)
+{
+    const PinHistoryEntry entry = m_store.entry(id);
+    if (!entry.isValid()) {
+        return false;
+    }
+    const QPixmap pixmap = m_store.loadPixmap(id);
+    if (pixmap.isNull()) {
+        return false;
+    }
+
+    QRect target = entry.geometry;
+    QScreen* targetScreen = nullptr;
+    if (!entry.screenName.isEmpty()) {
+        for (QScreen* s : QGuiApplication::screens()) {
+            if (s->name() == entry.screenName) {
+                targetScreen = s;
+                break;
+            }
+        }
+    }
+    if (!targetScreen) {
+        targetScreen = QGuiApplication::primaryScreen();
+        if (targetScreen) {
+            const QRect screenGeom = targetScreen->availableGeometry();
+            target.moveCenter(screenGeom.center());
+        }
+    } else {
+        target = target.intersected(targetScreen->geometry());
+        if (target.isEmpty()) {
+            target = entry.geometry;
+            target.moveCenter(targetScreen->availableGeometry().center());
+        }
+    }
+
+    FlameshotDaemon* daemon = FlameshotDaemon::instance();
+    if (!daemon) {
+        return false;
+    }
+    daemon->attachPin(pixmap, target, entry.zoom, entry.opacity);
+    return true;
+}

--- a/src/utils/pinhistorymanager.h
+++ b/src/utils/pinhistorymanager.h
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Manuel Martins & Contributors
+
+#pragma once
+
+#include "pinhistorystore.h"
+
+#include <QObject>
+
+class PinHistoryManager : public QObject
+{
+    Q_OBJECT
+public:
+    explicit PinHistoryManager(QObject* parent = nullptr);
+
+    bool isEnabled() const;
+    PinHistoryStore* store() { return &m_store; }
+    const PinHistoryStore* store() const { return &m_store; }
+
+    QList<PinHistoryEntry> entries() const { return m_store.entries(); }
+    void applyRetention();
+
+public slots:
+    void recordDismissal(const QPixmap& pixmap,
+                         const QRect& geometry,
+                         qreal zoom,
+                         qreal opacity,
+                         const QString& screenName);
+    bool restore(const QString& id);
+
+signals:
+    void changed();
+
+private:
+    PinHistoryStore m_store;
+};

--- a/src/utils/pinhistorystore.cpp
+++ b/src/utils/pinhistorystore.cpp
@@ -1,0 +1,373 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Manuel Martins & Contributors
+
+#include "pinhistorystore.h"
+
+#include "abstractlogger.h"
+
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QProcessEnvironment>
+#include <QSaveFile>
+#include <QUuid>
+#include <algorithm>
+
+namespace {
+
+constexpr int kManifestVersion = 1;
+const QString kManifestFile = QStringLiteral("manifest.json");
+const QString kRecoveredDir = QStringLiteral("recovered");
+
+QString resolveStoragePath()
+{
+#ifdef Q_OS_WIN
+    return QDir::homePath() +
+           QStringLiteral("/AppData/Roaming/flameshot/pin-history/");
+#else
+    const QString cachePath = QProcessEnvironment::systemEnvironment().value(
+      QStringLiteral("XDG_CACHE_HOME"),
+      QDir::homePath() + QStringLiteral("/.cache"));
+    return cachePath + QStringLiteral("/flameshot/pin-history/");
+#endif
+}
+
+QString makePixmapFileName(const QString& id)
+{
+    return id + QStringLiteral(".png");
+}
+
+} // namespace
+
+PinHistoryStore::PinHistoryStore()
+  : m_path(resolveStoragePath())
+  , m_manifestPath(m_path + kManifestFile)
+{
+    if (!ensureDirectory()) {
+        m_available = false;
+        return;
+    }
+    m_available = true;
+
+    if (!readManifest()) {
+        AbstractLogger::warning() << QStringLiteral(
+          "Pin history manifest unreadable, rebuilding from directory scan.");
+        rebuildFromScan();
+    }
+    sortByDismissedDesc();
+}
+
+bool PinHistoryStore::ensureDirectory()
+{
+    QDir dir(m_path);
+    if (!dir.exists() && !dir.mkpath(QStringLiteral("."))) {
+        AbstractLogger::warning()
+          << QStringLiteral("Pin history: unable to create directory at ")
+          << m_path;
+        return false;
+    }
+    const QFileInfo info(m_path);
+    if (!info.isWritable()) {
+        AbstractLogger::warning()
+          << QStringLiteral("Pin history: storage path is not writable: ")
+          << m_path;
+        return false;
+    }
+    return true;
+}
+
+bool PinHistoryStore::insert(const QPixmap& pixmap, PinHistoryEntry entry)
+{
+    if (!m_available || pixmap.isNull()) {
+        return false;
+    }
+    if (entry.id.isEmpty()) {
+        entry.id = QUuid::createUuid().toString(QUuid::WithoutBraces);
+    }
+    entry.pixmapFile = makePixmapFileName(entry.id);
+    entry.width = pixmap.width();
+    entry.height = pixmap.height();
+    if (!entry.dismissedAt.isValid()) {
+        entry.dismissedAt = QDateTime::currentDateTimeUtc();
+    }
+    if (!entry.createdAt.isValid()) {
+        entry.createdAt = entry.dismissedAt;
+    }
+
+    const QString pixmapPath = m_path + entry.pixmapFile;
+    QSaveFile file(pixmapPath);
+    if (!file.open(QIODevice::WriteOnly)) {
+        AbstractLogger::warning()
+          << QStringLiteral("Pin history: failed to open pixmap for write: ")
+          << pixmapPath;
+        return false;
+    }
+    if (!pixmap.save(&file, "PNG") || !file.commit()) {
+        AbstractLogger::warning()
+          << QStringLiteral("Pin history: failed to save pixmap at ")
+          << pixmapPath;
+        return false;
+    }
+
+    m_entries.prepend(entry);
+    sortByDismissedDesc();
+
+    if (!writeManifest()) {
+        return false;
+    }
+    return true;
+}
+
+PinHistoryEntry PinHistoryStore::entry(const QString& id) const
+{
+    for (const auto& e : m_entries) {
+        if (e.id == id) {
+            return e;
+        }
+    }
+    return {};
+}
+
+QPixmap PinHistoryStore::loadPixmap(const QString& id) const
+{
+    const PinHistoryEntry e = entry(id);
+    if (!e.isValid()) {
+        return {};
+    }
+    QPixmap p;
+    p.load(m_path + e.pixmapFile);
+    return p;
+}
+
+bool PinHistoryStore::updateThumbFile(const QString& id,
+                                      const QString& thumbFile)
+{
+    for (auto& e : m_entries) {
+        if (e.id == id) {
+            e.thumbFile = thumbFile;
+            return writeManifest();
+        }
+    }
+    return false;
+}
+
+bool PinHistoryStore::remove(const QString& id)
+{
+    for (int i = 0; i < m_entries.size(); ++i) {
+        if (m_entries[i].id != id) {
+            continue;
+        }
+        const PinHistoryEntry e = m_entries.takeAt(i);
+        QFile::remove(m_path + e.pixmapFile);
+        if (!e.thumbFile.isEmpty()) {
+            QFile::remove(m_path + e.thumbFile);
+        }
+        return writeManifest();
+    }
+    return false;
+}
+
+bool PinHistoryStore::removeMany(const QList<QString>& ids)
+{
+    if (ids.isEmpty()) {
+        return true;
+    }
+    const QSet<QString> idSet(ids.begin(), ids.end());
+    QMutableListIterator<PinHistoryEntry> it(m_entries);
+    while (it.hasNext()) {
+        const PinHistoryEntry& e = it.next();
+        if (!idSet.contains(e.id)) {
+            continue;
+        }
+        QFile::remove(m_path + e.pixmapFile);
+        if (!e.thumbFile.isEmpty()) {
+            QFile::remove(m_path + e.thumbFile);
+        }
+        it.remove();
+    }
+    return writeManifest();
+}
+
+void PinHistoryStore::clear()
+{
+    for (const auto& e : m_entries) {
+        QFile::remove(m_path + e.pixmapFile);
+        if (!e.thumbFile.isEmpty()) {
+            QFile::remove(m_path + e.thumbFile);
+        }
+    }
+    m_entries.clear();
+    writeManifest();
+}
+
+qint64 PinHistoryStore::diskUsage() const
+{
+    qint64 total = 0;
+    for (const auto& e : m_entries) {
+        total += QFileInfo(m_path + e.pixmapFile).size();
+        if (!e.thumbFile.isEmpty()) {
+            total += QFileInfo(m_path + e.thumbFile).size();
+        }
+    }
+    total += QFileInfo(m_manifestPath).size();
+    return total;
+}
+
+void PinHistoryStore::applyRetention(int maxEntries, int maxAgeDays)
+{
+    bool dirty = false;
+    if (maxAgeDays > 0) {
+        const QDateTime cutoff =
+          QDateTime::currentDateTimeUtc().addDays(-maxAgeDays);
+        QMutableListIterator<PinHistoryEntry> it(m_entries);
+        while (it.hasNext()) {
+            const PinHistoryEntry& e = it.next();
+            if (e.dismissedAt.isValid() && e.dismissedAt < cutoff) {
+                QFile::remove(m_path + e.pixmapFile);
+                if (!e.thumbFile.isEmpty()) {
+                    QFile::remove(m_path + e.thumbFile);
+                }
+                it.remove();
+                dirty = true;
+            }
+        }
+    }
+    if (maxEntries > 0 && m_entries.size() > maxEntries) {
+        sortByDismissedDesc();
+        while (m_entries.size() > maxEntries) {
+            const PinHistoryEntry e = m_entries.takeLast();
+            QFile::remove(m_path + e.pixmapFile);
+            if (!e.thumbFile.isEmpty()) {
+                QFile::remove(m_path + e.thumbFile);
+            }
+            dirty = true;
+        }
+    }
+    if (dirty) {
+        writeManifest();
+    }
+}
+
+bool PinHistoryStore::writeManifest()
+{
+    if (!m_available) {
+        return false;
+    }
+    QJsonArray arr;
+    for (const auto& e : m_entries) {
+        arr.append(e.toJson());
+    }
+    QJsonObject root;
+    root.insert(QStringLiteral("version"), kManifestVersion);
+    root.insert(QStringLiteral("entries"), arr);
+
+    QSaveFile file(m_manifestPath);
+    if (!file.open(QIODevice::WriteOnly | QIODevice::Text)) {
+        AbstractLogger::warning()
+          << QStringLiteral("Pin history: failed to open manifest for write.");
+        return false;
+    }
+    const QByteArray data = QJsonDocument(root).toJson(QJsonDocument::Indented);
+    if (file.write(data) != data.size() || !file.commit()) {
+        AbstractLogger::warning()
+          << QStringLiteral("Pin history: failed to commit manifest.");
+        return false;
+    }
+    return true;
+}
+
+bool PinHistoryStore::readManifest()
+{
+    QFile file(m_manifestPath);
+    if (!file.exists()) {
+        m_entries.clear();
+        return true;
+    }
+    if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+        return false;
+    }
+    QJsonParseError err{};
+    const QJsonDocument doc = QJsonDocument::fromJson(file.readAll(), &err);
+    if (err.error != QJsonParseError::NoError || !doc.isObject()) {
+        return false;
+    }
+    const QJsonArray arr =
+      doc.object().value(QStringLiteral("entries")).toArray();
+    m_entries.clear();
+    m_entries.reserve(arr.size());
+    for (const auto& v : arr) {
+        if (!v.isObject()) {
+            continue;
+        }
+        PinHistoryEntry e = PinHistoryEntry::fromJson(v.toObject());
+        if (!e.isValid()) {
+            continue;
+        }
+        if (!QFileInfo::exists(m_path + e.pixmapFile)) {
+            continue; // stale manifest entry, drop silently
+        }
+        m_entries.append(e);
+    }
+    return true;
+}
+
+void PinHistoryStore::rebuildFromScan()
+{
+    m_entries.clear();
+    QDir dir(m_path);
+    const QFileInfoList pngs = dir.entryInfoList(
+      QStringList() << QStringLiteral("*.png"), QDir::Files, QDir::Time);
+
+    const QString recoveredPath = m_path + kRecoveredDir + QStringLiteral("/");
+    bool recoveredDirCreated = false;
+
+    for (const QFileInfo& info : pngs) {
+        const QString base = info.completeBaseName();
+        if (base.endsWith(QStringLiteral("-thumb"))) {
+            continue; // handled via main entry, or orphaned
+        }
+        const QUuid uuid = QUuid::fromString(base);
+        if (uuid.isNull()) {
+            // Unknown file — quarantine rather than delete.
+            if (!recoveredDirCreated) {
+                QDir().mkpath(recoveredPath);
+                recoveredDirCreated = true;
+            }
+            QFile::rename(info.absoluteFilePath(),
+                          recoveredPath + info.fileName());
+            continue;
+        }
+        PinHistoryEntry e;
+        e.id = uuid.toString(QUuid::WithoutBraces);
+        e.pixmapFile = info.fileName();
+        e.createdAt = info.birthTime().toUTC();
+        if (!e.createdAt.isValid()) {
+            e.createdAt = info.lastModified().toUTC();
+        }
+        e.dismissedAt = info.lastModified().toUTC();
+
+        const QString candidateThumb = base + QStringLiteral("-thumb.png");
+        if (QFileInfo::exists(m_path + candidateThumb)) {
+            e.thumbFile = candidateThumb;
+        }
+
+        QPixmap probe(info.absoluteFilePath());
+        if (!probe.isNull()) {
+            e.width = probe.width();
+            e.height = probe.height();
+        }
+        m_entries.append(e);
+    }
+    writeManifest();
+}
+
+void PinHistoryStore::sortByDismissedDesc()
+{
+    std::sort(m_entries.begin(),
+              m_entries.end(),
+              [](const PinHistoryEntry& a, const PinHistoryEntry& b) {
+                  return a.dismissedAt > b.dismissedAt;
+              });
+}

--- a/src/utils/pinhistorystore.h
+++ b/src/utils/pinhistorystore.h
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Manuel Martins & Contributors
+
+#pragma once
+
+#include "pinhistoryentry.h"
+
+#include <QList>
+#include <QPixmap>
+#include <QString>
+
+class PinHistoryStore
+{
+public:
+    PinHistoryStore();
+
+    bool isAvailable() const { return m_available; }
+    const QString& path() const { return m_path; }
+
+    bool insert(const QPixmap& pixmap, PinHistoryEntry entry);
+    QList<PinHistoryEntry> entries() const { return m_entries; }
+    PinHistoryEntry entry(const QString& id) const;
+
+    QPixmap loadPixmap(const QString& id) const;
+    bool updateThumbFile(const QString& id, const QString& thumbFile);
+
+    bool remove(const QString& id);
+    bool removeMany(const QList<QString>& ids);
+    void clear();
+
+    qint64 diskUsage() const;
+
+    void applyRetention(int maxEntries, int maxAgeDays);
+
+private:
+    bool ensureDirectory();
+    bool writeManifest();
+    bool readManifest();
+    void rebuildFromScan();
+    void sortByDismissedDesc();
+
+    QString m_path;
+    QString m_manifestPath;
+    QList<PinHistoryEntry> m_entries;
+    bool m_available{ false };
+};

--- a/src/widgets/CMakeLists.txt
+++ b/src/widgets/CMakeLists.txt
@@ -19,6 +19,8 @@ target_sources(
 
         colorpickerwidget.h
         capture/capturetoolobjects.h
+        pinhistorymodel.h
+        pinhistorydialog.h
 )
 
 if (ENABLE_IMGUR)
@@ -46,6 +48,8 @@ target_sources(
         orientablepushbutton.cpp
         colorpickerwidget.cpp
         capture/capturetoolobjects.cpp
+        pinhistorymodel.cpp
+        pinhistorydialog.cpp
 )
 
 if (ENABLE_IMGUR)

--- a/src/widgets/pinhistorydialog.cpp
+++ b/src/widgets/pinhistorydialog.cpp
@@ -1,0 +1,281 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Manuel Martins & Contributors
+
+#include "pinhistorydialog.h"
+
+#include "pinhistorymodel.h"
+#include "utils/confighandler.h"
+#include "utils/pinhistoryentry.h"
+#include "utils/pinhistorymanager.h"
+#include "utils/pinhistorystore.h"
+
+#include <QAction>
+#include <QApplication>
+#include <QClipboard>
+#include <QDateTime>
+#include <QDesktopServices>
+#include <QFileDialog>
+#include <QKeyEvent>
+#include <QLabel>
+#include <QListView>
+#include <QMenu>
+#include <QMessageBox>
+#include <QToolBar>
+#include <QUrl>
+#include <QVBoxLayout>
+
+namespace {
+constexpr int kTileWidth = 180;
+constexpr int kTileHeight = 180;
+} // namespace
+
+PinHistoryDialog::PinHistoryDialog(PinHistoryManager* manager, QWidget* parent)
+  : QDialog(parent)
+  , m_manager(manager)
+{
+    setWindowTitle(tr("Pin history"));
+    setMinimumSize(800, 500);
+    setAttribute(Qt::WA_DeleteOnClose);
+
+    auto* layout = new QVBoxLayout(this);
+    layout->setContentsMargins(0, 0, 0, 0);
+
+    m_toolbar = new QToolBar(this);
+    m_sortAction = m_toolbar->addAction(tr("Newest first"));
+    m_sortAction->setCheckable(true);
+    m_sortAction->setChecked(true);
+    connect(
+      m_sortAction, &QAction::toggled, this, &PinHistoryDialog::toggleSort);
+
+    m_toolbar->addSeparator();
+    m_clearAction = m_toolbar->addAction(tr("Clear all"));
+    connect(
+      m_clearAction, &QAction::triggered, this, &PinHistoryDialog::clearAll);
+
+    layout->addWidget(m_toolbar);
+
+    m_model = new PinHistoryModel(m_manager->store(), this);
+
+    m_view = new QListView(this);
+    m_view->setModel(m_model);
+    m_view->setViewMode(QListView::IconMode);
+    m_view->setUniformItemSizes(true);
+    m_view->setResizeMode(QListView::Adjust);
+    m_view->setMovement(QListView::Static);
+    m_view->setGridSize(QSize(kTileWidth, kTileHeight));
+    m_view->setIconSize(QSize(164, 120));
+    m_view->setSelectionMode(QAbstractItemView::ExtendedSelection);
+    m_view->setWordWrap(true);
+    m_view->setContextMenuPolicy(Qt::CustomContextMenu);
+    connect(m_view,
+            &QListView::customContextMenuRequested,
+            this,
+            &PinHistoryDialog::onContextMenu);
+    connect(m_view,
+            &QListView::doubleClicked,
+            this,
+            [this](const QModelIndex&) { restoreSelected(); });
+
+    layout->addWidget(m_view);
+
+    m_emptyLabel =
+      new QLabel(tr("No pins yet. Dismissed pins will appear here."), this);
+    m_emptyLabel->setAlignment(Qt::AlignCenter);
+    m_emptyLabel->setEnabled(false);
+    layout->addWidget(m_emptyLabel);
+
+    connect(
+      m_manager, &PinHistoryManager::changed, this, &PinHistoryDialog::refresh);
+
+    m_manager->applyRetention();
+    m_model->refresh();
+    updateEmptyState();
+}
+
+void PinHistoryDialog::refresh()
+{
+    m_model->refresh();
+    updateEmptyState();
+}
+
+void PinHistoryDialog::updateEmptyState()
+{
+    const bool empty = m_model->rowCount() == 0;
+    m_view->setVisible(!empty);
+    m_emptyLabel->setVisible(empty);
+    m_clearAction->setEnabled(!empty);
+}
+
+QStringList PinHistoryDialog::selectedIds() const
+{
+    QStringList ids;
+    const QList<PinHistoryEntry> entries =
+      m_model->entriesAt(m_view->selectionModel()->selectedIndexes());
+    ids.reserve(entries.size());
+    for (const auto& e : entries) {
+        ids.append(e.id);
+    }
+    return ids;
+}
+
+void PinHistoryDialog::onContextMenu(const QPoint& pos)
+{
+    const QModelIndex indexAtPos = m_view->indexAt(pos);
+    if (!indexAtPos.isValid()) {
+        return;
+    }
+    if (!m_view->selectionModel()->isSelected(indexAtPos)) {
+        m_view->setCurrentIndex(indexAtPos);
+    }
+    const int selectionCount =
+      m_view->selectionModel()->selectedIndexes().size();
+
+    QMenu menu(this);
+    QAction* restoreAction = menu.addAction(tr("Restore as pin"));
+    QAction* copyAction = menu.addAction(tr("Copy to clipboard"));
+    QAction* saveAction = menu.addAction(tr("Save as…"));
+    QAction* revealAction = menu.addAction(tr("Reveal in file manager"));
+    menu.addSeparator();
+    QAction* removeAction = menu.addAction(tr("Delete"));
+
+    copyAction->setEnabled(selectionCount == 1);
+    restoreAction->setEnabled(selectionCount == 1);
+    saveAction->setEnabled(selectionCount == 1);
+    revealAction->setEnabled(selectionCount == 1);
+
+    QAction* chosen = menu.exec(m_view->viewport()->mapToGlobal(pos));
+    if (chosen == restoreAction) {
+        restoreSelected();
+    } else if (chosen == copyAction) {
+        copySelected();
+    } else if (chosen == saveAction) {
+        saveSelected();
+    } else if (chosen == revealAction) {
+        revealSelected();
+    } else if (chosen == removeAction) {
+        removeSelected();
+    }
+}
+
+void PinHistoryDialog::restoreSelected()
+{
+    const QStringList ids = selectedIds();
+    if (ids.size() != 1) {
+        return;
+    }
+    m_manager->restore(ids.first());
+}
+
+void PinHistoryDialog::copySelected()
+{
+    const QStringList ids = selectedIds();
+    if (ids.size() != 1) {
+        return;
+    }
+    const QPixmap p = m_manager->store()->loadPixmap(ids.first());
+    if (p.isNull()) {
+        return;
+    }
+    QApplication::clipboard()->setPixmap(p);
+}
+
+void PinHistoryDialog::saveSelected()
+{
+    const QStringList ids = selectedIds();
+    if (ids.size() != 1) {
+        return;
+    }
+    const PinHistoryEntry entry = m_manager->store()->entry(ids.first());
+    if (!entry.isValid()) {
+        return;
+    }
+    const QString defaultName = QStringLiteral("flameshot-pin-%1.png")
+                                  .arg(entry.dismissedAt.toLocalTime().toString(
+                                    QStringLiteral("yyyyMMdd-HHmmss")));
+    const QString path = QFileDialog::getSaveFileName(
+      this,
+      tr("Save pin as…"),
+      defaultName,
+      tr("PNG image (*.png);;JPEG image (*.jpg);;All files (*)"));
+    if (path.isEmpty()) {
+        return;
+    }
+    const QPixmap p = m_manager->store()->loadPixmap(entry.id);
+    if (p.isNull()) {
+        return;
+    }
+    p.save(path);
+}
+
+void PinHistoryDialog::revealSelected()
+{
+    QDesktopServices::openUrl(QUrl::fromLocalFile(m_manager->store()->path()));
+}
+
+void PinHistoryDialog::removeSelected()
+{
+    const QStringList ids = selectedIds();
+    if (ids.isEmpty()) {
+        return;
+    }
+    if (ConfigHandler().historyConfirmationToDelete()) {
+        const QMessageBox::StandardButton answer = QMessageBox::warning(
+          this,
+          tr("Delete pins from history?"),
+          tr("Delete %n pin(s) from history?", "", ids.size()),
+          QMessageBox::Yes | QMessageBox::Cancel,
+          QMessageBox::Cancel);
+        if (answer != QMessageBox::Yes) {
+            return;
+        }
+    }
+    m_manager->store()->removeMany(ids);
+    refresh();
+}
+
+void PinHistoryDialog::clearAll()
+{
+    if (m_model->rowCount() == 0) {
+        return;
+    }
+    const QMessageBox::StandardButton answer = QMessageBox::warning(
+      this,
+      tr("Clear all pins?"),
+      tr("Delete all %n pin(s) from history? This cannot be undone.",
+         "",
+         m_model->rowCount()),
+      QMessageBox::Yes | QMessageBox::Cancel,
+      QMessageBox::Cancel);
+    if (answer != QMessageBox::Yes) {
+        return;
+    }
+    m_manager->store()->clear();
+    refresh();
+}
+
+void PinHistoryDialog::toggleSort()
+{
+    m_model->setNewestFirst(m_sortAction->isChecked());
+    m_sortAction->setText(m_sortAction->isChecked() ? tr("Newest first")
+                                                    : tr("Oldest first"));
+}
+
+void PinHistoryDialog::keyPressEvent(QKeyEvent* event)
+{
+    switch (event->key()) {
+        case Qt::Key_Return:
+        case Qt::Key_Enter:
+            restoreSelected();
+            return;
+        case Qt::Key_Space:
+            copySelected();
+            return;
+        case Qt::Key_Delete:
+        case Qt::Key_Backspace:
+            removeSelected();
+            return;
+        default:
+            break;
+    }
+    QDialog::keyPressEvent(event);
+}

--- a/src/widgets/pinhistorydialog.h
+++ b/src/widgets/pinhistorydialog.h
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Manuel Martins & Contributors
+
+#pragma once
+
+#include <QDialog>
+
+class PinHistoryManager;
+class PinHistoryModel;
+class QAction;
+class QListView;
+class QLabel;
+class QToolBar;
+
+class PinHistoryDialog : public QDialog
+{
+    Q_OBJECT
+public:
+    explicit PinHistoryDialog(PinHistoryManager* manager,
+                              QWidget* parent = nullptr);
+
+protected:
+    void keyPressEvent(QKeyEvent* event) override;
+
+private slots:
+    void onContextMenu(const QPoint& pos);
+    void restoreSelected();
+    void copySelected();
+    void saveSelected();
+    void revealSelected();
+    void removeSelected();
+    void clearAll();
+    void toggleSort();
+    void refresh();
+
+private:
+    QStringList selectedIds() const;
+    void updateEmptyState();
+
+    PinHistoryManager* m_manager;
+    PinHistoryModel* m_model;
+    QListView* m_view;
+    QLabel* m_emptyLabel;
+    QToolBar* m_toolbar;
+    QAction* m_sortAction;
+    QAction* m_clearAction;
+};

--- a/src/widgets/pinhistorymodel.cpp
+++ b/src/widgets/pinhistorymodel.cpp
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Manuel Martins & Contributors
+
+#include "pinhistorymodel.h"
+
+#include "utils/pinhistorystore.h"
+
+#include <QCoreApplication>
+#include <QDateTime>
+#include <QLocale>
+#include <algorithm>
+
+namespace {
+constexpr int kThumbWidth = 164;
+constexpr int kThumbHeight = 120;
+} // namespace
+
+PinHistoryModel::PinHistoryModel(PinHistoryStore* store, QObject* parent)
+  : QAbstractListModel(parent)
+  , m_store(store)
+{
+    refresh();
+}
+
+int PinHistoryModel::rowCount(const QModelIndex& parent) const
+{
+    if (parent.isValid()) {
+        return 0;
+    }
+    return m_rows.size();
+}
+
+QVariant PinHistoryModel::data(const QModelIndex& index, int role) const
+{
+    if (!index.isValid() || index.row() < 0 || index.row() >= m_rows.size()) {
+        return {};
+    }
+    const PinHistoryEntry& e = m_rows[index.row()];
+
+    switch (role) {
+        case Qt::DisplayRole:
+            return QCoreApplication::translate("PinHistoryModel", "%1\n%2 × %3")
+              .arg(formatTimestamp(e.dismissedAt))
+              .arg(e.width)
+              .arg(e.height);
+        case Qt::DecorationRole:
+            return thumbnailFor(e);
+        case Qt::ToolTipRole:
+            return QCoreApplication::translate("PinHistoryModel",
+                                               "Dismissed %1\n%2 × %3 px")
+              .arg(QLocale::system().toString(e.dismissedAt.toLocalTime(),
+                                              QLocale::LongFormat))
+              .arg(e.width)
+              .arg(e.height);
+        case IdRole:
+            return e.id;
+        case DismissedAtRole:
+            return e.dismissedAt;
+        case WidthRole:
+            return e.width;
+        case HeightRole:
+            return e.height;
+        default:
+            return {};
+    }
+}
+
+PinHistoryEntry PinHistoryModel::entryAt(const QModelIndex& index) const
+{
+    if (!index.isValid() || index.row() < 0 || index.row() >= m_rows.size()) {
+        return {};
+    }
+    return m_rows[index.row()];
+}
+
+QList<PinHistoryEntry> PinHistoryModel::entriesAt(
+  const QModelIndexList& indexes) const
+{
+    QList<PinHistoryEntry> out;
+    out.reserve(indexes.size());
+    for (const QModelIndex& i : indexes) {
+        const PinHistoryEntry e = entryAt(i);
+        if (e.isValid()) {
+            out.append(e);
+        }
+    }
+    return out;
+}
+
+void PinHistoryModel::refresh()
+{
+    beginResetModel();
+    m_rows = m_store ? m_store->entries() : QList<PinHistoryEntry>{};
+    std::sort(m_rows.begin(),
+              m_rows.end(),
+              [this](const PinHistoryEntry& a, const PinHistoryEntry& b) {
+                  return m_newestFirst ? a.dismissedAt > b.dismissedAt
+                                       : a.dismissedAt < b.dismissedAt;
+              });
+    // Cleanup stale thumbnail cache entries.
+    QSet<QString> liveIds;
+    liveIds.reserve(m_rows.size());
+    for (const auto& e : m_rows) {
+        liveIds.insert(e.id);
+    }
+    for (auto it = m_thumbCache.begin(); it != m_thumbCache.end();) {
+        if (!liveIds.contains(it.key())) {
+            it = m_thumbCache.erase(it);
+        } else {
+            ++it;
+        }
+    }
+    endResetModel();
+}
+
+void PinHistoryModel::setNewestFirst(bool newestFirst)
+{
+    if (m_newestFirst == newestFirst) {
+        return;
+    }
+    m_newestFirst = newestFirst;
+    refresh();
+}
+
+QPixmap PinHistoryModel::thumbnailFor(const PinHistoryEntry& entry) const
+{
+    if (!m_store) {
+        return {};
+    }
+    auto it = m_thumbCache.find(entry.id);
+    if (it != m_thumbCache.end()) {
+        return it.value();
+    }
+    const QPixmap full = m_store->loadPixmap(entry.id);
+    if (full.isNull()) {
+        return {};
+    }
+    const QPixmap thumb = full.scaled(
+      kThumbWidth, kThumbHeight, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+    m_thumbCache.insert(entry.id, thumb);
+    return thumb;
+}
+
+QString PinHistoryModel::formatTimestamp(const QDateTime& dt)
+{
+    if (!dt.isValid()) {
+        return {};
+    }
+    const QDateTime local = dt.toLocalTime();
+    const QDate today = QDate::currentDate();
+    const QLocale locale = QLocale::system();
+    if (local.date() == today) {
+        return QCoreApplication::translate("PinHistoryModel", "Today %1")
+          .arg(locale.toString(local.time(), QLocale::ShortFormat));
+    }
+    if (local.date() == today.addDays(-1)) {
+        return QCoreApplication::translate("PinHistoryModel", "Yesterday %1")
+          .arg(locale.toString(local.time(), QLocale::ShortFormat));
+    }
+    return locale.toString(local, QLocale::ShortFormat);
+}

--- a/src/widgets/pinhistorymodel.h
+++ b/src/widgets/pinhistorymodel.h
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Manuel Martins & Contributors
+
+#pragma once
+
+#include "utils/pinhistoryentry.h"
+
+#include <QAbstractListModel>
+#include <QHash>
+#include <QPixmap>
+
+class PinHistoryStore;
+
+class PinHistoryModel : public QAbstractListModel
+{
+    Q_OBJECT
+public:
+    enum Roles
+    {
+        IdRole = Qt::UserRole + 1,
+        DismissedAtRole,
+        WidthRole,
+        HeightRole,
+    };
+
+    explicit PinHistoryModel(PinHistoryStore* store, QObject* parent = nullptr);
+
+    int rowCount(const QModelIndex& parent = {}) const override;
+    QVariant data(const QModelIndex& index,
+                  int role = Qt::DisplayRole) const override;
+
+    PinHistoryEntry entryAt(const QModelIndex& index) const;
+    QList<PinHistoryEntry> entriesAt(const QModelIndexList& indexes) const;
+
+    void refresh();
+    void setNewestFirst(bool newestFirst);
+    bool newestFirst() const { return m_newestFirst; }
+
+private:
+    QPixmap thumbnailFor(const PinHistoryEntry& entry) const;
+    static QString formatTimestamp(const QDateTime& dt);
+
+    PinHistoryStore* m_store;
+    QList<PinHistoryEntry> m_rows;
+    mutable QHash<QString, QPixmap> m_thumbCache;
+    bool m_newestFirst{ true };
+};

--- a/src/widgets/trayicon.cpp
+++ b/src/widgets/trayicon.cpp
@@ -5,9 +5,13 @@
 #include "core/qguiappcurrentscreen.h"
 #include "utils/confighandler.h"
 #include "utils/globalvalues.h"
+#include "utils/pinhistoryentry.h"
+#include "utils/pinhistorymanager.h"
 
+#include <QAction>
 #include <QApplication>
 #include <QGuiApplication>
+#include <QLocale>
 #include <QMenu>
 #include <QScreen>
 #include <QTimer>
@@ -21,6 +25,9 @@
 TrayIcon::TrayIcon(QObject* parent)
   : QSystemTrayIcon(parent)
   , m_screenMenu(nullptr)
+  , m_recentPinsMenu(nullptr)
+  , m_recentPinsAction(nullptr)
+  , m_pinHistoryAction(nullptr)
 {
     initMenu();
     initScreenMenu();
@@ -190,6 +197,18 @@ void TrayIcon::initMenu()
             Flameshot::instance(),
             &Flameshot::openSavePath);
 
+    m_pinHistoryAction = new QAction(tr("&Pin history…"), this);
+    connect(m_pinHistoryAction,
+            &QAction::triggered,
+            Flameshot::instance(),
+            &Flameshot::pinHistory);
+
+    m_recentPinsMenu = new QMenu(tr("Recent pins"), m_menu);
+    connect(m_recentPinsMenu,
+            &QMenu::aboutToShow,
+            this,
+            &TrayIcon::rebuildRecentPinsMenu);
+
     m_menu->addAction(m_captureAction);
     m_menu->addAction(m_launcherAction);
     m_menu->addSeparator();
@@ -197,6 +216,8 @@ void TrayIcon::initMenu()
     m_menu->addAction(recentAction);
 #endif
     m_menu->addAction(openSavePathAction);
+    m_menu->addAction(m_pinHistoryAction);
+    m_recentPinsAction = m_menu->addMenu(m_recentPinsMenu);
     m_menu->addSeparator();
     m_menu->addAction(configAction);
     m_menu->addSeparator();
@@ -292,4 +313,47 @@ void TrayIcon::startGuiCaptureOnScreen(int screenIndex)
     CaptureRequest req(CaptureRequest::GRAPHICAL_MODE, 400);
     req.setSelectedMonitor(screenIndex);
     Flameshot::instance()->requestCapture(req);
+}
+
+void TrayIcon::rebuildRecentPinsMenu()
+{
+    m_recentPinsMenu->clear();
+
+    auto* daemon = FlameshotDaemon::instance();
+    PinHistoryManager* manager = daemon ? daemon->pinHistory() : nullptr;
+    const bool enabled = manager && ConfigHandler().pinHistoryEnabled();
+
+    if (!enabled) {
+        if (m_recentPinsAction) {
+            m_recentPinsAction->setVisible(false);
+        }
+        return;
+    }
+
+    const QList<PinHistoryEntry> entries = manager->entries();
+    if (entries.isEmpty()) {
+        if (m_recentPinsAction) {
+            m_recentPinsAction->setVisible(false);
+        }
+        return;
+    }
+
+    if (m_recentPinsAction) {
+        m_recentPinsAction->setVisible(true);
+    }
+
+    constexpr int kMaxRecent = 5;
+    const int limit = std::min<int>(entries.size(), kMaxRecent);
+    for (int i = 0; i < limit; ++i) {
+        const PinHistoryEntry& entry = entries[i];
+        const QString timeLabel = QLocale::system().toString(
+          entry.dismissedAt.toLocalTime().time(), QLocale::ShortFormat);
+        const QString label =
+          tr("%1 · %2×%3").arg(timeLabel).arg(entry.width).arg(entry.height);
+        QAction* action = m_recentPinsMenu->addAction(label);
+        const QString id = entry.id;
+        connect(action, &QAction::triggered, this, [manager, id]() {
+            manager->restore(id);
+        });
+    }
 }

--- a/src/widgets/trayicon.h
+++ b/src/widgets/trayicon.h
@@ -27,10 +27,15 @@ private:
     void startGuiCapture();
     void startGuiCaptureOnScreen(int screenIndex);
 
+    void rebuildRecentPinsMenu();
+
     QMenu* m_menu;
     QMenu* m_screenMenu;
+    QMenu* m_recentPinsMenu;
+    QAction* m_recentPinsAction;
     QAction* m_captureAction;
     QAction* m_launcherAction;
+    QAction* m_pinHistoryAction;
     QAction* m_infoAction;
 #if !defined(DISABLE_UPDATE_CHECKER)
     QAction* m_appUpdates;


### PR DESCRIPTION
Closes #360.

Dismissing a pin was a one-way door. This opens it.

Every close path (Esc, double-click, close button, programmatic close) now funnels through a new `dismissed()` signal from `PinWidget::closeEvent`, writes the full-resolution pixmap plus metadata (geometry, screen name, zoom, opacity, created and dismissed timestamps) to a JSON-indexed store, and makes the entry recoverable from a new Pin History dialog (virtualized `QListView` with lazy thumbnails), a Recent pins tray submenu (top 5, rebuilt on `aboutToShow`), and an explicit `restore()` that routes through `FlameshotDaemon::attachPin` — now public and taking optional zoom and opacity so restored pins reproduce the prior visual state rather than snapping to defaults.

Retention runs on three triggers (startup, every dismissal, dialog open) against both max-entries and max-age, against recorded event timestamps rather than wall-clock deltas, so the retention math tolerates system clock changes.

## What lands

- `src/utils/pinhistory{entry,store,manager}.{h,cpp}` — POD, persistent store (`QSaveFile` atomic writes, rebuild-from-scan that quarantines unknown files under `recovered/` on manifest corruption), and the manager owned by `FlameshotDaemon`.
- `src/config/pinhistoryconf.{h,cpp}` — new `Pin History` configuration tab (enable toggle, max entries 1–1000, max age with preset intervals, storage path label, disk usage, reveal, clear).
- `src/widgets/pinhistory{dialog,model}.{h,cpp}` — the dialog with context menu (Restore / Copy / Save As / Reveal / Delete) and toolbar (Clear all, Sort). Uniform item sizes on the `QListView` give free virtualization.
- Modified: `PinWidget` (new signal + `closeEvent` override + constructor gains optional `zoom`/`opacity` with backward-compatible defaults), `FlameshotDaemon` (`attachPin` public + optional zoom/opacity + manager ownership), `TrayIcon` (`Pin history…` action + `Recent pins` submenu populated on `aboutToShow`), `ConfigHandler` (three new flat keys in `[General]`).

## Verified locally (macOS 15, native dev build)

- [x] AC-1 pin → dismiss → shows in history and Recent pins
- [x] AC-2 persists across app restart
- [x] AC-4 double-click restores at stored geometry
- [x] AC-5 dismissed restore creates a new entry, original untouched
- [x] AC-6 copy-to-clipboard is pixel-exact
- [x] AC-8 / AC-9 delete one / clear all (with confirmation)
- [x] AC-12 disable / re-enable preserves existing entries
- [x] AC-19 disabled feature ≡ current master behavior

## Not yet verified (flagged per spec Appendix A.5)

- [ ] AC-17 Linux X11, Linux Wayland, Windows (author is single-platform)
- [ ] AC-10 max-entries enforcement (scriptable, not run)
- [ ] AC-11 max-age purge (needs a time-freeze harness)
- [ ] AC-14 / AC-15 stress and large-store performance

None are merge blockers. Happy to defer to reviewers with different platforms, or to a hardening pass once maintainers are comfortable with the design.

## Design decisions that deserve a second look

- **Storage path** mirrors `src/utils/history.cpp` (`$XDG_CACHE_HOME/flameshot/pin-history/` on Linux and macOS, `%APPDATA%/flameshot/pin-history/` on Windows). Spec §DM-1 argues for `AppDataLocation` instead, because OS cache cleaners could wipe user-controlled retention. Happy to switch if `history.cpp`'s cache placement is a legacy choice rather than a convention worth extending.
- **Config namespace** — new keys (`pinHistoryEnabled`, `pinHistoryMaxEntries`, `pinHistoryMaxAgeDays`) sit flat in `[General]` next to `uploadHistoryMax` and `historyConfirmationToDelete`. Spec §FR-23 wanted a `[PinHistory]` section; flat won because no existing feature carves its own section.
- **Threading** — writes are synchronous. The project has no existing threading primitives, and a full-res PNG encode on SSD sits well under perceptual thresholds on the dismissal path. `QtConcurrent::run` is the obvious next step if multi-monitor grabs start to show hitches.

## Deferred (spec §12 extensions, additive follow-ups)

FR-14 date-range filter, quicklook-on-hover preview, bulk save-as-ZIP, and a configurable hotkey slot for the dialog. None required for MVP; all additive on top of this landing.

## Translations

All user-visible strings wrapped in `tr()` or `QT_TRANSLATE_NOOP`. `lupdate` not run as part of this PR — recommend folding this into the next Weblate sync.