### PR TITLE
scripts: add KWin script workaround for pin window on KDE Plasma Wayland

### DIFF
--- a/scripts/kwin/flameshot-pin-fix/contents/code/main.js
+++ b/scripts/kwin/flameshot-pin-fix/contents/code/main.js
@@ -1,0 +1,7 @@
+workspace.windowAdded.connect(function(window) {
+    if (!window.caption.startsWith("flameshot-pin")) {
+        return;
+    }
+    window.keepAbove = true;
+    window.skipTaskbar = true;
+});

--- a/scripts/kwin/flameshot-pin-fix/metadata.json
+++ b/scripts/kwin/flameshot-pin-fix/metadata.json
@@ -1,0 +1,9 @@
+{
+    "KPlugin": {
+        "Description": "Keep flameshot pin windows always on top and off the taskbar",
+        "Id": "flameshot-pin-fix",
+        "License": "GPL-3.0",
+        "Name": "Flameshot Pin Fix",
+        "Version": "1.0"
+    }
+}


### PR DESCRIPTION
  ## Problem

  On KDE Plasma + Wayland, the pin window has two issues:

  1. It sinks below other windows when focus changes — `Qt::WindowStaysOnTopHint` is silently ignored on Wayland because the xdg-shell protocol has no "keep above" state.
  2. It appears in the taskbar and can be minimized from there.

  Related: #4679

  ## Solution

  A small optional KWin script that listens for `windowAdded` and sets `keepAbove`/`skipTaskbar` for any window titled `flameshot-pin`.

  ## Scope

  - Only affects KDE Plasma + Wayland users
  - All other platforms are completely unaffected
  - Two new files under `scripts/kwin/`, no changes to the main codebase

  ## Installation

  ```bash
  mkdir -p ~/.local/share/kwin/scripts/flameshot-pin-fix/contents/code
  cp scripts/kwin/flameshot-pin-fix/metadata.json \
     ~/.local/share/kwin/scripts/flameshot-pin-fix/
  cp scripts/kwin/flameshot-pin-fix/contents/code/main.js \
     ~/.local/share/kwin/scripts/flameshot-pin-fix/contents/code/
  ```

  Then enable it in **System Settings → Window Management → KWin Scripts**,
  and re-login or run `qdbus org.kde.KWin /KWin reconfigure`.

  To verify you are on Wayland: `echo $XDG_SESSION_TYPE` should output `wayland`.

  ## Notes

  The proper fix would be to use the `zwlr_layer_shell_v1` protocol in `PinWidget`,
  but that requires significant refactoring. This script serves as a lightweight
  workaround in the meantime.

  Tested on KDE Plasma 6, Wayland, Arch Linux.