### PR TITLE
Turn on the alarms: pin QHotkey, enable warnings framework, add ASAN+UBSAN CI

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -84,6 +84,61 @@ jobs:
         # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
         run: ctest -C $BUILD_TYPE
 
+  linux-sanitizers:
+    name: Linux ASAN+UBSAN
+    runs-on: ubuntu-24.04
+    # Catches memory and undefined-behavior bugs that the normal build misses.
+    # See cmake/Sanitizers.cmake. Tracked in backlog story S1.4.
+
+    steps:
+      - name: Checkout Source code
+        if: github.event_name == 'push'
+        uses: actions/checkout@v6
+
+      - name: Checkout Source code
+        if: github.event_name == 'pull_request'
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Checkout Source code
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Install Dependencies
+        run: |
+          sudo apt-get -y -qq update
+          sudo apt-get -y --no-install-recommends install \
+            cmake \
+            extra-cmake-modules \
+            build-essential \
+            qt6-base-dev \
+            qt6-svg-dev \
+            qt6-tools-dev \
+
+      - name: Configure CMake with sanitizers
+        shell: bash
+        run: |
+          cmake -S "$GITHUB_WORKSPACE" -B "${{runner.workspace}}/build-san" \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DENABLE_SANITIZER_ADDRESS=ON \
+            -DENABLE_SANITIZER_UNDEFINED_BEHAVIOR=ON
+
+      - name: Build
+        shell: bash
+        run: cmake --build "${{runner.workspace}}/build-san"
+
+      - name: Test
+        working-directory: ${{runner.workspace}}/build-san
+        shell: bash
+        env:
+          # Make UBSAN aborts visible in the job log instead of being silently absorbed.
+          UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
+          ASAN_OPTIONS: detect_leaks=0
+        run: ctest --output-on-failure
+
   windows-build:
     runs-on: ${{ matrix.config.os }}
     strategy:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,10 +141,13 @@ include(cmake/StaticAnalyzers.cmake)
 option(BUILD_STATIC_LIBS ON)
 
 if(WIN32 OR APPLE)
+  # Pinned to a specific commit so the build is reproducible.
+  # The flameshot-org/QHotkey fork has no release tags; bump this SHA
+  # deliberately when picking up upstream fixes.
   FetchContent_Declare(
     qHotKey
     GIT_REPOSITORY https://github.com/flameshot-org/QHotkey
-    GIT_TAG master
+    GIT_TAG d7063877c14d5ae2b489dc70bbe02e76a43bf38b
   )
   FetchContent_MakeAvailable(QHotKey)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,7 +106,11 @@ include(cmake/Cache.cmake)
 
 # standard compiler warnings
 include(cmake/CompilerWarnings.cmake)
-# set_project_warnings(project_warnings)
+# WARNINGS_AS_ERRORS defaults TRUE inside CompilerWarnings.cmake; keep it OFF
+# initially so existing latent warnings don't break the build. Flip on once
+# the baseline is clean (tracked in docs/backlog story S1.3).
+set(WARNINGS_AS_ERRORS OFF CACHE BOOL "Treat compiler warnings as errors")
+set_project_warnings(project_warnings)
 
 # sanitizer options if supported by compiler
 include(cmake/Sanitizers.cmake)

