### PR TITLE
Avoid GNOME Wayland screenshot flash and monitor picker with optional Shell bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,14 @@ Now every time you press <kbd>Prt Sc</kbd> it will start Flameshot GUI instead o
 
 - Experimental Gnome Wayland and Plasma Wayland support.
 
+- GNOME Wayland normally captures through `xdg-desktop-portal`, which may show
+  a GNOME Shell flash. Flameshot includes an optional GNOME Shell bridge under
+  [`contrib/gnome-shell-extension`](contrib/gnome-shell-extension/README.md).
+  When enabled on supported GNOME Shell versions, Flameshot uses that bridge to
+  capture without the portal flash and to auto-select the monitor under the
+  pointer on multi-monitor setups. If the bridge is not installed or fails,
+  Flameshot falls back to the existing portal backend.
+
 - If you are using Gnome you need to install the [AppIndicator and KStatusNotifierItem Support](https://extensions.gnome.org/extension/615/appindicator-support/) extension in order to see the system tray icon.
 
 - Press <kbd>Enter</kbd> or <kbd>Ctrl</kbd> + <kbd>C</kbd> when you are in a capture mode and you don't have an active selection and the whole desktop will be copied to your clipboard. Pressing <kbd>Ctrl</kbd> + <kbd>S</kbd> will save your capture to a file. Check the [Shortcuts](#keyboard-shortcuts) for more information.

--- a/contrib/gnome-shell-extension/README.md
+++ b/contrib/gnome-shell-extension/README.md
@@ -1,0 +1,92 @@
+# Flameshot GNOME Shell integration
+
+This optional extension lets Flameshot capture screenshots from inside GNOME
+Shell on Wayland. GNOME denies normal applications direct access to
+`org.gnome.Shell.Screenshot`, so Flameshot normally has to use
+`xdg-desktop-portal`. On GNOME Wayland that portal path can produce a bright
+flash.
+
+When this extension is enabled, Flameshot first calls
+`org.flameshot.ShellIntegration.Screenshot`. The extension forwards the request
+to GNOME Shell's screenshot service with the Shell screenshot API's `flash`
+argument set to `false`. It also returns the pointer position at capture time so
+Flameshot can automatically choose the monitor under the pointer instead of
+showing a monitor picker on multi-monitor GNOME Wayland sessions.
+
+If the extension is unavailable or fails, Flameshot falls back to the existing
+portal backend.
+
+This extension currently targets GNOME Shell 49 and 50. It uses GNOME Shell
+internals to add its own D-Bus service name to Shell's screenshot sender
+allowlist. That avoids enabling `global.context.unsafe_mode` and prevents
+GNOME's unsafe-mode warning notification.
+
+## Install
+
+Install for the current user:
+
+```sh
+contrib/gnome-shell-extension/install.sh
+```
+
+Or manually:
+
+```sh
+mkdir -p "${HOME}/.local/share/gnome-shell/extensions"
+cp -r contrib/gnome-shell-extension/flameshot-native@flameshot.org \
+  "${HOME}/.local/share/gnome-shell/extensions/"
+gnome-extensions enable flameshot-native@flameshot.org
+```
+
+You may need to log out and back in before GNOME Shell sees a newly installed
+extension.
+
+Verify that GNOME Shell loaded the bridge:
+
+```sh
+gdbus introspect --session \
+  --dest org.flameshot.ShellIntegration \
+  --object-path /org/flameshot/ShellIntegration
+```
+
+The `Screenshot` method should expose `pointer_x` and `pointer_y` outputs:
+
+```text
+Screenshot(in s filename,
+           out b success,
+           out s filename_used,
+           out i pointer_x,
+           out i pointer_y)
+```
+
+Test the bridge directly:
+
+```sh
+gdbus call --session \
+  --dest org.flameshot.ShellIntegration \
+  --object-path /org/flameshot/ShellIntegration \
+  --method org.flameshot.ShellIntegration.Screenshot \
+  /tmp/flameshot-shell-bridge-test.png
+```
+
+## GNOME shortcut
+
+To bind Flameshot to <kbd>Super</kbd> + <kbd>Shift</kbd> + <kbd>S</kbd>, first
+clear GNOME Shell's built-in screenshot UI shortcut:
+
+```sh
+gsettings set org.gnome.shell.keybindings show-screenshot-ui "[]"
+```
+
+Then create a custom GNOME shortcut that runs:
+
+```sh
+flameshot gui
+```
+
+If Flameshot is installed into a non-standard prefix, use the full binary path,
+for example:
+
+```sh
+${HOME}/.local/bin/flameshot gui
+```

--- a/contrib/gnome-shell-extension/flameshot-native@flameshot.org/extension.js
+++ b/contrib/gnome-shell-extension/flameshot-native@flameshot.org/extension.js
@@ -1,0 +1,110 @@
+import Gio from 'gi://Gio';
+import GLib from 'gi://GLib';
+
+import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+
+const BUS_NAME = 'org.flameshot.ShellIntegration';
+const OBJECT_PATH = '/org/flameshot/ShellIntegration';
+
+const INTERFACE_XML = `
+<node>
+  <interface name="${BUS_NAME}">
+    <method name="Screenshot">
+      <arg name="filename" type="s" direction="in"/>
+      <arg name="success" type="b" direction="out"/>
+      <arg name="filename_used" type="s" direction="out"/>
+      <arg name="pointer_x" type="i" direction="out"/>
+      <arg name="pointer_y" type="i" direction="out"/>
+    </method>
+  </interface>
+</node>`;
+
+export default class FlameshotNativeExtension extends Extension {
+    enable() {
+        this._allowlistOwner = null;
+        this._watcherId = 0;
+
+        this._dbusObject = Gio.DBusExportedObject.wrapJSObject(
+            INTERFACE_XML, this);
+        this._dbusObject.export(Gio.DBus.session, OBJECT_PATH);
+        this._ownName = Gio.DBus.session.own_name(
+            BUS_NAME, Gio.BusNameOwnerFlags.NONE, null, null);
+        this._watcherId = Gio.DBus.watch_name(
+            Gio.BusType.SESSION,
+            BUS_NAME,
+            Gio.BusNameWatcherFlags.NONE,
+            (connection_, name_, owner) => this._allowScreenshotOwner(owner),
+            () => this._removeScreenshotOwner());
+    }
+
+    disable() {
+        if (this._watcherId) {
+            Gio.DBus.unwatch_name(this._watcherId);
+            this._watcherId = 0;
+        }
+        this._removeScreenshotOwner();
+
+        if (this._ownName) {
+            Gio.DBus.session.unown_name(this._ownName);
+            this._ownName = 0;
+        }
+
+        if (this._dbusObject) {
+            this._dbusObject.unexport();
+            this._dbusObject.run_dispose();
+            this._dbusObject = null;
+        }
+    }
+
+    _senderChecker() {
+        return Main.shellDBusService?._screenshotService?._senderChecker ?? null;
+    }
+
+    _allowScreenshotOwner(owner) {
+        const checker = this._senderChecker();
+        if (!checker)
+            return;
+
+        this._allowlistOwner = owner;
+        checker._allowlistMap.set(BUS_NAME, owner);
+        checker._checkAndResolveInitialized(BUS_NAME);
+    }
+
+    _removeScreenshotOwner() {
+        const checker = this._senderChecker();
+        if (!checker || !this._allowlistOwner)
+            return;
+
+        checker._allowlistMap.delete(BUS_NAME);
+        checker._checkAndResolveInitialized(BUS_NAME);
+        this._allowlistOwner = null;
+    }
+
+    ScreenshotAsync([filename], invocation) {
+        const [pointerX, pointerY] = global.get_pointer();
+
+        Gio.DBus.session.call(
+            'org.gnome.Shell.Screenshot',
+            '/org/gnome/Shell/Screenshot',
+            'org.gnome.Shell.Screenshot',
+            'Screenshot',
+            new GLib.Variant('(bbs)', [false, false, filename]),
+            new GLib.VariantType('(bs)'),
+            Gio.DBusCallFlags.NONE,
+            -1,
+            null,
+            (connection, result) => {
+                try {
+                    const [success, filenameUsed] =
+                        connection.call_finish(result).deepUnpack();
+                    invocation.return_value(
+                        new GLib.Variant('(bsii)', [
+                            success, filenameUsed, pointerX, pointerY,
+                        ]));
+                } catch (e) {
+                    invocation.return_gerror(e);
+                }
+            });
+    }
+}

--- a/contrib/gnome-shell-extension/flameshot-native@flameshot.org/metadata.json
+++ b/contrib/gnome-shell-extension/flameshot-native@flameshot.org/metadata.json
@@ -1,0 +1,9 @@
+{
+  "name": "Flameshot Native Screenshot Bridge",
+  "description": "Allows Flameshot to capture GNOME Wayland screenshots through GNOME Shell without the portal flash.",
+  "uuid": "flameshot-native@flameshot.org",
+  "shell-version": [
+    "49",
+    "50"
+  ]
+}

--- a/contrib/gnome-shell-extension/install.sh
+++ b/contrib/gnome-shell-extension/install.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env sh
+set -eu
+
+uuid="flameshot-native@flameshot.org"
+script_dir="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+source_dir="${script_dir}/${uuid}"
+target_dir="${HOME}/.local/share/gnome-shell/extensions/${uuid}"
+
+mkdir -p "$(dirname -- "${target_dir}")"
+rm -rf "${target_dir}"
+cp -r "${source_dir}" "${target_dir}"
+
+if command -v gnome-extensions >/dev/null 2>&1; then
+    gnome-extensions enable "${uuid}" || true
+fi
+
+printf '%s\n' "Installed ${uuid} to ${target_dir}"
+printf '%s\n' "Log out and back in if GNOME Shell has not loaded it yet."

--- a/src/utils/screengrabber.cpp
+++ b/src/utils/screengrabber.cpp
@@ -28,9 +28,13 @@
 
 #if !(defined(Q_OS_MACOS) || defined(Q_OS_WIN))
 #include "request.h"
+#include <QDBusConnection>
 #include <QDBusInterface>
+#include <QDBusMessage>
 #include <QDBusReply>
 #include <QDir>
+#include <QFile>
+#include <QTemporaryFile>
 #include <QUrl>
 #include <QUuid>
 #endif
@@ -42,6 +46,7 @@ ScreenGrabber::ScreenGrabber(QObject* parent)
   , m_selectedMonitor(-1)
   , m_monitorSelectionLoop(nullptr)
   , m_userCancelled(false)
+  , m_hasGnomeShellPointer(false)
 {
     // Increase image allocation limit for large screenshots
     // (multi-monitor/high-DPI) Default is 128MB, set to 1GB to handle 4K+
@@ -137,6 +142,71 @@ void ScreenGrabber::freeDesktopPortal(bool& ok, QPixmap& res)
 #endif
 }
 
+bool ScreenGrabber::gnomeShellNativeScreenshot(QPixmap& res)
+{
+#if !(defined(Q_OS_MACOS) || defined(Q_OS_WIN))
+    m_hasGnomeShellPointer = false;
+
+    if (!m_info.waylandDetected() ||
+        m_info.windowManager() != DesktopInfo::GNOME) {
+        return false;
+    }
+
+    const QString service = QStringLiteral("org.flameshot.ShellIntegration");
+    auto* connectionInterface = QDBusConnection::sessionBus().interface();
+    if (!connectionInterface->isServiceRegistered(service)) {
+        return false;
+    }
+
+    QTemporaryFile file(QDir::temp().filePath(
+      QStringLiteral("flameshot-gnome-shell-XXXXXX.png")));
+    file.setAutoRemove(false);
+    if (!file.open()) {
+        return false;
+    }
+
+    const QString filename = file.fileName();
+    file.close();
+    QFile::remove(filename);
+
+    QDBusInterface screenshotInterface(
+      service,
+      QStringLiteral("/org/flameshot/ShellIntegration"),
+      QStringLiteral("org.flameshot.ShellIntegration"));
+
+    QDBusMessage reply =
+      screenshotInterface.call(QStringLiteral("Screenshot"), filename);
+
+    if (reply.type() == QDBusMessage::ErrorMessage) {
+        QFile::remove(filename);
+        AbstractLogger::error()
+          << tr("GNOME Shell native screenshot failed: %1")
+               .arg(reply.errorMessage());
+        return false;
+    }
+
+    const auto args = reply.arguments();
+    if (args.size() < 2 || !args.at(0).toBool()) {
+        QFile::remove(filename);
+        return false;
+    }
+
+    const QString filenameUsed = args.at(1).toString();
+    res = QPixmap(filenameUsed);
+    QFile::remove(filenameUsed);
+
+    if (!res.isNull() && args.size() >= 4) {
+        m_gnomeShellPointer = QPoint(args.at(2).toInt(), args.at(3).toInt());
+        m_hasGnomeShellPointer = true;
+    }
+
+    return !res.isNull();
+#else
+    Q_UNUSED(res)
+    return false;
+#endif
+}
+
 QPixmap ScreenGrabber::selectMonitorAndCrop(const QPixmap& fullScreenshot,
                                             bool& ok)
 {
@@ -153,17 +223,21 @@ QPixmap ScreenGrabber::selectMonitorAndCrop(const QPixmap& fullScreenshot,
     }
 
     // Capture Active Monitor: auto-select monitor under cursor
-    if (ConfigHandler().captureActiveMonitor()) {
-        if (m_info.waylandDetected()) {
+    if (ConfigHandler().captureActiveMonitor() || m_hasGnomeShellPointer) {
+        QGuiAppCurrentScreen screenFinder;
+        QScreen* cursorScreen = nullptr;
+        if (m_hasGnomeShellPointer) {
+            cursorScreen = screenFinder.currentScreen(m_gnomeShellPointer);
+        } else if (m_info.waylandDetected()) {
             AbstractLogger::error()
               << tr("Capture Active Monitor is not supported on Wayland due to "
                     "Wayland security model.");
             ok = false;
             return QPixmap();
+        } else {
+            cursorScreen = screenFinder.currentScreen();
         }
 
-        QGuiAppCurrentScreen screenFinder;
-        QScreen* cursorScreen = screenFinder.currentScreen();
         int monitorIndex = screens.indexOf(cursorScreen);
         if (monitorIndex >= 0) {
             m_selectedMonitor = monitorIndex;
@@ -237,6 +311,8 @@ QPixmap ScreenGrabber::grabEntireDesktop(bool& ok, int preSelectedMonitor)
             AbstractLogger::error() << tr("Unable to capture screen");
             return QPixmap();
         }
+    } else if (gnomeShellNativeScreenshot(screenshot)) {
+        ok = true;
     } else {
         freeDesktopPortal(ok, screenshot);
         if (!ok) {
@@ -298,6 +374,8 @@ QPixmap ScreenGrabber::grabFullDesktop(bool& ok)
         if (!ok) {
             AbstractLogger::error() << tr("Unable to capture screen");
         }
+    } else if (gnomeShellNativeScreenshot(screenshot)) {
+        ok = true;
     } else {
         freeDesktopPortal(ok, screenshot);
         if (!ok) {

--- a/src/utils/screengrabber.h
+++ b/src/utils/screengrabber.h
@@ -8,6 +8,7 @@
 #include <QEvent>
 #include <QList>
 #include <QObject>
+#include <QPoint>
 #include <QPixmap>
 #include <QScreen>
 
@@ -37,6 +38,7 @@ private:
     void adjustDevicePixelRatio(QPixmap& pixmap);
     QWidget* createMonitorPreviews(const QPixmap& fullScreenshot);
     QPixmap cropToMonitor(const QPixmap& fullScreenshot, int monitorIndex);
+    bool gnomeShellNativeScreenshot(QPixmap& res);
     QPixmap windowsScreenshot(int wid);
     QPixmap x11LegacyScreenshot();
 
@@ -45,5 +47,7 @@ private:
     int m_selectedMonitor;
     QEventLoop* m_monitorSelectionLoop;
     bool m_userCancelled;
+    bool m_hasGnomeShellPointer;
+    QPoint m_gnomeShellPointer;
     static bool m_monitorSelectionActive;
 };


### PR DESCRIPTION
## Summary

  Adds an optional GNOME Shell screenshot bridge for GNOME Wayland.

  The bridge lets Flameshot capture through GNOME Shell with screenshot flash disabled, then falls back to the existing portal path when
  the bridge is unavailable.

  ## What changed

  - Add optional GNOME Shell extension under `contrib/gnome-shell-extension`
  - Add a Flameshot GNOME Wayland backend that calls `org.flameshot.ShellIntegration`
  - Preserve existing `xdg-desktop-portal` fallback behavior
  - Return pointer coordinates from the Shell bridge so Flameshot can auto-select the active monitor on multi-monitor setups
  - Add install and verification docs for the GNOME Shell bridge
  - Document the optional GNOME Wayland integration in `README.md`

  ## Testing

  Tested locally on GNOME Shell 50.1 Wayland:

  - Built successfully with CMake
  - Installed and enabled the GNOME Shell bridge
  - Verified bridge D-Bus method with `gdbus introspect`
  - Verified direct bridge screenshot call returns success
  - Verified `flameshot gui` opens without GNOME portal flash
  - Verified monitor picker is skipped by using the pointer monitor
  - Verified no unsafe-mode notification after switching to Shell screenshot sender allowlist
