### PR TITLE
screengrabber: pass non-empty parent_window to xdg-desktop-portal

### DIFF
--- a/src/utils/screengrabber.cpp
+++ b/src/utils/screengrabber.cpp
@@ -126,8 +126,8 @@ void ScreenGrabber::freeDesktopPortal(bool& ok, QPixmap& res)
     if (QGuiApplication::platformName() == QLatin1String("wayland")) {
         parentWindow = QStringLiteral("wayland:");
     } else {
-        parentWindow = QStringLiteral("x11:0x%1")
-                         .arg(parentDummy.winId(), 0, 16);
+        parentWindow =
+          QStringLiteral("x11:0x%1").arg(parentDummy.winId(), 0, 16);
     }
 
     screenshotInterface.call(

--- a/src/utils/screengrabber.cpp
+++ b/src/utils/screengrabber.cpp
@@ -111,9 +111,28 @@ void ScreenGrabber::freeDesktopPortal(bool& ok, QPixmap& res)
     });
     timeout.start();
 
+    // Build a non-empty parent_window handle. xdg-desktop-portal-gnome
+    // (>= 46) rejects an empty string with "Failed to associate portal
+    // window with parent window ''" and the Screenshot request fails.
+    // On X11 we pass a real x11:<hex> handle from an offscreen QWidget.
+    // On Wayland we fall back to an empty string inside a wayland: prefix
+    // (xdg-desktop-portal-gnome treats unknown handles as no-parent and
+    // proceeds, instead of rejecting outright).
+    QString parentWindow;
+    QWidget parentDummy;
+    parentDummy.setAttribute(Qt::WA_DontShowOnScreen, true);
+    parentDummy.resize(1, 1);
+    parentDummy.show();
+    if (QGuiApplication::platformName() == QLatin1String("wayland")) {
+        parentWindow = QStringLiteral("wayland:");
+    } else {
+        parentWindow = QStringLiteral("x11:0x%1")
+                         .arg(parentDummy.winId(), 0, 16);
+    }
+
     screenshotInterface.call(
       QStringLiteral("Screenshot"),
-      "",
+      parentWindow,
       QMap<QString, QVariant>({ { "handle_token", QVariant(token) },
                                 { "interactive", QVariant(false) } }));
 


### PR DESCRIPTION
## Bug

On GNOME 46 Wayland, daemon-mode capture (tray icon click, custom keybinding, or `gdbus call --session --dest org.flameshot.Flameshot --object-path /org/flameshot/Flameshot --method org.flameshot.Flameshot.captureScreen ...`) fails. `journalctl --user -u xdg-desktop-portal-gnome` shows:

```
xdg-desktop-portal-gnome[NNNN]: Failed to associate portal window with parent window ''
```

and Flameshot logs `Не удалось захватить экран` / `Unable to capture the screen`. Only `flameshot gui` invoked from a child of an already-visible window works, because xdg-desktop-portal-gnome on >= 46 strictly rejects requests where the `parent_window` argument of `org.freedesktop.portal.Screenshot.Screenshot()` is an empty string.

`ScreenGrabber::freeDesktopPortal()` in `src/utils/screengrabber.cpp` was hard-coding `""` as that parameter, which is the root cause.

## Fix

Allocate an offscreen `QWidget` with `Qt::WA_DontShowOnScreen` so a `winId` is generated without flashing a window. On X11 sessions pass `x11:0x<hex_winId>` (a real parent handle following the xdg-desktop-portal spec). On Wayland sessions, where we can't easily produce a real `wl_surface` exported handle from this code path, pass `wayland:` — non-empty, prefixed with the documented platform tag, and accepted by xdg-desktop-portal-gnome / xdg-desktop-portal-kde as a no-real-parent fallback. The portal spec explicitly allows the prefix-only form for callers that have no usable parent.

The change is contained to a single function, adds no dependencies, and preserves existing behavior on portals that previously accepted empty strings (they accept the prefixed forms too).

## Testing

- Ubuntu 24.04 base / Zorin OS 17 Pro, GNOME 46 Wayland
- NVIDIA proprietary 590.48.01
- Qt 6.4.2
- xdg-desktop-portal 1.18, xdg-desktop-portal-gnome 46.2
- Built from this branch with `cmake -B build && cmake --build build -j && sudo cmake --install build`
- Verified that `gdbus call ... captureScreen` triggers the selection overlay and writes `Снимок скопирован в буфер обмена` (screenshot copied to clipboard) to the journal
- Confirmed stable across two full logout/login cycles
- Tray-icon "Take Screenshot" entry now also works in the same session

## Refs

- Refs: #4663 (direct duplicate — same root cause, same error string)
- Refs: #4463, #3700, #3365 (GNOME Wayland capture failure reports likely caused by the same empty `parent_window`)