### PR TITLE
feat: configurable arrow key step size for selection widget

### DIFF
--- a/flameshot.example.ini
+++ b/flameshot.example.ini
@@ -122,6 +122,12 @@
 ;; Set JPEG Quality (int in range 0-100)
 ;jpegQuality=75
 ;
+;; Arrow key step size for moving the selection (int in range 1-200)
+;arrowMoveStep=1
+;
+;; Arrow key step size for resizing the selection (int in range 1-200)
+;arrowResizeStep=1
+;
 ;; Shortcut Settings for all tools
 ;[Shortcuts]
 ;TYPE_ARROW=A

--- a/src/config/generalconf.cpp
+++ b/src/config/generalconf.cpp
@@ -53,6 +53,8 @@ GeneralConf::GeneralConf(QWidget* parent)
     initCopyPathAfterSave();
     initAntialiasingPinZoom();
     initUndoLimit();
+    initArrowMoveStep();
+    initArrowResizeStep();
     initInsecurePixelate();
 #if !defined(Q_OS_MACOS)
     initCaptureActiveMonitor();
@@ -120,6 +122,8 @@ void GeneralConf::_updateComponents(bool allowEmptySavePath)
     m_showQuitPrompt->setChecked(config.showQuitPrompt());
     m_screenshotPathFixedCheck->setChecked(config.savePathFixed());
     m_undoLimit->setValue(config.undoLimit());
+    m_arrowMoveStep->setValue(config.arrowMoveStep());
+    m_arrowResizeStep->setValue(config.arrowResizeStep());
 
     if (allowEmptySavePath || !config.savePath().isEmpty()) {
         m_savePath->setText(config.savePath());
@@ -658,6 +662,68 @@ void GeneralConf::initUndoLimit()
 void GeneralConf::undoLimit(int limit)
 {
     ConfigHandler().setUndoLimit(limit);
+}
+
+void GeneralConf::initArrowMoveStep()
+{
+    auto* box = new QGroupBox(tr("Arrow move step (px)"));
+    box->setFlat(true);
+    m_layout->addWidget(box);
+
+    auto* vboxLayout = new QVBoxLayout();
+    box->setLayout(vboxLayout);
+
+    m_arrowMoveStep = new QSpinBox(this);
+    m_arrowMoveStep->setMinimum(1);
+    m_arrowMoveStep->setMaximum(200);
+    m_arrowMoveStep->setToolTip(
+      tr("Pixels to move the selection per arrow key press"));
+    QString foreground = this->palette().windowText().color().name();
+    m_arrowMoveStep->setStyleSheet(
+      QStringLiteral("color: %1").arg(foreground));
+
+    connect(m_arrowMoveStep,
+            static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged),
+            this,
+            &GeneralConf::arrowMoveStepChanged);
+
+    vboxLayout->addWidget(m_arrowMoveStep);
+}
+
+void GeneralConf::arrowMoveStepChanged(int val)
+{
+    ConfigHandler().setArrowMoveStep(val);
+}
+
+void GeneralConf::initArrowResizeStep()
+{
+    auto* box = new QGroupBox(tr("Arrow resize step (px)"));
+    box->setFlat(true);
+    m_layout->addWidget(box);
+
+    auto* vboxLayout = new QVBoxLayout();
+    box->setLayout(vboxLayout);
+
+    m_arrowResizeStep = new QSpinBox(this);
+    m_arrowResizeStep->setMinimum(1);
+    m_arrowResizeStep->setMaximum(200);
+    m_arrowResizeStep->setToolTip(
+      tr("Pixels to resize the selection per Shift+arrow key press"));
+    QString foreground = this->palette().windowText().color().name();
+    m_arrowResizeStep->setStyleSheet(
+      QStringLiteral("color: %1").arg(foreground));
+
+    connect(m_arrowResizeStep,
+            static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged),
+            this,
+            &GeneralConf::arrowResizeStepChanged);
+
+    vboxLayout->addWidget(m_arrowResizeStep);
+}
+
+void GeneralConf::arrowResizeStepChanged(int val)
+{
+    ConfigHandler().setArrowResizeStep(val);
 }
 
 void GeneralConf::initUseJpgForClipboard()

--- a/src/config/generalconf.h
+++ b/src/config/generalconf.h
@@ -61,6 +61,8 @@ private slots:
     void setJpegQuality(int v);
     void setReverseArrow(bool checked);
     void setInsecurePixelate(bool checked);
+    void arrowMoveStepChanged(int val);
+    void arrowResizeStepChanged(int val);
 #if !defined(Q_OS_MACOS)
     void captureActiveMonitorChanged(bool checked);
 #endif
