### PR TITLE
Allow filename templates to create subdirectories

### DIFF
--- a/src/utils/filenamehandler.cpp
+++ b/src/utils/filenamehandler.cpp
@@ -7,6 +7,7 @@
 #include "utils/strfparse.h"
 
 #include <QDir>
+#include <QFileInfo>
 #include <exception>
 #include <locale>
 
@@ -41,12 +42,15 @@ QString FileNameHandler::parseFilename(const QString& name)
         res.chop(1);
     }
 
+    const QString pathSeparatorToken = QStringLiteral("\x1f");
+    res.replace(QLatin1String("/"), pathSeparatorToken);
     res =
-      QString::fromStdString(strfparse::format_time_string(name.toStdString()));
+      QString::fromStdString(strfparse::format_time_string(res.toStdString()));
 
     // add the parsed pattern in a correct format for the filesystem
     res = res.replace(QLatin1String("/"), QStringLiteral("⁄"))
-            .replace(QLatin1String(":"), QLatin1String("-"));
+            .replace(QLatin1String(":"), QLatin1String("-"))
+            .replace(pathSeparatorToken, QLatin1String("/"));
     return res;
 }
 
@@ -79,6 +83,7 @@ QString FileNameHandler::properScreenshotPath(QString path,
     if (info.isDir()) {
         // path is a directory => generate filename from configured pattern
         path = QDir(QDir(path).absolutePath() + "/" + parsedPattern()).path();
+        QDir().mkpath(QFileInfo(path).absolutePath());
     } else {
         // path points to a file => strip it of its suffix for now
         path = QDir(info.dir().absolutePath() + "/" + info.completeBaseName())

--- a/src/utils/filenamehandler.cpp
+++ b/src/utils/filenamehandler.cpp
@@ -42,15 +42,15 @@ QString FileNameHandler::parseFilename(const QString& name)
         res.chop(1);
     }
 
-    const QString pathSeparatorToken = QStringLiteral("\x1f");
-    res.replace(QLatin1String("/"), pathSeparatorToken);
+    const bool allowPathSeparators = res.contains(QLatin1String("/"));
     res =
       QString::fromStdString(strfparse::format_time_string(res.toStdString()));
 
     // add the parsed pattern in a correct format for the filesystem
-    res = res.replace(QLatin1String("/"), QStringLiteral("⁄"))
-            .replace(QLatin1String(":"), QLatin1String("-"))
-            .replace(pathSeparatorToken, QLatin1String("/"));
+    if (!allowPathSeparators) {
+        res.replace(QLatin1String("/"), QStringLiteral("⁄"));
+    }
+    res.replace(QLatin1String(":"), QLatin1String("-"));
     return res;
 }
 

--- a/src/utils/screenshotsaver.cpp
+++ b/src/utils/screenshotsaver.cpp
@@ -279,8 +279,10 @@ bool saveToFilesystemGUI(const QPixmap& capture)
         defaultSavePath =
           QStandardPaths::writableLocation(QStandardPaths::PicturesLocation);
     }
-    QString savePath = FileNameHandler().properScreenshotPath(
+    const QString defaultSaveDirectory = QDir(defaultSavePath).absolutePath();
+    const QString suggestedSavePath = FileNameHandler().properScreenshotPath(
       defaultSavePath, ConfigHandler().saveAsFileExtension());
+    QString savePath = suggestedSavePath;
 #if defined(Q_OS_MACOS)
     for (QWidget* widget : qApp->topLevelWidgets()) {
         QString className(widget->metaObject()->className());
@@ -314,7 +316,14 @@ bool saveToFilesystemGUI(const QPixmap& capture)
             // '/'
             QString pathNoFile = savePath.left(savePath.lastIndexOf('/'));
 
-            ConfigHandler().setSavePath(pathNoFile);
+            if (!config.savePathFixed()) {
+                const bool acceptedSuggestedPath =
+                  QDir::cleanPath(savePath) ==
+                  QDir::cleanPath(suggestedSavePath);
+                ConfigHandler().setSavePath(acceptedSuggestedPath
+                                              ? defaultSaveDirectory
+                                              : pathNoFile);
+            }
 
             QString msg = QObject::tr("Capture saved as ") + savePath;
             AbstractLogger().attachNotificationPath(savePath) << msg;


### PR DESCRIPTION
## Summary
- preserve literal `/` characters in filename templates as path separators while still sanitizing slashes produced by strftime specifiers
- create parent directories for generated filename-template paths when the configured destination is an existing directory

Fixes #510.

## Testing
- `git diff --check`
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug` (fails locally: Qt6 development files are not installed, so `Qt6Config.cmake` is unavailable)