--- a/docs/backlog/20260520-1620-flameshot-v14-backlog.md
+++ b/docs/backlog/20260520-1620-flameshot-v14-backlog.md
@@ -1,0 +1,525 @@
+# Flameshot — Prioritized Backlog (post-v14 beta 2)
+
+**Date:** 2026-05-20
+**Source:** [Staff Engineer Panel Review](../reviews/20260520-1620-flameshot-staff-review.md)
+**Repo state:** `master` @ `1ee047f1 prep for v14 beta 2 (#4692)`, clean working tree.
+
+---
+
+## Executive Summary
+
+Flameshot v14 is in beta 2 with a healthy commit cadence but two structural problems sized as P0 risk: (1) **zero automated test coverage** across 225 source files makes every PR a roll of the dice — visible in the PR #4658 spec-file ping-pong that has flipped merged↔reverted five times; (2) **a 2,085-line `CaptureWidget` god class** is the load-bearing center of the app, and it can't be safely refactored until tests exist around it.
+
+The good news: the codebase has a clean tool-plugin design, a well-thought-through `ConfigHandler` schema, and a complete-but-disabled quality toolchain (warnings framework, ASAN/UBSAN, clang-tidy, sanitizers) — all defined in `cmake/` and never invoked. The cheapest 1-week of work in this repo is just **turning on what already exists**.
+
+This backlog organizes 38 stories across 7 epics, sized for an OSS project with volunteer maintainers. The recommended next-sprint scope (PR-1 of the staff plan) is 8 items that together stand up a real CI safety net for the v14 GA release — none of them require deep code restructuring, none take more than a day each, and together they would have prevented two of the last three reverted PRs.
+
+**No CaptureWidget rewrite is recommended for v14 or v15.** Tests come first, structure later.
+
+---
+
+## Epics
+
+| Epic | Theme | Stories | Priority focus |
+|---|---|---|---|
+| **E1** | CI / Quality Gates | 6 | P0/P1 — cheapest, highest leverage |
+| **E2** | Test Foundation | 7 | P0/P1 — prerequisite for all major refactors |
+| **E3** | Cross-Platform Stability | 6 | P1 — addresses the macOS bug-fix surge |
+| **E4** | Security & Network Hardening | 5 | P1/P2 — small surface, real issues |
+| **E5** | Code-Health Cleanups | 8 | P2/P3 — incremental, contributor-friendly |
+| **E6** | Build & Packaging | 3 | P0/P1 — directly fixes #4658 pattern |
+| **E7** | Documentation | 3 | P1/P2 — lowers contribution friction |
+
+---
+
+## E1 — CI / Quality Gates
+
+> "Most of the tools to fix this codebase are already in `cmake/`. They're just not turned on."
+
+### S1.1 — Pin QHotkey dependency
+**Problem:** `CMakeLists.txt:144-149` pins QHotkey to branch `master`. Non-reproducible build; vulnerable to upstream changes.
+**Acceptance:**
+- `GIT_TAG` references a release tag (`v1.5.0`) or full commit SHA
+- Build produces identical output across two consecutive runs
+- CMake fetch warning eliminated
+**Size:** XS (30 min)
+**Priority:** **P0**
+**Deps:** none
+
+### S1.2 — Enable warnings framework (no -Werror)
+**Problem:** `cmake/CompilerWarnings.cmake` is fully defined but never invoked — `set_project_warnings()` is commented out at `CMakeLists.txt:109`.
+**Acceptance:**
+- Line 109 uncommented with `WARNINGS_AS_ERRORS=FALSE`
+- Build still succeeds across all three platforms in CI
+- Warning count baseline captured in a CI summary
+**Size:** S (1 hr config + observe)
+**Priority:** **P0**
+**Deps:** none
+
+### S1.3 — Fix warnings exposed by S1.2 and enable -Werror
+**Problem:** Once warnings are visible, the team needs a path to clean them up without halting development.
+**Acceptance:**
+- New code in CI is gated on zero new warnings (using a diff filter)
+- Or: full repo warning-clean and `WARNINGS_AS_ERRORS=TRUE` enabled
+- Either path documented in CONTRIBUTING.md
+**Size:** M (1-2 days, depends on baseline count)
+**Priority:** P1
+**Deps:** S1.2
+
+### S1.4 — Enable ASAN+UBSAN on Linux CI
+**Problem:** `cmake/Sanitizers.cmake` defines all four sanitizers; all default OFF; none invoked in CI.
+**Acceptance:**
+- One CI job in `build_cmake.yml` runs with `-DENABLE_SANITIZER_ADDRESS=ON -DENABLE_SANITIZER_UNDEFINED_BEHAVIOR=ON`
+- Job passes on master HEAD; failures gate PRs
+- Documented as the "memory safety canary" job
+**Size:** S (2 hr)
+**Priority:** **P0**
+**Deps:** none
+
+### S1.5 — Enforce clang-tidy on changed lines
+**Problem:** `.clang-tidy` is configured (with `WarningsAsErrors: '*'`) but never runs in CI.
+**Acceptance:**
+- New CI workflow runs `clang-tidy-diff` on PRs, scoped to changed lines only
+- Existing violations are grandfathered (no big-bang cleanup required)
+- README/CONTRIBUTING explains how to run locally
+**Size:** M (1 day)
+**Priority:** P1
+**Deps:** none
+
+### S1.6 — Delete dead `ctest` invocation or wire to real tests
+**Problem:** `build_cmake.yml` runs `ctest` against an empty test suite — hollow gate.
+**Acceptance:**
+- After S2.1 lands, `ctest` invocation runs real tests
+- Or: invocation removed with a one-line comment until E2 lands
+**Size:** XS (15 min)
+**Priority:** P1
+**Deps:** S2.1 (preferred) or none (for the removal path)
+
+---
+
+## E2 — Test Foundation
+
+> "The MVP is not 80% coverage. It's the smallest test suite that prevents the next reverted PR."
+
+### S2.1 — Scaffold `tests/CMakeLists.txt` with Qt Test runner
+**Problem:** No `enable_testing()`, no `add_test()`, no test framework wired. Tests/ contains only manual shell scripts.
+**Acceptance:**
+- `enable_testing()` at top-level CMake
+- `tests/CMakeLists.txt` discovers and registers Qt Test executables
+- A single trivial test passes (e.g., `2+2==4`) to prove the wiring
+- `ctest` from build/ runs the suite
+**Size:** S (4 hr)
+**Priority:** **P0**
+**Deps:** none
+
+### S2.2 — Unit tests for `ConfigHandler::checkForErrors()`
+**Problem:** `confighandler.cpp:569-709` contains four validation layers (`checkUnrecognizedSettings`, `checkShortcutConflicts`, `checkSemantics`, orchestrator). Pure logic, no UI deps, ~50 schema options worth of edge cases.
+**Acceptance:**
+- One test per validation layer (4 minimum)
+- One round-trip test (write config → read config → no errors)
+- One test per schema-typed option category (Bool, BoundedInt, Color, String, ExistingDir)
+- Failure to load a malformed config produces structured `AbstractLogger` errors
+**Size:** M (1 day)
+**Priority:** **P0**
+**Deps:** S2.1
+
+### S2.3 — Unit tests for `FileNameHandler` path templating
+**Problem:** Filename generation uses `%TIME`, `%DATE`, and custom tokens. Untested edge cases (special chars, locale, fallbacks) are a frequent source of issues like the May 2026 locale fix at `filenamehandler.cpp:17-24`.
+**Acceptance:**
+- Round-trip tests for each supported token
+- Locale fallback test (catches the existing try/catch path)
+- Cross-platform path-separator tests
+- Invalid template handling
+**Size:** M (1 day)
+**Priority:** **P0**
+**Deps:** S2.1
+
+### S2.4 — Unit tests for `ValueHandler` type coercion
+**Problem:** `valuehandler.cpp` (585 LOC) coerces config strings to typed values. Untested.
+**Acceptance:**
+- One test per `ValueHandler` subclass (Bool, Int, Color, String, BoundedInt, etc.)
+- Boundary conditions (out-of-range, malformed strings)
+- Default-value fallback verified
+**Size:** M (1 day)
+**Priority:** P1
+**Deps:** S2.1
+
+### S2.5 — Per-platform capture smoke test
+**Problem:** Apple has shipped two privacy-permission changes in 18 months. Wayland portal spec evolves. Each change means a manual-detected regression (see #4664 — broke daemon-mode capture for all GNOME Wayland users until fixed reactively).
+**Acceptance:**
+- New CI workflow per platform (Linux xvfb, macOS-15, Windows-2025)
+- Each invokes `flameshot full --raw > capture.png`
+- Asserts non-empty, non-zero-pixel PNG output
+- Runs on every PR that touches `src/utils/screengrabber.*`
+- Runs nightly on `master`
+**Size:** M (2 days, mostly CI plumbing)
+**Priority:** P1
+**Deps:** none
+
+### S2.6 — CLI smoke tests
+**Problem:** `flameshot --help`, `flameshot config`, `flameshot gui`, etc., have no automated regression test.
+**Acceptance:**
+- Headless test invokes 8-10 CLI entry points
+- Asserts exit codes and stderr/stdout shape
+- Catches the `commandlineparser.cpp` (409 LOC) class of regressions early
+**Size:** S (4 hr)
+**Priority:** P1
+**Deps:** S2.1
+
+### S2.7 — Decide fate of `tests/action_options.sh` and `tests/path_option.sh`
+**Problem:** Two manual shell scripts that nobody runs. Either revive or delete.
+**Acceptance:**
+- Decision recorded in `docs/CONTRIBUTING.md`
+- Ported to Qt Test executables, OR deleted with rationale in commit message
+**Size:** XS-S (1 hr if delete; 4 hr if port)
+**Priority:** P2
+**Deps:** S2.1
+
+---
+
+## E3 — Cross-Platform Stability
+
+> "The macOS bug rate isn't because the code is bad — it's because Apple shipped two privacy-policy changes in 18 months."
+
+### S3.1 — Fix synchronous QEventLoop freeze in monitor selection
+**Problem:** `screengrabber.cpp:85-112` runs a synchronous `QEventLoop` with a 30-second timeout. On slow Wayland portal responses, the entire app freezes for up to 30s.
+**Acceptance:**
+- Replaced with async pattern (`QFutureWatcher` or signal callback)
+- UI remains responsive during portal wait
+- Existing 30s timeout preserved (now as a non-blocking timer)
+- Regression test added (S2.5 can verify)
+**Size:** M (1 day)
+**Priority:** P1
+**Deps:** S2.5 helpful but not blocking
+
+### S3.2 — Extract `PortalScreenGrabber` class
+**Problem:** xdg-desktop-portal code (lines 52-160 of `screengrabber.cpp`) is interleaved with X11/macOS/Win code in a 734-line file. Bug #4664 was in this block; isolating it is the first step toward testability.
+**Acceptance:**
+- New `src/utils/portalscreengrabber.{h,cpp}` (or similar)
+- `ScreenGrabber::grabScreen()` delegates to platform-specific class
+- All existing capture flows continue to work (verified by S2.5)
+- No behavior change — pure restructuring
+**Size:** M (1 day)
+**Priority:** P1
+**Deps:** S2.5 strongly recommended
+
+### S3.3 — Normalize runtime-vs-compile-time platform detection
+**Problem:** `screengrabber.cpp:126` uses `QGuiApplication::platformName()` (runtime) alongside `#if defined(Q_OS_MACOS)` (compile-time) for the same purpose in nearby code.
+**Acceptance:**
+- One detection model used consistently (runtime preferred for Linux WSI variants)
+- `DesktopInfo` (already exists in `src/utils/desktopinfo.h`) used as the single source
+- Migration documented in code comments where compile-time `#ifdef` is necessary (e.g., macOS Carbon API calls)
+**Size:** M (1 day)
+**Priority:** P2
+**Deps:** S3.2 (extraction makes this cleaner)
+
+### S3.4 — RFC: Subclass-per-platform `IScreenGrabber` interface
+**Problem:** Long-term architectural target — replace the `#ifdef` jungle with `X11ScreenGrabber`, `WaylandPortalScreenGrabber`, `MacOSScreenGrabber`, `WindowsScreenGrabber` as compile-conditional implementations.
+**Acceptance:**
+- RFC document in `docs/RFC/` with interface design, migration plan, testing approach
+- Reviewed by maintainers, decision recorded
+- Implementation deferred to v15 (do not build in v14)
+**Size:** M (1 day for RFC; XL if implemented)
+**Priority:** P2 (the RFC); P3 (the implementation)
+**Deps:** S3.2 should land first to inform the design
+
+### S3.5 — Group recent macOS fixes into a regression-prevention test set
+**Problem:** Five `fix(macos):` commits in the last 11 fixes (clipboard, fullscreen overlay, privacy API, config tab rendering, etc.). Each was reactive.
+**Acceptance:**
+- Each of the 5 fixes has a corresponding regression test (or test ticket if not currently testable)
+- Tests live in `tests/integration/macos/`
+- CI runs on macOS-15 arm64 + intel
+**Size:** L (3 days — depends on what's reachable from integration tests)
+**Priority:** P2
+**Deps:** S2.5
+
+### S3.6 — Investigate Windows screen-scaling pin position (related to #4614)
+**Problem:** Pin position on Windows for scaled screens was a recent fix; the root cause may have other manifestations.
+**Acceptance:**
+- Code audit of all `devicePixelRatio()` / scaling-related usage in `src/widgets/`
+- Regression test for pinning on a scaled display
+- Any additional issues filed as separate tickets
+**Size:** M (1 day audit + tests)
+**Priority:** P2
+**Deps:** S2.5
+
+---
+
+## E4 — Security & Network Hardening
+
+> "Five real findings. None are critical, but the QHotkey unpinning is the biggest open door."
+
+### S4.1 — Move Imgur Client ID to build-time define
+**Problem:** Default Imgur Client ID `313baf0c7b4d3ff` is hardcoded at `confighandler.cpp:134`. Distros currently can't easily override.
+**Acceptance:**
+- `-DFLAMESHOT_IMGUR_CLIENT_ID=...` CMake option
+- Default preserved for source builds
+- Documented in README "for packagers"
+**Size:** S (2 hr)
+**Priority:** P2
+**Deps:** none
+
+### S4.2 — Document or sandbox terminal launcher command injection vector
+**Problem:** `terminallauncher.cpp:48` passes a user-supplied string to a terminal emulator. Shell metacharacters will be interpreted. Not a vulnerability per se (user explicitly opted in), but a sharp edge.
+**Acceptance:**
+- Code comment at the call site explains the trust boundary
+- UI shows a one-time warning when adding a command containing shell metacharacters
+- OR: documented as a "by design" choice in `docs/SECURITY.md`
+**Size:** S (2 hr)
+**Priority:** P2
+**Deps:** none
+
+### S4.3 — Share `QNetworkAccessManager` across uploaders
+**Problem:** `imguruploader.h:29` creates a fresh NAM per uploader. No connection pooling; potential for cookie/cache divergence if more storage backends are added.
+**Acceptance:**
+- Singleton NAM owned at app or daemon level
+- Each uploader requests handles via a factory
+- No behavior change for the user
+**Size:** S (4 hr)
+**Priority:** P3
+**Deps:** none
+
+### S4.4 — Audit and document the D-Bus interface surface
+**Problem:** D-Bus interface is currently safe (session bus only, no shell command parameters, only byte arrays and text) but undocumented.
+**Acceptance:**
+- New `docs/dbus-interface.md` documenting every exposed method, parameter types, trust model
+- Linked from `docs/SECURITY.md`
+**Size:** S (3 hr)
+**Priority:** P2
+**Deps:** none
+
+### S4.5 — Add basic security policy and reporting
+**Problem:** No `SECURITY.md` at repo root. Researchers have no clear disclosure path.
+**Acceptance:**
+- `SECURITY.md` at repo root with supported versions, reporting email/process, expected response time
+- Linked from README
+**Size:** XS (1 hr)
+**Priority:** P1
+**Deps:** none
+
+---
+
+## E5 — Code-Health Cleanups
+
+> "Mechanical work that lowers contribution friction. Volunteers can pick these up between bigger tasks."
+
+### S5.1 — Convert 18 SLOT() strings to PMF connect form
+**Problem:** `capturewidget.cpp:1650-1718` uses string-based `SLOT()` connections that fail at runtime, not compile time.
+**Acceptance:**
+- All 18 connections use `&Class::method` form
+- Build passes; clang-tidy `modernize-use-default-member-init` happy
+**Size:** S (2 hr)
+**Priority:** P1
+**Deps:** none
+
+### S5.2 — Standardize `CaptureWidget` pointer ownership
+**Problem:** `capturewidget.h:187-206` mixes `QPointer<>` (auto-null on delete) with raw pointers manually deleted at `:572, 600, 606, 1468, 2022`. Latent crash risk for future contributors.
+**Acceptance:**
+- One ownership model used throughout (`QPointer` for all dynamically-deleted members recommended)
+- Code comment at the top of the member-declarations block explains the chosen rule
+- No behavior change
+**Size:** M (1 day)
+**Priority:** P1
+**Deps:** none
+
+### S5.3 — Replace `add_definitions()` with target-scoped calls
+**Problem:** `src/CMakeLists.txt:64-68` uses 5 deprecated `add_definitions()` calls for Windows version macros.
+**Acceptance:**
+- All 5 converted to `target_compile_definitions()` with explicit scope
+- Also fix `:104-105` (direct `CMAKE_CXX_FLAGS` manipulation for MSVC `/MP`)
+- Windows build still produces a working .exe
+**Size:** S (30 min)
+**Priority:** P2
+**Deps:** none
+
+### S5.4 — Promote magic numbers to named constants
+**Problem:** `capturewidget.cpp:701, 1091, 1157, 1194` contain unmarked pixel literals (`(0, 0, 10, 12)`, `200`, `QPoint(1000, 200)`).
+**Acceptance:**
+- Each magic number named (`const int XYWH_BOX_PADDING_X = 10;`) or moved to a theme/config struct
+- No behavior change; visual diff = zero pixels
+**Size:** S (2 hr)
+**Priority:** P3
+**Deps:** none
+
+### S5.5 — Consistent `AbstractLogger` use; remove silent error swallowing
+**Problem:** `screengrabber.cpp:381` returns `nullptr` silently; `screenshotsaver.cpp:78` returns `false` silently on some paths. 36 direct `qDebug`/`qWarning` calls bypass the well-designed `AbstractLogger` system.
+**Acceptance:**
+- Audit pass: every silent `return nullptr/false` either logs via `AbstractLogger` or has a code comment explaining why
+- New code follows the convention (documented in CONTRIBUTING.md)
+**Size:** M (1 day)
+**Priority:** P2
+**Deps:** none
+
+### S5.6 — Replace `QThread::msleep(delay)` in flameshot.cpp
+**Problem:** Blocks main thread for a synthetic delay. Should be a `QTimer::singleShot`.
+**Acceptance:**
+- `QThread::msleep` removed
+- Equivalent async behavior via `QTimer`
+- Tests (when they exist) prove the delay still applies
+**Size:** XS (30 min)
+**Priority:** P2
+**Deps:** none
+
+### S5.7 — Split `TextTool` configuration into its own helper class
+**Problem:** `texttool.cpp` is 357 LOC — 7x its peer tools. It directly inherits `CaptureTool` instead of using an abstract base, and embeds widget + config + font management.
+**Acceptance:**
+- Font / config logic moved to a helper class
+- TextTool LOC reduced to <150
+- Behavior unchanged (verified by tool unit tests when E2 progresses)
+**Size:** M (1 day)
+**Priority:** P3
+**Deps:** S2.1 helpful
+
+### S5.8 — Self-registering tool factory
+**Problem:** `toolfactory.cpp:35-71` is a hard-coded 24-case switch. Adding a tool requires touching 3+ central files. Closed to extension.
+**Acceptance:**
+- Tools register themselves at static-init time (X-macro list, or `REGISTER_TOOL()` macro)
+- Adding a new tool requires only adding files under `src/tools/<newname>/`
+- All 24 existing tools migrated; behavior unchanged
+**Size:** L (2 days)
+**Priority:** P3
+**Deps:** S2.1 (need to verify tool behavior preserved)
+
+---
+
+## E6 — Build & Packaging
+
+> "The #4658 ping-pong is the loudest signal in the repo. It's a process gap, not a code gap."
+
+### S6.1 — PR-blocking packaging matrix
+**Problem:** Packaging (.deb / .rpm / .dmg / .exe) only runs on `master` after merge, not on PRs. PR #4658 was merged → reverted → re-merged five times because packaging breakage wasn't visible pre-merge.
+**Acceptance:**
+- New `.github/workflows/packaging-pr.yml` builds all four package types on every PR
+- Failures block merge
+- Matrix kept lean: one representative distro per package format (Debian 12, Fedora latest, macOS-15, Windows-2025)
+- Build time documented; if >20min wall clock, consider matrix-skip rules
+**Size:** M (1 day)
+**Priority:** **P0**
+**Deps:** none
+
+### S6.2 — Pin all FetchContent dependencies
+**Problem:** Beyond QHotkey (S1.1), audit every other `FetchContent_Declare` for unpinned versions.
+**Acceptance:**
+- Spreadsheet in PR description: dep / current pin / desired pin / decision
+- All deps pinned to tag or SHA
+- Renovate-style note in CONTRIBUTING about when to update
+**Size:** S (2 hr)
+**Priority:** P1
+**Deps:** S1.1 sets the precedent
+
+### S6.3 — Reproducible build documentation
+**Problem:** README has install instructions per distro, but no "build the same binary twice and verify identical output" recipe.
+**Acceptance:**
+- New section in CONTRIBUTING.md
+- Step-by-step Docker recipe for reproducing the Linux build
+- Optional: bit-identical verification command
+**Size:** S (4 hr)
+**Priority:** P3
+**Deps:** S1.1, S6.2
+
+---
+
+## E7 — Documentation
+
+> "Lower the bar to contribution, especially for the first patch."
+
+### S7.1 — CONTRIBUTING.md test-writing section
+**Problem:** Currently no guidance on how to add a test. Without this, the test suite (E2) won't grow with the project.
+**Acceptance:**
+- "How to add a test" section in `docs/CONTRIBUTING.md`
+- One worked example (e.g., adding a `ConfigHandler` test)
+- Links to the Qt Test docs
+**Size:** S (4 hr)
+**Priority:** P1
+**Deps:** S2.1, S2.2
+
+### S7.2 — Architecture overview doc
+**Problem:** A new contributor reading `capturewidget.cpp` for the first time has no map. The tools/ plugin contract is good but undocumented.
+**Acceptance:**
+- New `docs/dev/architecture.md` with: app entry points, daemon lifecycle, capture pipeline, tool plugin contract, config layer
+- Diagrams optional but encouraged
+- Links to key files with line numbers
+**Size:** M (1 day)
+**Priority:** P2
+**Deps:** none
+
+### S7.3 — macOS-specific build guide
+**Problem:** README's macOS install section covers homebrew/macports but not building from source on Apple Silicon. With 5 of last 11 fixes being macOS-specific, more macOS contributors would help.
+**Acceptance:**
+- New section in README or `docs/dev/build-macos.md`
+- Tested recipe for both Apple Silicon and Intel
+- Includes `xattr` quarantine workaround
+- Mentions known limitations (no global hotkey, no D-Bus)
+**Size:** S (3 hr)
+**Priority:** P2
+**Deps:** none
+
+---
+
+## Priority Distribution
+
+| Tier | Count | Definition |
+|---|---|---|
+| **P0 (must-do for v14 GA)** | 6 | S1.1, S1.2, S1.4, S2.1, S2.2, S2.3, S6.1 |
+| **P1 (next release)** | 12 | S1.3, S1.5, S1.6, S2.4, S2.5, S2.6, S3.1, S3.2, S4.5, S5.1, S5.2, S6.2, S7.1 |
+| **P2 (nice-to-have)** | 13 | S2.7, S3.3, S3.4-RFC, S3.5, S3.6, S4.1, S4.2, S4.4, S5.3, S5.5, S5.6, S7.2, S7.3 |
+| **P3 (long-term)** | 6 | S3.4-impl, S4.3, S5.4, S5.7, S5.8, S6.3 |
+
+*P0 ≠ "all in v14 GA." It means "if we ship v14 without these, we ship the same delivery risk we have today." The realistic v14-GA scope is S1.1, S1.2, S1.4, S6.1 (the CI gates), plus S2.1 to unblock testing for v14.1.*
+
+---
+
+## Recommended Next Sprint (10 items, ~2 weeks volunteer effort)
+
+| # | Story | Size | Why this together |
+|---|---|---|---|
+| 1 | **S1.1** — Pin QHotkey | XS | Single highest-risk single-line fix in the repo |
+| 2 | **S1.2** — Enable warnings (no -Werror) | S | Sets up S1.3 follow-up; surfaces the warning baseline |
+| 3 | **S1.4** — ASAN+UBSAN on Linux CI | S | Cheapest memory-safety win; existing framework |
+| 4 | **S2.1** — `tests/CMakeLists.txt` scaffold | S | Prerequisite for every test going forward |
+| 5 | **S2.2** — `ConfigHandler` unit tests | M | First real test; immediately makes existing `ctest` invocation useful |
+| 6 | **S2.3** — `FileNameHandler` unit tests | M | Highest bug-density area; pays back fast |
+| 7 | **S5.1** — SLOT() → PMF | S | Mechanical, satisfying win for new contributors |
+| 8 | **S6.1** — PR-blocking packaging matrix | M | Directly prevents the #4658 ping-pong from recurring |
+| 9 | **S4.5** — `SECURITY.md` | XS | 1-hour fix; closes a basic OSS-hygiene gap |
+| 10 | **S7.1** — CONTRIBUTING.md testing section | S | Compounds the value of #4-6 by inviting contributors |
+
+**Rationale:** This sprint stands up the CI safety net before v14 GA. Together these items would have caught two of the last three reverted PRs (#4658 spec uniformization via #8; the empty-parent-window portal bug #4664 via #5+#6 if a capture smoke test had existed — close enough to motivate adding it next sprint as S2.5). None require touching CaptureWidget. Eight of the ten are sized XS-S; the two M-sized items (S2.2, S6.1) are independent and can be parallelized. A reasonable volunteer pace ships items 1, 4, 9 in week 1 (low-touch infrastructure) and 2, 3, 5, 6, 7, 8, 10 in week 2.
+
+---
+
+## Known Issues Cross-Reference
+
+| GitHub Issue / PR | Story Coverage |
+|---|---|
+| #3177 (fixed in 95032bd2) | None needed — fixed |
+| #4664 (X11 portal parent_window) | S2.5 (regression test); S3.2 (portal extraction) |
+| #4658 (spec uniformization ping-pong) | **S6.1** — the direct fix |
+| #4676, #4675, #4658 (revert cycles) | Same — S6.1 |
+| #4680 (fix for #3177) | Already merged |
+| #4692 (v14 beta 2 prep) | Current state |
+| #4622, #4629, #4617, #4627, #4614 (recent macOS fixes) | S3.5 (regression test set); S2.5 (per-platform smoke) |
+| #4637 (KDE Plasma keyboard shortcut config) | No direct story; consider as ad-hoc fix |
+| #4596 (cosmic full-screen) | S3.3 (runtime platform detection improvement) |
+
+---
+
+## Notes on Effort Sizing
+
+This backlog uses S/M/L sizing calibrated for volunteer OSS contributors working evenings/weekends:
+
+- **XS** = under 1 hour, often a single-line change
+- **S** = 1-4 hours, single sitting
+- **M** = 1 day, plus review cycle
+- **L** = 2-3 days, multi-session work
+- **XL** = a week+, architectural change
+
+The implicit overhead per story (review, CI cycles, addressing feedback) is roughly 1× the build estimate for an OSS project. Plan sprint capacity accordingly.
+
+## What This Backlog Does NOT Recommend
+
+- **A v14 CaptureWidget rewrite.** Untestable currently; refactor without tests is net-negative. (See staff review for unanimous panel agreement.)
+- **A full Qt6 modernization pass** (`qt_add_executable` etc.). Mechanical, low value, easy to do later.
+- **Pulling QHotkey in-tree.** Maintenance cost > supply-chain benefit if it's pinned (S1.1).
+- **Coverage targets.** A volunteer project chasing 80% coverage is a dead project. The aim is "tests for the things most likely to break," not numerical thresholds.
+- **A test-driven rewrite of any kind in v14.** v14 is in beta. New features, new structure, and new abstractions all wait for v15.

--- a/docs/backlog/20260520-1620-flameshot-v14-backlog.md
+++ b/docs/backlog/20260520-1620-flameshot-v14-backlog.md
@@ -1,8 +1,36 @@
 # Flameshot — Prioritized Backlog (post-v14 beta 2)
 
-**Date:** 2026-05-20
+**Date:** 2026-05-20 (updated 22:40)
 **Source:** [Staff Engineer Panel Review](../reviews/20260520-1620-flameshot-staff-review.md)
-**Repo state:** `master` @ `1ee047f1 prep for v14 beta 2 (#4692)`, clean working tree.
+**Repo state:** branch `pr1-turn-on-alarms` @ `72fdd9bd`, 5 commits ahead of `master`, working tree clean.
+
+---
+
+## Progress Log
+
+### 2026-05-20 evening — PR-1 "Turn on the alarms" — IN FLIGHT
+
+Branch `pr1-turn-on-alarms` created off `master @ 1ee047f1`. Commits landed:
+
+| Commit | Story | Status |
+|---|---|---|
+| `b388c66d` | Docs (staff review + backlog) | ✅ committed |
+| `10ff5140` | **S1.1** — Pin QHotkey | ✅ committed — fork has no release tags, pinned to current HEAD SHA `d7063877` instead |
+| `4090fa11` | **S1.2** — Enable warnings framework (errors OFF) | ✅ committed — `WARNINGS_AS_ERRORS=OFF` forced for initial landing |
+| `4e23f9da` | **S1.4** — Add ASAN+UBSAN Linux CI job | ✅ committed — `linux-sanitizers` job in `build_cmake.yml` |
+| `72fdd9bd` | **S2.7** — Document manual test scripts | ✅ committed — chose "keep + document" path, added `tests/README.md` |
+
+**Not yet done (pick up next session):**
+- ❌ **Local build verification** on macOS — paused before installing `qt@6`/`cmake`/`ninja` via brew. The four changes are mechanical and reviewed, but no compiler has touched them yet. Recommended verification order when resuming: (1) `cmake` configure-only on this Mac (cheap, catches CMake syntax errors and validates the QHotkey pin downloads); (2) full local build (also satisfies the "can we install on the MacBook" question from the same session); (3) push branch to trigger CI matrix (truth source for the sanitizer job and Linux/Windows builds).
+- ❌ **PR not opened.** No `gh pr create` yet — branch is local only. Open when verification passes.
+
+**Risk notes:**
+- S1.2 is the riskiest commit: uncommenting `set_project_warnings(project_warnings)` will surface every latent warning across 225 files. With `WARNINGS_AS_ERRORS=OFF` it can't break the build, but the noise volume in CI logs may be substantial. Capture the count when first CI run completes — that baseline informs S1.3 sizing.
+- S1.4 sanitizer job runs `ctest` which is currently empty. Job will pass trivially today; real coverage starts when S2.1+ land.
+
+**Next session entry point:** `git checkout pr1-turn-on-alarms` then either run the local verify or `git push -u origin pr1-turn-on-alarms` for CI.
+
+---
 
 ---
 
@@ -36,23 +64,23 @@ This backlog organizes 38 stories across 7 epics, sized for an OSS project with 
 
 > "Most of the tools to fix this codebase are already in `cmake/`. They're just not turned on."
 
-### S1.1 — Pin QHotkey dependency
+### S1.1 — Pin QHotkey dependency ✅ DONE (`10ff5140`)
 **Problem:** `CMakeLists.txt:144-149` pins QHotkey to branch `master`. Non-reproducible build; vulnerable to upstream changes.
 **Acceptance:**
-- `GIT_TAG` references a release tag (`v1.5.0`) or full commit SHA
-- Build produces identical output across two consecutive runs
-- CMake fetch warning eliminated
-**Size:** XS (30 min)
+- ✅ `GIT_TAG` references full commit SHA `d7063877c14d5ae2b489dc70bbe02e76a43bf38b` (fork has no release tags)
+- ⏳ "Build produces identical output across two consecutive runs" — pending build verification
+- ⏳ CMake fetch warning eliminated — pending build run
+**Size:** XS (30 min) — actual: 15 min
 **Priority:** **P0**
 **Deps:** none
 
-### S1.2 — Enable warnings framework (no -Werror)
+### S1.2 — Enable warnings framework (no -Werror) ✅ DONE (`4090fa11`)
 **Problem:** `cmake/CompilerWarnings.cmake` is fully defined but never invoked — `set_project_warnings()` is commented out at `CMakeLists.txt:109`.
 **Acceptance:**
-- Line 109 uncommented with `WARNINGS_AS_ERRORS=FALSE`
-- Build still succeeds across all three platforms in CI
-- Warning count baseline captured in a CI summary
-**Size:** S (1 hr config + observe)
+- ✅ Line 109 replaced with `set_project_warnings(project_warnings)`; `WARNINGS_AS_ERRORS=OFF` forced via CACHE override
+- ⏳ "Build still succeeds across all three platforms in CI" — pending push
+- ⏳ "Warning count baseline captured in a CI summary" — capture from first CI run; informs S1.3 sizing
+**Size:** S (1 hr config + observe) — actual: 20 min config
 **Priority:** **P0**
 **Deps:** none
 
@@ -66,13 +94,14 @@ This backlog organizes 38 stories across 7 epics, sized for an OSS project with 
 **Priority:** P1
 **Deps:** S1.2
 
-### S1.4 — Enable ASAN+UBSAN on Linux CI
+### S1.4 — Enable ASAN+UBSAN on Linux CI ✅ DONE (`4e23f9da`)
 **Problem:** `cmake/Sanitizers.cmake` defines all four sanitizers; all default OFF; none invoked in CI.
 **Acceptance:**
-- One CI job in `build_cmake.yml` runs with `-DENABLE_SANITIZER_ADDRESS=ON -DENABLE_SANITIZER_UNDEFINED_BEHAVIOR=ON`
-- Job passes on master HEAD; failures gate PRs
-- Documented as the "memory safety canary" job
-**Size:** S (2 hr)
+- ✅ New `linux-sanitizers` job in `build_cmake.yml` runs with `-DENABLE_SANITIZER_ADDRESS=ON -DENABLE_SANITIZER_UNDEFINED_BEHAVIOR=ON`
+- ✅ `UBSAN_OPTIONS=halt_on_error=1` to make violations loud; `ASAN_OPTIONS=detect_leaks=0` to silence Qt's noisy at-exit "leaks"
+- ⏳ "Job passes on master HEAD" — pending push
+- ⏳ Will pass trivially today (empty `ctest`); real coverage starts after S2.1+
+**Size:** S (2 hr) — actual: 30 min
 **Priority:** **P0**
 **Deps:** none
 
@@ -166,14 +195,15 @@ This backlog organizes 38 stories across 7 epics, sized for an OSS project with 
 **Priority:** P1
 **Deps:** S2.1
 
-### S2.7 — Decide fate of `tests/action_options.sh` and `tests/path_option.sh`
+### S2.7 — Decide fate of `tests/action_options.sh` and `tests/path_option.sh` ✅ DONE (`72fdd9bd`)
 **Problem:** Two manual shell scripts that nobody runs. Either revive or delete.
 **Acceptance:**
-- Decision recorded in `docs/CONTRIBUTING.md`
-- Ported to Qt Test executables, OR deleted with rationale in commit message
-**Size:** XS-S (1 hr if delete; 4 hr if port)
+- ✅ Decision: **keep + document**. They are real, usable manual smoke recipes — just undiscoverable.
+- ✅ Added `tests/README.md` describing what each covers, how to run, dependencies, and why they're not in CI
+- ⏳ Future port to Qt Test runner deferred to when S2.1 lands
+**Size:** XS-S (1 hr if delete; 4 hr if port) — actual: 25 min for the README path
 **Priority:** P2
-**Deps:** S2.1
+**Deps:** S2.1 (only if porting; the document-only decision unblocks)
 
 ---
 
@@ -471,18 +501,22 @@ This backlog organizes 38 stories across 7 epics, sized for an OSS project with 
 
 ## Recommended Next Sprint (10 items, ~2 weeks volunteer effort)
 
-| # | Story | Size | Why this together |
-|---|---|---|---|
-| 1 | **S1.1** — Pin QHotkey | XS | Single highest-risk single-line fix in the repo |
-| 2 | **S1.2** — Enable warnings (no -Werror) | S | Sets up S1.3 follow-up; surfaces the warning baseline |
-| 3 | **S1.4** — ASAN+UBSAN on Linux CI | S | Cheapest memory-safety win; existing framework |
-| 4 | **S2.1** — `tests/CMakeLists.txt` scaffold | S | Prerequisite for every test going forward |
-| 5 | **S2.2** — `ConfigHandler` unit tests | M | First real test; immediately makes existing `ctest` invocation useful |
-| 6 | **S2.3** — `FileNameHandler` unit tests | M | Highest bug-density area; pays back fast |
-| 7 | **S5.1** — SLOT() → PMF | S | Mechanical, satisfying win for new contributors |
-| 8 | **S6.1** — PR-blocking packaging matrix | M | Directly prevents the #4658 ping-pong from recurring |
-| 9 | **S4.5** — `SECURITY.md` | XS | 1-hour fix; closes a basic OSS-hygiene gap |
-| 10 | **S7.1** — CONTRIBUTING.md testing section | S | Compounds the value of #4-6 by inviting contributors |
+| # | Story | Size | Status | Why this together |
+|---|---|---|---|---|
+| 1 | **S1.1** — Pin QHotkey | XS | ✅ committed (`10ff5140`) | Single highest-risk single-line fix in the repo |
+| 2 | **S1.2** — Enable warnings (no -Werror) | S | ✅ committed (`4090fa11`) | Sets up S1.3 follow-up; surfaces the warning baseline |
+| 3 | **S1.4** — ASAN+UBSAN on Linux CI | S | ✅ committed (`4e23f9da`) | Cheapest memory-safety win; existing framework |
+| 4 | **S2.1** — `tests/CMakeLists.txt` scaffold | S | ⏸ next | Prerequisite for every test going forward |
+| 5 | **S2.2** — `ConfigHandler` unit tests | M | ⏸ next | First real test; immediately makes existing `ctest` invocation useful |
+| 6 | **S2.3** — `FileNameHandler` unit tests | M | ⏸ next | Highest bug-density area; pays back fast |
+| 7 | **S5.1** — SLOT() → PMF | S | ⏸ next | Mechanical, satisfying win for new contributors |
+| 8 | **S6.1** — PR-blocking packaging matrix | M | ⏸ next | Directly prevents the #4658 ping-pong from recurring |
+| 9 | **S4.5** — `SECURITY.md` | XS | ⏸ next | 1-hour fix; closes a basic OSS-hygiene gap |
+| 10 | **S7.1** — CONTRIBUTING.md testing section | S | ⏸ next | Compounds the value of #4-6 by inviting contributors |
+
+Plus side win this evening: **S2.7** (document the manual test scripts) committed as `72fdd9bd`. Not on the original next-sprint list but it slotted in naturally with the PR-1 work.
+
+**Sprint progress: 4/10 stories committed + 1 bonus** (S1.1, S1.2, S1.4, S2.7 — call it 4½). PR not yet opened pending build verification. The remaining six stories (#4-#10) are the natural pickup for the next working session.
 
 **Rationale:** This sprint stands up the CI safety net before v14 GA. Together these items would have caught two of the last three reverted PRs (#4658 spec uniformization via #8; the empty-parent-window portal bug #4664 via #5+#6 if a capture smoke test had existed — close enough to motivate adding it next sprint as S2.5). None require touching CaptureWidget. Eight of the ten are sized XS-S; the two M-sized items (S2.2, S6.1) are independent and can be parallelized. A reasonable volunteer pace ships items 1, 4, 9 in week 1 (low-touch infrastructure) and 2, 3, 5, 6, 7, 8, 10 in week 2.
 

--- a/docs/reviews/20260520-1620-flameshot-staff-review.md
+++ b/docs/reviews/20260520-1620-flameshot-staff-review.md
@@ -1,0 +1,342 @@
+# Flameshot v14 — Staff Engineer Panel Review
+
+**Date:** 2026-05-20
+**Panel:** Tim (SpaceX), Rob (Roblox), Fran (Meta), Al (AWS), Will Larson (Moderator)
+**Trigger:** User-requested deep technical dive on the Flameshot codebase ahead of v14.0.0 GA. Output is intended to feed `/pm` directly into a prioritized backlog.
+**Repo state at review:** `master` clean, in sync with `origin/master`, HEAD = `1ee047f1 prep for v14 beta 2 (#4692)`.
+
+---
+
+## Problem Statement
+
+**Work type:** Architectural / Enhancement.
+
+Flameshot is a mature C++/Qt6 cross-platform screenshot/annotation tool, ~225 source files, 14 years of organic growth. v14.0.0 is in beta 2. The user asked for "improvements we can make to the code" with a full backlog suitable for incremental adoption by volunteer contributors.
+
+### Quantified state
+
+| Concern | Quantified |
+|---|---|
+| God object — `CaptureWidget` | **2,085 LOC** in one file, owns event routing + tool lifecycle + undo + panel coordination |
+| Top 5 source files (LOC) | `capturewidget.cpp` 2085 / `generalconf.cpp` 991 / `confighandler.cpp` 844 / `screengrabber.cpp` 734 / `main.cpp` 684 |
+| Automated test coverage | **0%**. Two shell scripts (`tests/action_options.sh`, `tests/path_option.sh`) require human verification |
+| CI test gate | `build_cmake.yml` invokes `ctest` against an empty suite — hollow gate |
+| Warnings framework | `set_project_warnings()` is **commented out** at `CMakeLists.txt:109` — defined but not applied |
+| Supply chain | QHotkey pinned to `master` branch (`CMakeLists.txt:147`), not a tag or SHA |
+| Release-engineering signal | PR **#4658** (openSUSE spec uniformization) has flipped merged↔reverted **5 times** in the past month |
+| Recent fix density | **5 of last 11 fixes are `fix(macos):`** — macOS is the most volatile surface |
+| Logging discipline | 36 `qDebug/qWarning` calls across 225 files; `AbstractLogger` is well-designed but inconsistently used |
+| TODO/FIXME markers | 37 total — low |
+| Tooling exists but disabled | clang-tidy config + ASAN/UBSAN/TSAN/MSAN options + warnings framework all defined and unused |
+
+### Root-cause chain
+
+1. No automated tests →
+2. No mechanism to detect regression →
+3. Maintainers can't tell which PRs are safe →
+4. Process becomes "merge → observe in production → revert if broken" (the #4658 ping-pong) →
+5. Refactor work piles up because nobody can verify it →
+6. CaptureWidget becomes unmaintainable god class
+
+### Constraints
+
+- Open-source, volunteer maintainers, no paid team
+- v14 is in beta — narrow window for small wins, no window for big refactors
+- The 2,085-line `CaptureWidget` is load-bearing
+
+---
+
+## Panel Analysis
+
+### Tim — Staff Engineer, SpaceX
+
+**Risk assessment:** The single failure mode that scares me is **regression silence**. You have a 2,085-line god class that paints, routes events, owns tool state, and manages undo — and zero automated tests. Every PR that touches `capturewidget.cpp` is rolling dice. The #4658 five-cycle merge/revert isn't a code smell, it's a delivery-system failure.
+
+**Risk matrix:**
+
+| Risk | P (1-5) | C (1-5) | Score |
+|---|---|---|---|
+| Regression in CaptureWidget on next refactor | 5 | 5 | **25** |
+| QHotkey `master` branch hijack or breaking-change cascade | 2 | 5 | 10 |
+| #4658-style merge/revert ping-pong continues | 5 | 3 | 15 |
+| Silent error swallow ships a bad upload to user | 3 | 3 | 9 |
+| macOS Sonoma+ permission API drift breaks capture again | 4 | 4 | 16 |
+
+**Key quote:** *"You don't have a tech-debt problem. You have a 'can't verify anything is safe' problem. Fix that first; the rest follows."*
+
+**Unique contribution:** The 5x ping-pong on #4658 is not a "fix the spec file" problem — it's evidence the team can't tell when a packaging change is safe. The fix isn't more careful reviewing, it's a packaging-smoke-test job that builds the .deb/.rpm/.dmg/.exe on every PR.
+
+### Rob — Staff Engineer, Roblox
+
+**Risk assessment:** CaptureWidget makes **83+ direct calls into child panels**. Those are 83 things that break silently when a child widget changes its API. The plugin model (`src/tools/`) is actually well-designed (23 `emit requestAction(Request)` calls, zero downcasts, complete i18n), but the capture widget is the festering hotspot.
+
+The latent bug nobody's talking about: memory-model inconsistency in `capturewidget.h:187-206`. Some members are `QPointer` (auto-null on delete), some are raw pointers with manual `delete` calls (lines 572, 600, 606, 1468, 2022). Adding a new feature in 18 months that calls into one of the raw-pointer members after deletion = intermittent crash, nightmare to repro.
+
+**Key quote:** *"The plugin model is good — leave it alone. The capture widget is bad — but you can't fix it without tests. Pick the boring path."*
+
+**Unique contribution:** `screengrabber.cpp:85-112` spins a synchronous `QEventLoop` with a 30-second timeout during monitor selection. On a slow Wayland portal response, that **freezes the entire app for 30 seconds**. Real reported-but-unfiled bug waiting to happen.
+
+### Fran — Staff Engineer, Meta
+
+**Risk assessment:** Stop thinking "improve the code" and start bucketing:
+
+**Bucket A — Fix yesterday (CI gates):**
+- Warnings framework off (`CMakeLists.txt:109`) — turn on
+- QHotkey on `master` — pin
+- clang-tidy config exists but doesn't run — wire it
+- CI calls `ctest` against empty suite — add a real test
+
+**Bucket B — Compounding (test foundation):**
+- Smoke tests for CLI entry points
+- Unit tests for `ConfigHandler::checkForErrors()` (already isolated, `confighandler.cpp:569-709`)
+- Unit tests for `FileNameHandler`
+- One per-platform headless capture smoke
+
+**Bucket C — Don't care (yet):** Decomposing CaptureWidget. Without tests, decomposing it makes things worse. Revisit v15.
+
+**Key quote:** *"Sort everything into 'fix yesterday', 'compound', and 'don't care'. Most projects die because they confuse the buckets."*
+
+**Unique contribution:** The #4658 ping-pong is a **process gap**, not a code problem. There's no .deb/.rpm/.dmg build that runs on every PR (only on master). Move packaging to PR-blocking.
+
+### Al — Staff Engineer, AWS (Qt/Desktop platform analog)
+
+**Risk assessment:** You have **three different cross-platform problems pretending to be one:**
+
+1. **Screen capture** — fundamentally different APIs per platform. Currently `#if defined(Q_OS_*)` jungle in `screengrabber.cpp`. Tolerable at 3 branches; unmaintainable when each branch has sub-cases (GNOME 45 vs GNOME 46 — exactly the bug #4664 fixed).
+2. **Global hotkey** — delegated to QHotkey dep. **Right call. Don't bring it in-tree.**
+3. **Single-instance / IPC** — D-Bus vs KDSingleApplication split via `#ifdef`. Each path is small. OK.
+
+The actual platform problem is #1. Extract `IScreenGrabber` → `X11ScreenGrabber`, `WaylandPortalScreenGrabber`, `MacOSScreenGrabber`, `WindowsScreenGrabber`. Then #4664-style bugs are "diff one file, write one test."
+
+On macOS bug surge: Apple's privacy-permission cadence will keep producing these. Write **one integration test per platform** that catches "did capture return non-null pixels" so regressions are caught in CI.
+
+**Key quote:** *"The macOS bug rate isn't because the code is bad — it's because Apple shipped two privacy-policy changes in 18 months. Build a test that runs after every OS release, not patches reactive to each issue."*
+
+**Unique contribution:** Runtime vs compile-time platform detection is mixed. `QGuiApplication::platformName()` at `screengrabber.cpp:126` runs alongside `#if defined(Q_OS_MACOS)` in nearby code. Pick one model.
+
+---
+
+## Consensus Matrix
+
+| Question | Tim | Rob | Fran | Al |
+|---|---|---|---|---|
+| Refactor CaptureWidget now? | No | No | No | No |
+| Enable warnings framework (1-line)? | **Yes** | Yes | Yes | Yes |
+| Pin QHotkey to tag/SHA? | **Yes** | Yes | Yes | Yes |
+| Unit-test ConfigHandler/FileNameHandler/ValueHandler first? | Yes | Yes | **Yes** | Yes |
+| Per-PR packaging build matrix? | Yes | Yes | **Yes** | Yes |
+| Per-platform capture smoke test? | Yes | Yes | Yes | **Yes** |
+| Standardize CaptureWidget pointer ownership? | Yes | **Yes** | Defer | Yes |
+| Convert `SLOT()` strings to PMF? | Yes | **Yes** | Yes | Yes |
+| Extract portal code from screengrabber? | Defer | Yes | Defer | **Yes** |
+| Pull QHotkey in-tree? | No | No | No | No |
+| Big-bang Qt6 modernization? | No | No | No | No |
+| Move clang-tidy from available → enforced? | Yes | Yes | **Yes** | Yes |
+
+**Unanimous (8):** Don't refactor CaptureWidget · Enable warnings · Pin QHotkey · Test isolated logic first · PR packaging matrix · Per-platform capture smoke · Convert SLOT() strings · Enforce clang-tidy on diffs
+
+**Majority (3-of-4):** Extract portal code · Standardize pointer ownership
+
+---
+
+## Will's Clarifying Questions (with verified answers)
+
+| Question | Answer | Impact |
+|---|---|---|
+| Does CI actually run `ctest`? | Yes — `build_cmake.yml` runs it against an empty suite | Adding ONE real test immediately makes existing CI infra useful |
+| Current C++ standard? | **C++20** via `cxx_std_20` in `cmake/StandardProjectSettings.cmake:18` | No urgent "modernize" epic |
+| `compile_commands.json` exported? | Yes (`StandardProjectSettings.cmake:18`) | clang-tidy can run today with no CMake changes |
+| Sanitizers framework exist but disabled? | Yes — all four sanitizers defined, all default OFF | Easy win: enable ASAN+UBSAN on Linux CI |
+| Contributor / testing docs? | README has compile/install per-distro; no testing guide because there are no tests | New "How to write a test" doc must accompany test foundation work |
+| QHotkey has a Qt6-compatible tagged release? | Repo is `flameshot-org/QHotkey` fork; upstream last release was `v1.5.0` (2024) | Pin to `v1.5.0` or fork HEAD SHA |
+| Anybody run the shell scripts? | Manual-only, no CI hook | Effectively dead — revive (port to real runner) or delete |
+| Is uncommenting warnings safe? | Risk: `WARNINGS_AS_ERRORS` defaults TRUE — might break first build | Update plan: land warnings ON + errors OFF first, fix, then flip |
+
+### Reassessment
+
+- **Warnings framework:** Two-step rollout. (1) Enable warnings, errors OFF — 1 hr. (2) Fix the warnings — 1-2 days. (3) Flip errors ON — 5 min.
+- **Sanitizers:** Added to the recommendation list — ASAN+UBSAN on the Linux CI job. ~2 hr.
+
+---
+
+## Will Larson's Decision — Top 13 Ranked Improvements
+
+| # | What | Why now | File:Line | Effort |
+|---|---|---|---|---|
+| 1 | Pin QHotkey to a release tag or SHA | Supply-chain risk; non-reproducible builds | `CMakeLists.txt:144-149` | **S** (30 min) |
+| 2 | Enable warnings framework (no -Werror first) | One-line uncomment exposes years of latent issues | `CMakeLists.txt:109` | **S** (1 hr) |
+| 3 | Wire `enable_testing()` + Qt Test runner | Foundation for everything else; replaces hollow `ctest` | new `tests/CMakeLists.txt` | **S** (4 hr) |
+| 4 | Unit tests for `ConfigHandler` validation | Already isolated logic; catches config-schema bugs forever | `confighandler.cpp:569-709` | **M** (1 day) |
+| 5 | Unit tests for `FileNameHandler` + `ValueHandler` | Pure logic, no UI deps | `filenamehandler.cpp`, `valuehandler.cpp` | **M** (1 day) |
+| 6 | Add packaging matrix as PR-blocking job | Exactly what #4658's ping-pong needed | new `.github/workflows/packaging-pr.yml` | **M** (1 day) |
+| 7 | Add ASAN+UBSAN to Linux CI build | Sanitizers framework exists, just flip flags | `cmake/Sanitizers.cmake`, `build_cmake.yml` | **S** (2 hr) |
+| 8 | Per-platform capture smoke test (asserts non-null pixmap) | Catches recurring macOS-permission and X11-portal regressions | new `tests/integration/` | **M** (2 days) |
+| 9 | Convert 18 SLOT() strings to PMF in `initShortcuts` | Compile-time safety; mechanical | `capturewidget.cpp:1650-1718` | **S** (2 hr) |
+| 10 | Fix screengrabber synchronous `QEventLoop` freeze | Real UX bug — 30s app freeze on slow portal | `screengrabber.cpp:85-112` | **M** (1 day) |
+| 11 | Standardize `CaptureWidget` pointer ownership | Prevent slow-motion crash bug | `capturewidget.h:187-206` | **M** (1 day) |
+| 12 | Extract xdg-desktop-portal block into `PortalScreenGrabber` class | First testable platform-impl boundary; isolates #4664-style hotspot | `screengrabber.cpp:52-160` | **M** (1 day) |
+| 13 | Enable clang-tidy on diff'd lines in CI | Per-PR quality ratchet | `.clang-tidy` + new workflow | **M** (1 day) |
+
+## The 3 Biggest Architectural Risks if Unaddressed
+
+1. **CaptureWidget will eventually require a rewrite no one can ship.** At 2,085 LOC with zero tests, every quarter that passes makes the rewrite cost grow super-linearly while willingness shrinks. *Not urgent in v14, critical for v15 planning.* Mitigation: write tests around it first (items 4-8), so a future rewrite can be verified incrementally.
+
+2. **The platform-conditional jungle in `screengrabber.cpp` will turn each new macOS/GNOME/Wayland release into a fire drill.** Apple's privacy-permission cadence and Wayland portal spec evolution will keep producing #4664-style bugs. Cost-per-bug grows because each fix touches the same big function. Mitigation: portal extraction (item 12) — once one platform is a separate class, the rest follow.
+
+3. **No mechanism exists to detect that a packaging change is safe to ship.** #4658 ping-pong is the symptom; the disease is that maintainers can't tell which downstream distros a spec-file change broke. Mitigation: PR-blocking packaging matrix (item 6) — single highest-leverage process change in this entire review.
+
+## Recommended Test Strategy (from zero)
+
+The pragmatic MVP — **not** chasing coverage percentages.
+
+**Tier 1 — Compile/static safety (ship in days, no test code):**
+- Warnings on (item 2) → fix easy ones → flip to -Werror
+- clang-tidy on changed lines (item 13)
+- ASAN+UBSAN on Linux CI (item 7)
+
+**Tier 2 — Pure-logic unit tests (ship in 1-2 weeks):**
+- `ConfigHandler` validation (~50 option schemas, error paths) — item 4
+- `FileNameHandler` (path templating, edge cases on `%TIME`, `%DATE`, special chars) — item 5
+- `ValueHandler` (type coercion, validation) — item 5
+
+These three give the most coverage per hour: ~2,200 LOC of validation/parsing already isolated with no Qt-UI dependencies.
+
+**Tier 3 — One smoke per platform (ship in 2-3 weeks):**
+- Linux: `xvfb-run flameshot full --raw > /tmp/x.png; verify non-empty PNG`
+- macOS: same via GUI runner in `macos-15` GH runner
+- Windows: same via PowerShell
+
+Just one per platform. Goal isn't testing capture quality — it's catching "capture returns null after the OS API changes."
+
+**Tier 4 (deferred to v15+):** Tool-by-tool unit tests using the `CaptureTool` fixture (plugin model is clean enough to support this).
+
+**What NOT to do:** Don't try to test `CaptureWidget` directly. It's untestable in its current shape; testing-first blocks on refactoring-first which the panel unanimously says don't do yet.
+
+## Quick-Wins List (≤1 day each, no dependencies)
+
+| # | Action | Effort | File:Line |
+|---|---|---|---|
+| Q1 | Pin QHotkey | 30 min | `CMakeLists.txt:147` |
+| Q2 | Replace `add_definitions()` with `target_compile_definitions()` | 30 min | `src/CMakeLists.txt:64-68` |
+| Q3 | Convert 18 SLOT() strings to PMF | 2 hr | `capturewidget.cpp:1650-1718` |
+| Q4 | Enable warnings (without -Werror) | 1 hr | `CMakeLists.txt:109` |
+| Q5 | Enable ASAN+UBSAN on Linux CI | 2 hr | `cmake/Sanitizers.cmake`, `build_cmake.yml` |
+| Q6 | Delete or revive `action_options.sh` / `path_option.sh` | 1 hr | `tests/` |
+| Q7 | Add `enable_testing()` and tests/CMakeLists.txt scaffold | 1 hr | new `tests/CMakeLists.txt` |
+| Q8 | Add `.editorconfig` | 15 min | new `.editorconfig` |
+| Q9 | Document the test-writing workflow in CONTRIBUTING.md | 4 hr | `docs/CONTRIBUTING.md` |
+| Q10 | Replace silent `return nullptr` with `AbstractLogger::error()` log | 30 min | `screengrabber.cpp:381` |
+
+A volunteer with one weekend can land Q1-Q5 + Q7-Q8 — eight PRs that materially improve the project.
+
+## What's Explicitly Deferred
+
+| Item | Rationale | Revisit When |
+|---|---|---|
+| `CaptureWidget` decomposition | Untestable currently; refactor without tests is net-negative | After Tier 2+3 tests land |
+| Subclass-per-platform `ScreenGrabber` | Right destination, wrong order | After portal extraction (item 12) proves the pattern |
+| `qt_add_executable` / `qt_finalize_target` migration | Mechanical, low value | When upgrading to Qt 6.7+ |
+| Pulling QHotkey in-tree | Maintenance cost > supply-chain benefit if pinned | Only if upstream goes abandoned |
+| Async-everywhere capture pipeline refactor | Big swing, not justified by current bug rate (except 30s freeze) | After v15 |
+
+## Key Takeaways
+
+> *"The 5x merge/revert on #4658 is the loudest signal in this repo. It's not a code problem — it's a 'we cannot verify a change before shipping it' problem."* — Tim
+
+> *"The tool plugin model is good. The capture widget is bad. Don't refactor the bad without tests, and don't touch the good at all."* — Rob
+
+> *"Bucket A, B, C. Projects die because they confuse the buckets."* — Fran
+
+> *"The macOS bug rate is Apple's fault, not yours. The fix is a per-OS-release test, not chasing each issue."* — Al
+
+**Generalizable insights:**
+- A 2,000-line god class with zero tests is locked in place — tests are the prerequisite to any future cleanup.
+- "Pin your deps" and "actually run the warnings you've already configured" are the cheapest wins almost any project has lying around.
+- Process gaps (packaging not gated) masquerade as code problems (spec file keeps breaking).
+- For a volunteer OSS project, the question isn't "what's optimal" — it's "what's the smallest set of changes that compounds."
+
+## Files Referenced
+
+| File | Role |
+|---|---|
+| `CMakeLists.txt` | Root build, FetchContent pinning, warnings opt-in |
+| `cmake/CompilerWarnings.cmake` | Detailed but un-invoked warning framework |
+| `cmake/Sanitizers.cmake` | ASAN/UBSAN/TSAN/MSAN options, all default OFF |
+| `cmake/StaticAnalyzers.cmake` | clang-tidy + cppcheck, opt-in only |
+| `cmake/StandardProjectSettings.cmake` | C++20 standard, compile_commands.json |
+| `src/CMakeLists.txt` | Deprecated `add_definitions` at :64-68 |
+| `src/widgets/capture/capturewidget.{h,cpp}` | 2085 LOC god class; mixed pointer ownership |
+| `src/widgets/capture/selectionwidget.cpp` | 569 LOC, 150-line event filter |
+| `src/widgets/capture/buttonhandler.cpp` | 395 LOC |
+| `src/tools/capturetool.{h,cpp}` | Plugin base class — clean signal-bus design |
+| `src/tools/toolfactory.cpp` | Hard-coded 24-case factory; closed to extension |
+| `src/tools/text/texttool.cpp` | 357 LOC — outlier among tools |
+| `src/tools/imgupload/storages/imgur/imguruploader.cpp` | Each uploader owns its own NAM |
+| `src/utils/confighandler.{h,cpp}` | Good schema design at :74-154; validation at :569-709 |
+| `src/utils/screengrabber.cpp` | 734 LOC; portal block :52-160; synchronous QEventLoop :85-112 |
+| `src/utils/abstractlogger.h` | Well-designed but inconsistently used |
+| `src/core/flameshot.{h,cpp}` | 535 LOC coordinator; singleton |
+| `src/core/flameshotdaemon.{h,cpp}` | 517 LOC IPC + tray |
+| `src/core/flameshotdbusadapter.cpp` | Session-bus only — safe |
+| `.github/workflows/build_cmake.yml` | Runs `ctest` against empty suite |
+| `.github/workflows/MacOS-pack.yml` | dmg builds on `macos-15` (arm64 + intel) |
+| `tests/action_options.sh`, `tests/path_option.sh` | Manual GUI test scripts; not in CI |
+
+## Findings to Fix (consolidated)
+
+| # | File | Lines | Description | Fix |
+|---|---|---|---|---|
+| F1 | `CMakeLists.txt` | 144-149 | QHotkey pinned to `master` branch | Pin to `v1.5.0` or commit SHA |
+| F2 | `CMakeLists.txt` | 109 | `set_project_warnings()` commented out | Uncomment with `WARNINGS_AS_ERRORS=FALSE` initially |
+| F3 | `src/CMakeLists.txt` | 64-68 | Deprecated `add_definitions()` for Windows version | Replace with `target_compile_definitions()` |
+| F4 | `src/CMakeLists.txt` | 104-105 | Direct `CMAKE_CXX_FLAGS` manipulation for MSVC `/MP` | Use `target_compile_options()` |
+| F5 | `src/widgets/capture/capturewidget.h` | 187-206 | Mixed QPointer + raw pointers in member declarations | Standardize on QPointer for all dynamically-deleted members |
+| F6 | `src/widgets/capture/capturewidget.cpp` | 1650-1718 | 18 old-style SLOT() string connections | Convert to `&Class::method` PMF form |
+| F7 | `src/widgets/capture/capturewidget.cpp` | 572, 600, 606, 1468, 2022 | Manual `delete` calls on parented widgets | Audit each; remove or document why manual |
+| F8 | `src/widgets/capture/capturewidget.cpp` | 701, 1091, 1157, 1194 | Magic numbers in painting/event logic (`10, 12`, `200`, `QPoint(1000, 200)`) | Promote to named constants |
+| F9 | `src/utils/screengrabber.cpp` | 85-112 | Synchronous QEventLoop blocks UI for up to 30s | Convert to async pattern with QFutureWatcher / signal callback |
+| F10 | `src/utils/screengrabber.cpp` | 52-160 | xdg-desktop-portal logic interleaved with X11/macOS/Win | Extract to `PortalScreenGrabber` class |
+| F11 | `src/utils/screengrabber.cpp` | 381 | Silent `return nullptr` on monitor preview failure | Add `AbstractLogger::error()` log |
+| F12 | `src/utils/screenshotsaver.cpp` | 78 | Silent `return false` on save failure | Add `AbstractLogger::error()` log |
+| F13 | `src/tools/launcher/terminallauncher.cpp` | 48 | User-supplied command string passed to terminal — shell metacharacters interpreted | Document or sandbox; at minimum, warn in UI |
+| F14 | `src/utils/confighandler.cpp` | 134 | Default Imgur Client ID hardcoded as fallback (`313baf0c7b4d3ff`) | Move to build-time `-D` define so distros can override |
+| F15 | `tests/action_options.sh`, `tests/path_option.sh` | — | Manual-only, never run in CI | Either port to a real test runner or delete |
+| F16 | `.github/workflows/build_cmake.yml` | — | Calls `ctest` against empty suite | Add at least one real test or remove the call |
+| F17 | `src/core/flameshot.cpp` | header | `QThread::msleep(delay)` blocks main thread | Replace with `QTimer::singleShot` |
+| F18 | `src/tools/toolfactory.cpp` | 35-71 | Hard-coded 24-case factory; closed to extension | Move to self-registering pattern (compile-time list via X-macro or static registrar) |
+| F19 | `src/tools/imgupload/storages/imgur/imguruploader.h` | 29 | Each uploader creates own QNetworkAccessManager | Share a single NAM at app or daemon level |
+| F20 | `src/utils/screengrabber.cpp` | 126 vs nearby `#ifdef` | Mixed runtime/compile-time platform detection | Pick one model; runtime preferred for Linux WSI variants |
+
+## Implementation Plan (sequence of 4 staged PRs)
+
+**PR 1 — "Turn on the alarms" (½ day):**
+- F1 Pin QHotkey
+- F2 Warnings on (errors off)
+- F16 + F15 Either delete or revive the test scripts
+- Enable ASAN+UBSAN on Linux CI
+
+**PR 2 — "Build the test foundation" (3 days):**
+- Add `tests/CMakeLists.txt` with `enable_testing()` and Qt Test
+- Unit tests for `ConfigHandler::checkForErrors()` (F-coverage of 50 schema options)
+- Unit tests for `FileNameHandler` (path templating edge cases)
+- Unit tests for `ValueHandler` (type coercion)
+- Documentation in `docs/CONTRIBUTING.md` on how to write a Flameshot test
+
+**PR 3 — "Mechanical cleanups" (2 days, mostly auto-able):**
+- F3, F4 Modernize CMake idioms
+- F6 SLOT() → PMF
+- F8 Extract magic numbers
+- F11, F12, F17 Logging consistency + fix `QThread::msleep`
+- Fix the warnings exposed in PR 1; flip to `-Werror`
+
+**PR 4 — "Process gate + portal extraction" (3 days):**
+- F6-process: PR-blocking packaging matrix (`.deb`, `.rpm`, `.dmg`, `.exe` all build on every PR)
+- F10 Extract `PortalScreenGrabber` class
+- F9 Async monitor selection
+- Per-platform capture smoke test in CI
+
+**Deferred to v15 RFC:**
+- `CaptureWidget` decomposition
+- Full subclass-per-platform `ScreenGrabber`
+- F18 Self-registering tool factory
+- F19 Shared QNetworkAccessManager

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,38 @@
+# Tests
+
+This directory currently holds two **manual** smoke-test scripts. There is no
+automated unit/integration test suite yet — see backlog stories S2.1–S2.6 in
+`docs/backlog/` for the plan.
+
+## Manual scripts
+
+| Script | What it covers | How to run |
+|---|---|---|
+| `action_options.sh` | Final-action options for `flameshot` commands (`--path`, `--clipboard`, `--raw`, `--pin`, `--print-geometry`) across capture modes (`full`, `screen`, `gui`). Requires watching the screen and confirming notifications. | `./tests/action_options.sh /path/to/built/flameshot` |
+| `path_option.sh` | `-p / --path` handling: relative paths, absolute paths, redundancy removal, missing directories, suffix inference. | Start a matching `flameshot` daemon first, then `./tests/path_option.sh /path/to/built/flameshot` |
+
+Both scripts shell out to a real `flameshot` binary. Build first with the
+instructions in the root `README.md`, then point each script at
+`build/src/flameshot` (or your platform's equivalent).
+
+### Dependencies
+
+- `action_options.sh` uses ImageMagick's `display` for `--raw` verification.
+  Install via your distro (`apt install imagemagick`, `brew install
+  imagemagick`, etc.) before running.
+- Both scripts expect a working desktop session — they will not run usefully
+  inside a CI container or over SSH without an X/Wayland display.
+
+## Why these aren't in CI
+
+They require human verification (notifications, on-screen pins, image
+display windows). Replacing them with assertion-driven tests is tracked
+under backlog story S2.7. Until then they serve as recipes for maintainers
+to run by hand before tagging a release.
+
+## Adding new tests
+
+Once `tests/CMakeLists.txt` lands (story S2.1), new tests will live in
+subdirectories per subsystem (`tests/config/`, `tests/utils/`,
+`tests/integration/`) and be discovered automatically by `ctest`. Refer to
+`docs/CONTRIBUTING.md` for the test-writing workflow.


### PR DESCRIPTION
## Summary

Activates four existing-but-disabled CI/build safeguards that the staff review identified as the cheapest-first improvements for v14 hardening. **No source code changes** — only CMake config, CI workflows, and docs.

Each safeguard is independently revertable. WARNINGS_AS_ERRORS is forced OFF for this PR so the warnings-framework activation cannot break the build on any platform.

## Changes

| Commit | Story | What |
|---|---|---|
| `10ff5140` | S1.1 | Pin QHotkey FetchContent to commit SHA `d7063877` (was tracking `master` branch — non-reproducible). The fork has no release tags, so SHA is the only stable handle. |
| `4090fa11` | S1.2 | Uncomment `set_project_warnings(project_warnings)` at `CMakeLists.txt:109`. `cmake/CompilerWarnings.cmake` was fully defined but never invoked. `WARNINGS_AS_ERRORS=OFF` is forced via CACHE override so the build cannot break — this PR only surfaces the existing latent warnings. A follow-up PR (S1.3) will clean them up and enable -Werror once we know the baseline count. |
| `4e23f9da` | S1.4 | New `linux-sanitizers` job in `build_cmake.yml` running with `-DENABLE_SANITIZER_ADDRESS=ON -DENABLE_SANITIZER_UNDEFINED_BEHAVIOR=ON`. `UBSAN_OPTIONS=halt_on_error=1`; `ASAN_OPTIONS=detect_leaks=0` to silence Qt's noisy at-exit pseudo-leaks. `cmake/Sanitizers.cmake` was already defined. |
| `72fdd9bd` | S2.7 | Added `tests/README.md` describing the existing manual smoke scripts (`action_options.sh`, `path_option.sh`) — they were undiscoverable. No code changes; documentation only. |
| `b388c66d`, `e2353b82` | docs | Staff-engineer panel review and 38-story v14 backlog, with progress log. Provides context for this PR series. |

## Why these together

Each one is small (≤30 min of config), independent, and revertable in isolation — but together they stand up the CI safety net the v14 GA milestone needs. Together they would have caught two of the last three reverted PRs (#4658 spec-uniformization, #4664 portal parent_window).

The next planned PRs in this series (Qt Test scaffold, ConfigHandler tests, SECURITY.md, packaging-PR matrix, clang-tidy-diff) all depend on this foundation landing.

## Risk notes

- **S1.2 is the riskiest commit.** Activating warnings will surface every latent compiler warning across 225 source files in CI logs. The volume may be substantial, but `WARNINGS_AS_ERRORS=OFF` means it cannot break the build. **Please look at the CI warning count when this runs** — it sizes the follow-up cleanup PR.
- **S1.4 sanitizer job runs `ctest` against an empty test suite.** Job will pass trivially today; real coverage starts when the Qt Test scaffold lands (next PR).
- **Local build verification was skipped.** None of these four changes have been compiled locally — they're mechanical config edits and CI itself is the cheapest verification path across all three platforms.

## Test plan

- [ ] Linux build job: green
- [ ] macOS build job: green
- [ ] Windows build job: green
- [ ] New `linux-sanitizers` job: green
- [ ] Capture warning-count baseline from S1.2 CI logs and post it as a comment for follow-up sizing
- [ ] No regressions in existing matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)