### PR TITLE
Increment/decrement circle counter on mouse wheel

### DIFF
--- a/src/tools/capturetool.h
+++ b/src/tools/capturetool.h
@@ -105,7 +105,12 @@ public:
         return {};
     };
     virtual QRect boundingRect() const = 0;
-    virtual bool handleMouseWheelEvent(int delta, bool adjustmentButtonPressed, CaptureContext& context) { return false; }
+    virtual bool handleMouseWheelEvent(int delta,
+                                       bool adjustmentButtonPressed,
+                                       CaptureContext& context)
+    {
+        return false;
+    }
 
     // The icon of the tool.
     // inEditor is true when the icon is requested inside the editor

--- a/src/tools/capturetool.h
+++ b/src/tools/capturetool.h
@@ -105,6 +105,7 @@ public:
         return {};
     };
     virtual QRect boundingRect() const = 0;
+    virtual bool handleMouseWheelEvent(int delta, bool adjustmentButtonPressed, CaptureContext& context) { return false; }
 
     // The icon of the tool.
     // inEditor is true when the icon is requested inside the editor

--- a/src/tools/circlecount/circlecounttool.cpp
+++ b/src/tools/circlecount/circlecounttool.cpp
@@ -180,17 +180,37 @@ void CircleCountTool::paintMousePreview(QPainter& painter,
 
     // Thickness for pen is *2 to range from radius to diameter to match the
     // ellipse draw function
-    auto orig_pen = painter.pen();
-    auto orig_opacity = painter.opacity();
+    auto const previewWidth = (size() + THICKNESS_OFFSET) * 2;
+    painter.save();
     painter.setOpacity(0.35);
     painter.setPen(QPen(context.color,
-                        (size() + THICKNESS_OFFSET) * 2,
+                        previewWidth,
                         Qt::SolidLine,
                         Qt::RoundCap));
     painter.drawLine(context.mousePos,
                      { context.mousePos.x() + 1, context.mousePos.y() + 1 });
-    painter.setOpacity(orig_opacity);
-    painter.setPen(orig_pen);
+
+
+    auto font = painter.font();
+    font.setPixelSize(previewWidth/2);
+    font.setBold(true);
+    painter.setFont(font);
+
+    painter.setPen(QPen("white"));
+    painter.drawText(QRect{ context.mousePos.x() - previewWidth/2,
+                            context.mousePos.y() - previewWidth/2,
+                            previewWidth,
+                            previewWidth  }, Qt::AlignCenter, QString::number(context.circleCount));
+
+    painter.restore();
+}
+
+bool CircleCountTool::handleMouseWheelEvent(int delta, bool adjustmentButtonPressed, CaptureContext& ctx)
+{
+    if(adjustmentButtonPressed) {
+        ctx.circleCount = qMin(qMax(ctx.circleCount + delta, 1), 999);
+    }
+    return adjustmentButtonPressed;
 }
 
 void CircleCountTool::drawStart(const CaptureContext& context)

--- a/src/tools/circlecount/circlecounttool.cpp
+++ b/src/tools/circlecount/circlecounttool.cpp
@@ -10,6 +10,8 @@
 namespace {
 #define PADDING_VALUE 2
 #define THICKNESS_OFFSET 15
+int const MIN_COUNTER = 1;
+int const MAX_COUNTER = 999;
 }
 
 CircleCountTool::CircleCountTool(QObject* parent)
@@ -183,38 +185,47 @@ void CircleCountTool::paintMousePreview(QPainter& painter,
     auto const previewWidth = (size() + THICKNESS_OFFSET) * 2;
     painter.save();
     painter.setOpacity(0.35);
-    painter.setPen(QPen(context.color,
-                        previewWidth,
-                        Qt::SolidLine,
-                        Qt::RoundCap));
+    painter.setPen(
+      QPen(context.color, previewWidth, Qt::SolidLine, Qt::RoundCap));
     painter.drawLine(context.mousePos,
                      { context.mousePos.x() + 1, context.mousePos.y() + 1 });
 
-
     auto font = painter.font();
-    font.setPixelSize(previewWidth/2);
+    font.setPixelSize(previewWidth / 2);
     font.setBold(true);
     painter.setFont(font);
 
     painter.setPen(QPen("white"));
-    painter.drawText(QRect{ context.mousePos.x() - previewWidth/2,
-                            context.mousePos.y() - previewWidth/2,
+    painter.drawText(QRect{ context.mousePos.x() - previewWidth / 2,
+                            context.mousePos.y() - previewWidth / 2,
                             previewWidth,
-                            previewWidth  }, Qt::AlignCenter, QString::number(context.circleCount));
+                            previewWidth },
+                     Qt::AlignCenter,
+                     QString::number(context.circleCount));
 
     painter.restore();
 }
 