@@ -108,6 +110,8 @@ private:
     void initJpegQuality();
     void initReverseArrow();
     void initInsecurePixelate();
+    void initArrowMoveStep();
+    void initArrowResizeStep();
 #if !defined(Q_OS_MACOS)
     void initCaptureActiveMonitor();
 #endif
@@ -165,6 +169,8 @@ private:
     QSpinBox* m_jpegQuality;
     QCheckBox* m_reverseArrow;
     QCheckBox* m_insecurePixelate;
+    QSpinBox* m_arrowMoveStep;
+    QSpinBox* m_arrowResizeStep;
 #if !defined(Q_OS_MACOS)
     QCheckBox* m_captureActiveMonitor;
 #endif

--- a/src/utils/confighandler.cpp
+++ b/src/utils/confighandler.cpp
@@ -137,6 +137,9 @@ static QMap<class QString, QSharedPointer<ValueHandler>>
     OPTION("jpegQuality"                 , BoundedInt        ( 0,100,75      )),
     OPTION("reverseArrow"                ,Bool               ( false         )),
     OPTION("insecurePixelate"            ,Bool               ( false         )),
+    // Arrow key step sizes for selection move/resize (pixels per keypress)
+    OPTION("arrowMoveStep"               ,BoundedInt         ( 1, 200, 1    )),
+    OPTION("arrowResizeStep"             ,BoundedInt         ( 1, 200, 1    )),
 #if defined(Q_OS_WIN)
     // Not visible on settings dialog
     OPTION("ignorePrntScrForcesSnipping" ,Bool               ( false         )),

--- a/src/utils/confighandler.h
+++ b/src/utils/confighandler.h
@@ -140,6 +140,8 @@ public:
     CONFIG_GETTER_SETTER(jpegQuality, setJpegQuality, int)
     CONFIG_GETTER_SETTER(reverseArrow, setReverseArrow, bool)
     CONFIG_GETTER_SETTER(insecurePixelate, setInsecurePixelate, bool)
+    CONFIG_GETTER_SETTER(arrowMoveStep, setArrowMoveStep, int)
+    CONFIG_GETTER_SETTER(arrowResizeStep, setArrowResizeStep, int)
     CONFIG_GETTER_SETTER(showSelectionGeometryHideTime,
                          showSelectionGeometryHideTime,
                          int)

--- a/src/widgets/capture/selectionwidget.cpp
+++ b/src/widgets/capture/selectionwidget.cpp
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: 2017-2019 Alejandro Sirgo Rica & Contributors
 
 #include "selectionwidget.h"
+#include "utils/confighandler.h"
 #include "utils/globalvalues.h"
 #include "widgets/capture/capturetoolbutton.h"
 
@@ -20,6 +21,8 @@ SelectionWidget::SelectionWidget(QColor c, QWidget* parent)
   , m_color(std::move(c))
   , m_activeSide(NO_SIDE)
   , m_ignoreMouse(false)
