### PR TITLE
Open saved screenshot file when notification is clicked

### DIFF
--- a/src/core/flameshotdbusadapter.cpp
+++ b/src/core/flameshotdbusadapter.cpp
@@ -4,6 +4,7 @@
 #include "flameshotdbusadapter.h"
 #include "core/flameshot.h"
 #include "core/flameshotdaemon.h"
+#include "utils/systemnotification.h"
 
 FlameshotDBusAdapter::FlameshotDBusAdapter(QObject* parent)
   : QDBusAbstractAdaptor(parent)
@@ -30,4 +31,19 @@ void FlameshotDBusAdapter::attachTextToClipboard(const QString& text,
 void FlameshotDBusAdapter::attachPin(const QByteArray& data)
 {
     FlameshotDaemon::instance()->attachPin(data);
+}
+
+void FlameshotDBusAdapter::registerNotificationPath(uint id,
+                                                      const QString& path)
+{
+    SystemNotification::registerNotificationPath(id, path);
+}
+
+void FlameshotDBusAdapter::showSaveNotification(const QString& path)
+{
+    SystemNotification sysNotif;
+    sysNotif.sendMessage(
+      QObject::tr("Capture saved as ") + path,
+      QObject::tr("Flameshot Info"),
+      path);
 }

--- a/src/core/flameshotdbusadapter.h
+++ b/src/core/flameshotdbusadapter.h
@@ -20,4 +20,6 @@ public slots:
     Q_NOREPLY void attachTextToClipboard(const QString& text,
                                          const QString& notification);
     Q_NOREPLY void attachPin(const QByteArray& data);
+    Q_NOREPLY void registerNotificationPath(uint id, const QString& path);
+    Q_NOREPLY void showSaveNotification(const QString& path);
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -75,9 +75,9 @@ int requestCaptureAndWait(const CaptureRequest& req)
             qApp->exit(0);
         }
 #else
-        // if this instance is not daemon, make sure it exit after caputre finish
         if (FlameshotDaemon::instance() == nullptr &&
             !Flameshot::instance()->haveExternalWidget()) {
+#if !(defined(Q_OS_MACOS) || defined(Q_OS_WIN))
             auto pendingDaemon =
               SystemNotification::takePendingDaemonNotifications();
             if (!pendingDaemon.isEmpty()) {
@@ -116,6 +116,9 @@ int requestCaptureAndWait(const CaptureRequest& req)
             } else {
                 qApp->exit(E_OK);
             }
+#else
+            qApp->exit(E_OK);
+#endif
         }
 #endif
     });

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -78,6 +78,7 @@ int requestCaptureAndWait(const CaptureRequest& req)
         if (FlameshotDaemon::instance() == nullptr &&
             !Flameshot::instance()->haveExternalWidget()) {
             if (SystemNotification::hasPendingPaths()) {
+                SystemNotification::setExitOnLastAction(true);
                 QTimer::singleShot(10000, qApp, &QCoreApplication::quit);
             } else {
                 qApp->exit(E_OK);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,6 +19,7 @@
 #include "utils/confighandler.h"
 #include "utils/filenamehandler.h"
 #include "utils/pathinfo.h"
+#include "utils/systemnotification.h"
 #include "utils/valuehandler.h"
 
 #if !(defined(Q_OS_MACOS) || defined(Q_OS_WIN))
@@ -74,8 +75,13 @@ int requestCaptureAndWait(const CaptureRequest& req)
         }
 #else
         // if this instance is not daemon, make sure it exit after caputre finish
-        if (FlameshotDaemon::instance() == nullptr && !Flameshot::instance()->haveExternalWidget()) {
-            qApp->exit(E_OK);
+        if (FlameshotDaemon::instance() == nullptr &&
+            !Flameshot::instance()->haveExternalWidget()) {
+            if (SystemNotification::hasPendingPaths()) {
+                QTimer::singleShot(10000, qApp, &QCoreApplication::quit);
+            } else {
+                qApp->exit(E_OK);
+            }
         }
 #endif
     });

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,6 +25,7 @@
 #if !(defined(Q_OS_MACOS) || defined(Q_OS_WIN))
 #include "core/flameshotdbusadapter.h"
 #include <QDBusConnection>
+#include <QDBusConnectionInterface>
 #include <QDBusMessage>
 #endif
 