-bool CircleCountTool::handleMouseWheelEvent(int delta, bool adjustmentButtonPressed, CaptureContext& ctx)
+bool CircleCountTool::handleMouseWheelEvent(int delta,
+                                            bool adjustmentButtonPressed,
+                                            CaptureContext& ctx)
 {
-    if(adjustmentButtonPressed) {
-        ctx.circleCount = qMin(qMax(ctx.circleCount + delta, 1), 999);
+    if (adjustmentButtonPressed) {
+        ctx.circleCount =
+          qBound(MIN_COUNTER, ctx.circleCount + delta, MAX_COUNTER);
     }
     return adjustmentButtonPressed;
 }
 
 void CircleCountTool::drawStart(const CaptureContext& context)
 {
+    setCount(context.circleCount);
+    // ------------------------------------------------------------------
+    // Temporary solution until the circle count variable removed from
+    // the context altogether and made part of Circle count tool
+    CaptureContext& ctx = const_cast<CaptureContext&>(context);
+    ctx.circleCount = qBound(MIN_COUNTER, ctx.circleCount + 1, MAX_COUNTER);
+    // ------------------------------------------------------------------
     AbstractTwoPointTool::drawStart(context);
     m_valid = true;
 }

--- a/src/tools/circlecount/circlecounttool.h
+++ b/src/tools/circlecount/circlecounttool.h
@@ -24,6 +24,7 @@ public:
     void process(QPainter& painter, const QPixmap& pixmap) override;
     void paintMousePreview(QPainter& painter,
                            const CaptureContext& context) override;
+    bool handleMouseWheelEvent(int, bool, CaptureContext& ctx) override;
 
 protected:
     CaptureTool::Type type() const override;

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -45,6 +45,8 @@
 
 #define MOUSE_DISTANCE_TO_START_MOVING 3
 
+auto const MOUSE_WHEEL_TRESHOLD = 60;
+
 // CaptureWidget is the main component used to capture the screen. It contains
 // an area of selection with its respective buttons.
 
@@ -1145,12 +1147,13 @@ void CaptureWidget::wheelEvent(QWheelEvent* e)
      * not accept events faster that one in 200ms.
      * */
     int toolSizeOffset = 0;
-    if (e->angleDelta().y() >= 60) {
-        // mouse scroll (wheel) increment
-        toolSizeOffset = 1;
-    } else if (e->angleDelta().y() <= -60) {
-        // mouse scroll (wheel) decrement
-        toolSizeOffset = -1;
+    if(qAbs(e->angleDelta().y()) >= MOUSE_WHEEL_TRESHOLD) {
+        auto const delta = qMax(qMin(e->angleDelta().y() / MOUSE_WHEEL_TRESHOLD, 1), -1);
+        if(activeButtonTool() && activeButtonTool()->handleMouseWheelEvent(delta, m_adjustmentButtonPressed, m_context)) {
+            this->repaint();
+            return;
+        }
+        toolSizeOffset = delta;
     } else {
         // touchpad scroll
         qint64 current = QDateTime::currentMSecsSinceEpoch();

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -836,11 +836,6 @@ bool CaptureWidget::startDrawObjectTool(const QPoint& pos)
 
         m_context.mousePos = m_displayGrid ? snapToGrid(pos) : pos;
         m_activeTool->drawStart(m_context);
-        // TODO this is the wrong place to do this
-
-        if (m_activeTool->type() == CaptureTool::TYPE_CIRCLECOUNT) {
-            m_activeTool->setCount(m_context.circleCount++);
-        }
 
         return true;
     }
@@ -1147,9 +1142,12 @@ void CaptureWidget::wheelEvent(QWheelEvent* e)
      * not accept events faster that one in 200ms.
      * */
     int toolSizeOffset = 0;
-    if(qAbs(e->angleDelta().y()) >= MOUSE_WHEEL_TRESHOLD) {
-        auto const delta = qMax(qMin(e->angleDelta().y() / MOUSE_WHEEL_TRESHOLD, 1), -1);
-        if(activeButtonTool() && activeButtonTool()->handleMouseWheelEvent(delta, m_adjustmentButtonPressed, m_context)) {
+    if (qAbs(e->angleDelta().y()) >= MOUSE_WHEEL_TRESHOLD) {
+        auto const delta =
+          qMax(qMin(e->angleDelta().y() / MOUSE_WHEEL_TRESHOLD, 1), -1);
+        if (activeButtonTool() &&
+            activeButtonTool()->handleMouseWheelEvent(
+              delta, m_adjustmentButtonPressed, m_context)) {
             this->repaint();
             return;
         }


### PR DESCRIPTION
1. Enhance the circle counter functionality by allowing to manually edit the counter pressing keyboard CTRL key and scrolling the wheel
2. Cap counter to the 1..999 rage (Negative numbers don't quite make sense to me. 3 digits is the biggest number that actually fit the counter) Subject for discussion?