+  , m_moveStep(ConfigHandler().arrowMoveStep())
+  , m_resizeStep(ConfigHandler().arrowResizeStep())
 {
     // prevents this widget from consuming CaptureToolButton mouse events
     setAttribute(Qt::WA_TransparentForMouseEvents);
@@ -425,62 +428,74 @@ void SelectionWidget::updateColor(const QColor& c)
 
 void SelectionWidget::moveLeft()
 {
-    setGeometryByKeyboard(geometry().adjusted(-1, 0, -1, 0));
+    setGeometryByKeyboard(
+      geometry().adjusted(-m_moveStep, 0, -m_moveStep, 0));
 }
 
 void SelectionWidget::moveRight()
 {
-    setGeometryByKeyboard(geometry().adjusted(1, 0, 1, 0));
+    setGeometryByKeyboard(
+      geometry().adjusted(m_moveStep, 0, m_moveStep, 0));
 }
 
 void SelectionWidget::moveUp()
 {
-    setGeometryByKeyboard(geometry().adjusted(0, -1, 0, -1));
+    setGeometryByKeyboard(
+      geometry().adjusted(0, -m_moveStep, 0, -m_moveStep));
 }
 
 void SelectionWidget::moveDown()
 {
-    setGeometryByKeyboard(geometry().adjusted(0, 1, 0, 1));
+    setGeometryByKeyboard(
+      geometry().adjusted(0, m_moveStep, 0, m_moveStep));
 }
 
 void SelectionWidget::resizeLeft()
 {
-    setGeometryByKeyboard(geometry().adjusted(0, 0, -1, 0));
+    setGeometryByKeyboard(
+      geometry().adjusted(0, 0, -m_resizeStep, 0));
 }
 
 void SelectionWidget::resizeRight()
 {
-    setGeometryByKeyboard(geometry().adjusted(0, 0, 1, 0));
+    setGeometryByKeyboard(
+      geometry().adjusted(0, 0, m_resizeStep, 0));
 }
 
 void SelectionWidget::resizeUp()
 {
-    setGeometryByKeyboard(geometry().adjusted(0, 0, 0, -1));
+    setGeometryByKeyboard(
+      geometry().adjusted(0, 0, 0, -m_resizeStep));
 }
 
 void SelectionWidget::resizeDown()
 {
-    setGeometryByKeyboard(geometry().adjusted(0, 0, 0, 1));
+    setGeometryByKeyboard(
+      geometry().adjusted(0, 0, 0, m_resizeStep));
 }
 
 void SelectionWidget::symResizeLeft()
 {
-    setGeometryByKeyboard(geometry().adjusted(1, 0, -1, 0));
+    setGeometryByKeyboard(
+      geometry().adjusted(m_resizeStep, 0, -m_resizeStep, 0));
 }
 
 void SelectionWidget::symResizeRight()
 {
-    setGeometryByKeyboard(geometry().adjusted(-1, 0, 1, 0));
+    setGeometryByKeyboard(
+      geometry().adjusted(-m_resizeStep, 0, m_resizeStep, 0));
 }
 
 void SelectionWidget::symResizeUp()
 {
-    setGeometryByKeyboard(geometry().adjusted(0, -1, 0, 1));
+    setGeometryByKeyboard(
+      geometry().adjusted(0, -m_resizeStep, 0, m_resizeStep));
 }
 
 void SelectionWidget::symResizeDown()
 {
-    setGeometryByKeyboard(geometry().adjusted(0, 1, 0, -1));
+    setGeometryByKeyboard(
+      geometry().adjusted(0, m_resizeStep, 0, -m_resizeStep));
 }
 
 void SelectionWidget::updateAreas()

--- a/src/widgets/capture/selectionwidget.h
+++ b/src/widgets/capture/selectionwidget.h
@@ -103,4 +103,7 @@ private:
 
     QRect m_TLArea, m_TRArea, m_BLArea, m_BRArea;
     QRect m_LArea, m_TArea, m_RArea, m_BArea;
+
+    int m_moveStep;
+    int m_resizeStep;
 };


### PR DESCRIPTION
## Summary

- Adds two new config keys (`arrowMoveStep` and `arrowResizeStep`) that control how many pixels each arrow key press moves/resizes the selection
- Both exposed in the GUI settings (General tab) as spinboxes with range 1-200
- Default value of `1` preserves existing behavior — fully backwards compatible

## Motivation

The selection widget currently uses hardcoded 1px steps for arrow key movement and resizing. On modern high-resolution displays, this makes keyboard-driven region selection impractical — you'd need hundreds of key presses to move a selection across the screen.

This addresses the keyboard-only workflow requested in #3570. While it doesn't add full keyboard-only region creation, it makes the arrow key adjustment significantly more usable by letting users configure their preferred step size.

## Changes

| File | Change |
|------|--------|
| `src/utils/confighandler.cpp` | Register `arrowMoveStep` and `arrowResizeStep` as `BoundedInt(1, 200, 1)` |
| `src/utils/confighandler.h` | Add getter/setter macros |
| `src/widgets/capture/selectionwidget.h` | Add `m_moveStep` and `m_resizeStep` members |
| `src/widgets/capture/selectionwidget.cpp` | Load step sizes from config, use in all 12 move/resize/symResize methods |
| `src/config/generalconf.h` | Declare spinbox widgets and slots |
| `src/config/generalconf.cpp` | Add spinbox UI in General tab with tooltips |
| `flameshot.example.ini` | Document new keys |

## Usage

In `flameshot.ini`:
```ini
[General]
arrowMoveStep=10
arrowResizeStep=5
```

Or via the GUI: Settings → General → "Arrow move step (px)" / "Arrow resize step (px)"

## Test plan

- [ ] Default values (1) preserve existing 1px behavior
- [ ] Setting `arrowMoveStep=10` makes arrow keys move selection by 10px
- [ ] Setting `arrowResizeStep=20` makes Shift+arrow resize by 20px
- [ ] GUI spinboxes read and write values correctly
- [ ] Values persist across restarts
- [ ] Boundary clamping works (selection doesn't go off-screen)
- [ ] Minimum selection size (1x1) is still enforced

Closes #3570