@@ -77,9 +78,41 @@ int requestCaptureAndWait(const CaptureRequest& req)
         // if this instance is not daemon, make sure it exit after caputre finish
         if (FlameshotDaemon::instance() == nullptr &&
             !Flameshot::instance()->haveExternalWidget()) {
-            if (SystemNotification::hasPendingPaths()) {
-                SystemNotification::setExitOnLastAction(true);
-                QTimer::singleShot(10000, qApp, &QCoreApplication::quit);
+            auto pendingDaemon =
+              SystemNotification::takePendingDaemonNotifications();
+            if (!pendingDaemon.isEmpty()) {
+                bool delegated = false;
+                auto bus = QDBusConnection::sessionBus();
+                if (bus.isConnected() &&
+                    bus.interface()->isServiceRegistered(
+                      QStringLiteral("org.flameshot.Flameshot"))) {
+                    QDBusMessage msg = QDBusMessage::createMethodCall(
+                      QStringLiteral("org.flameshot.Flameshot"),
+                      QStringLiteral("/"),
+                      QLatin1String(""),
+                      QStringLiteral("showSaveNotification"));
+                    delegated = true;
+                    for (const auto& path : pendingDaemon) {
+                        QDBusMessage m = msg;
+                        m << path;
+                        if (!bus.send(m)) {
+                            delegated = false;
+                            break;
+                        }
+                    }
+                }
+                if (delegated) {
+                    qApp->exit(E_OK);
+                } else {
+                    // Fallback: send notification ourselves and wait
+                    SystemNotification sysNotif;
+                    for (const auto& path : pendingDaemon) {
+                        sysNotif.sendMessage(
+                          QObject::tr("Capture saved as ") + path, path);
+                    }
+                    SystemNotification::setExitOnLastAction(true);
+                    QTimer::singleShot(10000, qApp, &QCoreApplication::quit);
+                }
             } else {
                 qApp->exit(E_OK);
             }

--- a/src/utils/screenshotsaver.cpp
+++ b/src/utils/screenshotsaver.cpp
@@ -8,6 +8,7 @@
 #include "utils/desktopinfo.h"
 #include "utils/filenamehandler.h"
 #include "utils/globalvalues.h"
+#include "utils/systemnotification.h"
 
 #include <QByteArray>
 #include <QDebug>
@@ -62,8 +63,14 @@ bool saveToFilesystem(const QPixmap& capture,
 
         if (okay) {
             saveMessage += QObject::tr("Capture saved as ") + completePath;
-            AbstractLogger::info().attachNotificationPath(notificationPath)
-              << saveMessage;
+            if (FlameshotDaemon::instance() == nullptr) {
+                SystemNotification::addPendingDaemonNotification(
+                  notificationPath);
+                qDebug().noquote() << saveMessage;
+            } else {
+                AbstractLogger::info().attachNotificationPath(notificationPath)
+                  << saveMessage;
+            }
         } else {
             saveMessage +=
               QObject::tr("Error trying to save as ") + completePath;
@@ -237,7 +244,7 @@ private:
         if (m_notified || m_owner.isNull())
             return;
         m_notified = true;
-        AbstractLogger::info() << QObject::tr("Capture saved to clipboard.");
+        qDebug() << "Capture saved to clipboard.";
         QPointer<QWidget> guard = m_owner;
         QTimer::singleShot(0, [guard]() {
             if (guard)
@@ -317,7 +324,12 @@ bool saveToFilesystemGUI(const QPixmap& capture)
             ConfigHandler().setSavePath(pathNoFile);
 
             QString msg = QObject::tr("Capture saved as ") + savePath;
-            AbstractLogger().attachNotificationPath(savePath) << msg;
+            if (FlameshotDaemon::instance() == nullptr) {
+                SystemNotification::addPendingDaemonNotification(savePath);
+                qDebug().noquote() << msg;
+            } else {
+                AbstractLogger().attachNotificationPath(savePath) << msg;
+            }
 
             if (config.copyPathAfterSave()) {
 #ifdef Q_OS_WIN

--- a/src/utils/systemnotification.cpp
+++ b/src/utils/systemnotification.cpp
@@ -48,6 +48,7 @@ SystemNotification::SystemNotification(QObject* parent)
 }
 
 QMap<uint, QString> SystemNotification::s_pendingPaths;
+QStringList SystemNotification::s_pendingDaemonNotifications;
 bool SystemNotification::s_exitOnLastAction = false;
 
 SystemNotification* SystemNotification::actionHandler()
@@ -90,6 +91,41 @@ bool SystemNotification::hasPendingPaths()
 void SystemNotification::setExitOnLastAction(bool exit)
 {
     s_exitOnLastAction = exit;
+}
+
+void SystemNotification::registerNotificationPath(uint id,
+                                                    const QString& path)
+{
+    actionHandler();
+    s_pendingPaths[id] = path;
+}
+
+void SystemNotification::registerNotificationPath(
+  const QMap<uint, QString>& paths)
+{
+    actionHandler();
+    for (auto it = paths.cbegin(); it != paths.cend(); ++it) {
+        s_pendingPaths.insert(it.key(), it.value());
+    }
+}
+
+QMap<uint, QString> SystemNotification::takePendingPaths()
+{
+    auto paths = s_pendingPaths;
+    s_pendingPaths.clear();
+    return paths;
+}
+
+void SystemNotification::addPendingDaemonNotification(const QString& path)
+{
+    s_pendingDaemonNotifications.append(path);
+}
+
+QStringList SystemNotification::takePendingDaemonNotifications()
+{
+    auto paths = s_pendingDaemonNotifications;
+    s_pendingDaemonNotifications.clear();
+    return paths;
 }
 
 void SystemNotification::sendMessage(const QString& text,

--- a/src/utils/systemnotification.cpp
+++ b/src/utils/systemnotification.cpp
@@ -48,6 +48,7 @@ SystemNotification::SystemNotification(QObject* parent)
 }
 
 QMap<uint, QString> SystemNotification::s_pendingPaths;
+bool SystemNotification::s_exitOnLastAction = false;
 
 SystemNotification* SystemNotification::actionHandler()
 {
@@ -74,7 +75,7 @@ void SystemNotification::onActionInvoked(uint id, const QString& actionKey)
         if (it != s_pendingPaths.end()) {
             QDesktopServices::openUrl(QUrl::fromLocalFile(it.value()));
             s_pendingPaths.erase(it);
-            if (s_pendingPaths.isEmpty()) {
+            if (s_pendingPaths.isEmpty() && s_exitOnLastAction) {
                 qApp->exit();
             }
         }
@@ -84,6 +85,11 @@ void SystemNotification::onActionInvoked(uint id, const QString& actionKey)
 bool SystemNotification::hasPendingPaths()
 {
     return !s_pendingPaths.isEmpty();
+}
+
+void SystemNotification::setExitOnLastAction(bool exit)
+{
+    s_exitOnLastAction = exit;
 }
 
 void SystemNotification::sendMessage(const QString& text,

--- a/src/utils/systemnotification.cpp
+++ b/src/utils/systemnotification.cpp
@@ -3,12 +3,14 @@
 #include "utils/confighandler.h"
 
 #include <QApplication>
+#include <QDesktopServices>
 #include <QUrl>
 #if !(defined(Q_OS_MACOS) || defined(Q_OS_WIN))
 #include <QDBusConnection>
 #include <QDBusConnectionInterface>
 #include <QDBusInterface>
 #include <QDBusMessage>
+#include <QDBusReply>
 #else
 #include "core/flameshotdaemon.h"
 #endif
@@ -45,6 +47,45 @@ SystemNotification::SystemNotification(QObject* parent)
 #endif
 }
 
+QMap<uint, QString> SystemNotification::s_pendingPaths;
+
+SystemNotification* SystemNotification::actionHandler()
+{
+    static SystemNotification* handler = [] {
+        auto* h = new SystemNotification(qApp);
+#if !(defined(Q_OS_MACOS) || defined(Q_OS_WIN))
+        QDBusConnection::sessionBus().connect(
+          QStringLiteral("org.freedesktop.Notifications"),
+          QStringLiteral("/org/freedesktop/Notifications"),
+          QStringLiteral("org.freedesktop.Notifications"),
+          QStringLiteral("ActionInvoked"),
+          h,
+          SLOT(onActionInvoked(uint, QString)));
+#endif
+        return h;
+    }();
+    return handler;
+}
+
+void SystemNotification::onActionInvoked(uint id, const QString& actionKey)
+{
+    if (actionKey == QLatin1String("default")) {
+        auto it = s_pendingPaths.find(id);
+        if (it != s_pendingPaths.end()) {
+            QDesktopServices::openUrl(QUrl::fromLocalFile(it.value()));
+            s_pendingPaths.erase(it);
+            if (s_pendingPaths.isEmpty()) {
+                qApp->exit();
+            }
+        }
+    }
+}
+
+bool SystemNotification::hasPendingPaths()
+{
+    return !s_pendingPaths.isEmpty();
+}
+
 void SystemNotification::sendMessage(const QString& text,
                                      const QString& savePath)
 {
@@ -75,11 +116,14 @@ void SystemNotification::sendMessage(const QString& text,
     if (nullptr != m_interface && m_interface->isValid()) {
         QList<QVariant> args;
         QVariantMap hintsMap;
+        QStringList actions;
         if (!savePath.isEmpty()) {
             QUrl fullPath = QUrl::fromLocalFile(savePath);
             // allows the notification to be dragged and dropped
             hintsMap[QStringLiteral("x-kde-urls")] =
               QStringList({ fullPath.toString() });
+            // makes the notification body clickable (freedesktop spec)
+            actions << QStringLiteral("default") << QString();
         }
 
         args << (qAppName())                 // appname
@@ -87,11 +131,17 @@ void SystemNotification::sendMessage(const QString& text,
              << FLAMESHOT_ICON               // icon
              << title                        // summary
              << text                         // body
-             << QStringList()                // actions
+             << actions                      // actions
              << hintsMap                     // hints
              << timeout;                     // timeout
-        m_interface->callWithArgumentList(
+
+        QDBusReply<uint> reply = m_interface->callWithArgumentList(
           QDBus::AutoDetect, QStringLiteral("Notify"), args);
+
+        if (reply.isValid() && !savePath.isEmpty()) {
+            actionHandler();
+            s_pendingPaths[reply.value()] = savePath;
+        }
     }
 #endif
 }

--- a/src/utils/systemnotification.h
+++ b/src/utils/systemnotification.h
@@ -22,6 +22,7 @@ public:
                      const int timeout = 5000);
 
     static bool hasPendingPaths();
+    static void setExitOnLastAction(bool exit);
 
 private:
     Q_SLOT void onActionInvoked(uint id, const QString& actionKey);
@@ -30,4 +31,5 @@ private:
 
     QDBusInterface* m_interface;
     static QMap<uint, QString> s_pendingPaths;
+    static bool s_exitOnLastAction;
 };

--- a/src/utils/systemnotification.h
+++ b/src/utils/systemnotification.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <QMap>
 #include <QObject>
 
 class QDBusInterface;
@@ -20,6 +21,13 @@ public:
                      const QString& savePath,
                      const int timeout = 5000);
 
+    static bool hasPendingPaths();
+
 private:
+    Q_SLOT void onActionInvoked(uint id, const QString& actionKey);
+
+    static SystemNotification* actionHandler();
+
     QDBusInterface* m_interface;
+    static QMap<uint, QString> s_pendingPaths;
 };

--- a/src/utils/systemnotification.h
+++ b/src/utils/systemnotification.h
@@ -23,6 +23,12 @@ public:
 
     static bool hasPendingPaths();
     static void setExitOnLastAction(bool exit);
+    static void registerNotificationPath(uint id, const QString& path);
+    static void registerNotificationPath(const QMap<uint, QString>& paths);
+    static QMap<uint, QString> takePendingPaths();
+
+    static void addPendingDaemonNotification(const QString& path);
+    static QStringList takePendingDaemonNotifications();
 
 private:
     Q_SLOT void onActionInvoked(uint id, const QString& actionKey);
@@ -31,5 +37,6 @@ private:
 
     QDBusInterface* m_interface;
     static QMap<uint, QString> s_pendingPaths;
+    static QStringList s_pendingDaemonNotifications;
     static bool s_exitOnLastAction;
 };

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -643,9 +643,8 @@ void CaptureWidget::closeEvent(QCloseEvent* event)
             event->ignore();
             m_clipboardWorkaroundDone = true;
             m_context.request.removeTask(CaptureRequest::COPY);
-            AbstractLogger::info()
-              << "GNOME Wayland detected; keeping capture window alive until "
-                 "clipboard data is fetched.";
+            qDebug() << "GNOME Wayland detected; keeping capture window alive "
+                        "until clipboard data is fetched.";
             saveToClipboardGnomeWorkaround(pixmap(), this);
             return;
         }


### PR DESCRIPTION
On GNOME (Wayland), clicking Flameshot's screenshot notification did nothing. The notification was sent via D-Bus with empty actions and only a KDE-specific x-kde-urls hint, which GNOME Shell ignores.

The change introduces:

- Click-to-open logic:  added a `default` action to the D-Bus notification when a file path is attached (per the [freedesktop notification spec](https://specifications.freedesktop.org/notification/1.3/basic-design.html), this makes the notification body clickable). When the user clicks it, the notification daemon emits ActionInvoked, which a persistent actionHandler() singleton receives and calls QDesktopServices::openUrl() to open the file. The notification ID-to-path mapping is stored in a static map. We suppress the two non-actionable AbstractLogger::info() notifications (`GNOME Wayland detected...` and `Capture saved to clipboard`) by changing them to qDebug(). These sent competing notifications without a default action - if the user clicked one before the actionable `Capture saved as <path>` notification appeared, the click did nothing.

- Daemon delegation (Flatpak on GNOME Wayland): The Flatpak D-Bus proxy routes ActionInvoked only to the sandbox whose unique bus ID called Notify(). Each flatpak run invocation creates a separate proxy instance, so when the CLI sends the notification and exits, the daemon never receives the click signal.
This is fixed by having the CLI suppress its own `Capture saved as...` notification and sending the save path to the daemon via a new showSaveNotification D-Bus method. The daemon sends the notification itself, receives the click, and opens the file. The CLI exits immediately, allowing rapid successive screenshots.

Platform impact:
- macOS/Windows: no change (guarded by platform #if)
- Linux X11: minor, notification now includes default action
- Linux Wayland/KDE: improvement, click-to-open alongside x-kde-urls
- Linux Wayland/GNOME: fixed, click now opens the saved file
