### PR TITLE
Allow multiple flameshot GUI instances (fix for #3177)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -223,7 +223,8 @@ int main(int argc, char* argv[])
         auto kdsa =
           KDSingleApplication(QStringLiteral("org.flameshot.Flameshot"));
 
-        if (!kdsa.isPrimaryInstance()) {
+        if (!kdsa.isPrimaryInstance() &&
+            !ConfigHandler().allowMultipleGuiInstances()) {
             return 0; // Quit
         }
 #endif


### PR DESCRIPTION
This should fix #3177 
I don't understand how this was working on Linux without this...! Maybe @borgmanJeremy has an explanation?
But after adding that additional line, it (still) works on Linux and additionally on my Windows machine as well.