### PR TITLE
Document hyprland usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@
 
 - [Features](#features)
 - [Usage](#usage)
+  - [Usage on Windows](#usage-on-windows)
+  - [Usage on Hyprland](#usage-on-hyprland)
   - [CLI configuration](#cli-configuration)
   - [Config file](#config-file)
 - [Keyboard Shortcuts](#keyboard-shortcuts)

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@
 - [Features](#features)
 - [Usage](#usage)
   - [Usage on Windows](#usage-on-windows)
-  - [Usage on Hyprland](#usage-on-hyprland)
+  - [Usage on Hyprland / Sway / wlroots](#usage-on-hyprland--sway--wlroots)
   - [CLI configuration](#cli-configuration)
   - [Config file](#config-file)
 - [Keyboard Shortcuts](#keyboard-shortcuts)
@@ -163,45 +163,9 @@ running `flameshot.exe -h`.
 
 If you require console output, run `flameshot-cli.exe` instead. `flameshot-cli.exe` is a minimal wrapper around `flameshot.exe` that ensures all stdout is captured and output to the console.
 
-### Usage on Hyprland
+### Usage on Hyprland / Sway / wlroots
 
-Below is a simple Hyprland setup to integrate Flameshot with Hyprland.
-
-<details>
-  <summary>Click to show the code snippet</summary>
-
-> **Note:** This example uses the new Lua config format introduced in Hyprland v0.55
-
-```lua
--- KEY BINDINGS
--- When the PrintScreen key is pressed, the currently focused monitor (the one containing the cursor) is captured, and the Flameshot GUI is brought up for annotating, cropping, etc.
-hl.bind("Print", function()
-    local mon = hl.get_active_monitor()
-    local n = mon and mon.id or 0
-    hl.dispatch(hl.dsp.exec_cmd("flameshot screen --number " .. n .. " --edit"))
-end)
-
--- WINDOW RULES
-hl.window_rule({
-    match       = { class = "flameshot" },
-    no_anim     = true,
-    pin         = true,
-    float       = true,
-    decorate    = false,
-    no_blur     = true,
-    no_shadow   = true,
-})
-hl.window_rule({
-    match   = { class = "flameshot", title = "flameshot" },
-    move    = { 0, 0 },
-})
-hl.window_rule({
-    match = { class = "flameshot", title = "flameshot-pin" },
-    move  = { "cursor_x-(window_w*0.5)", "cursor_y-(window_h*0.5)" },
-})
-```
-</details>
-
+Please [refer to this document](docs/UsageHyprlandSwayWlroots.md) for detailed instructions on how to set up Flameshot on Hyprland, Sway, and wlroots-based Wayland compositors.
 
 ### CLI configuration
 

--- a/README.md
+++ b/README.md
@@ -161,6 +161,46 @@ running `flameshot.exe -h`.
 
 If you require console output, run `flameshot-cli.exe` instead. `flameshot-cli.exe` is a minimal wrapper around `flameshot.exe` that ensures all stdout is captured and output to the console.
 
+### Usage on Hyprland
+
+Below is a simple Hyprland setup to integrate Flameshot with Hyprland.
+
+<details>
+  <summary>Click to show the code snippet</summary>
+
+> **Note:** This example uses the new Lua config format introduced in Hyprland v0.55
+
+```lua
+-- KEY BINDINGS
+-- When the PrintScreen key is pressed, the currently focused monitor (the one containing the cursor) is captured, and the Flameshot GUI is brought up for annotating, cropping, etc.
+hl.bind("Print", function()
+    local mon = hl.get_active_monitor()
+    local n = mon and mon.id or 0
+    hl.dispatch(hl.dsp.exec_cmd("flameshot screen --number " .. n .. " --edit"))
+end)
+
+-- WINDOW RULES
+hl.window_rule({
+    match       = { class = "flameshot" },
+    no_anim     = true,
+    pin         = true,
+    float       = true,
+    decorate    = false,
+    no_blur     = true,
+    no_shadow   = true,
+})
+hl.window_rule({
+    match   = { class = "flameshot", title = "flameshot" },
+    move    = { 0, 0 },
+})
+hl.window_rule({
+    match = { class = "flameshot", title = "flameshot-pin" },
+    move  = { "cursor_x-(window_w*0.5)", "cursor_y-(window_h*0.5)" },
+})
+```
+</details>
+
+
 ### CLI configuration
 
 You can use the graphical menu to configure Flameshot, but alternatively you can use your terminal or scripts to do so.

--- a/docs/UsageHyprlandSwayWlroots.md
+++ b/docs/UsageHyprlandSwayWlroots.md
@@ -1,3 +1,42 @@
+# Hyprland support
+
+Flameshot works out of the box with very little configuration on Hyprland, as long as [`xdg-desktop-portal-hyprland`](https://wiki.hypr.land/Hypr-Ecosystem/xdg-desktop-portal-hyprland/) is installed and running.
+
+Below is a simple setup that you can use as a starting point:
+
+> [!NOTE]
+> This example uses the new Lua config format introduced in Hyprland v0.55
+
+```lua
+-- KEY BINDINGS
+-- PrintScreen key pressed -> the currently focused monitor (the one containing the cursor) is captured, and the Flameshot GUI is brought up for annotating, cropping, etc.
+hl.bind("Print", function()
+    local mon = hl.get_active_monitor()
+    local n = mon and mon.id or 0
+    hl.dispatch(hl.dsp.exec_cmd("flameshot screen --number " .. n .. " --edit"))
+end)
+
+-- WINDOW RULES
+hl.window_rule({
+    match       = { class = "flameshot" },
+    no_anim     = true,
+    pin         = true,
+    float       = true,
+    decorate    = false,
+    no_blur     = true,
+    no_shadow   = true,
+})
+hl.window_rule({
+    match   = { class = "flameshot", title = "flameshot" },
+    move    = { 0, 0 },
+})
+hl.window_rule({
+    match = { class = "flameshot", title = "flameshot-pin" },
+    move  = { "cursor_x-(window_w*0.5)", "cursor_y-(window_h*0.5)" },
+})
+```
+
+
 # Sway and wlroots support
 Flameshot currently supports Sway and other wlroots based Wayland compositors through [xdg-desktop-portal-wlr](https://github.com/emersion/xdg-desktop-portal-wlr). However, due to the way dbus works, there may be some extra steps required for the integration to work properly.
 


### PR DESCRIPTION
As promised in #4731, I'm adding the documentation I wished I had when I was configuring Flameshot to work nicely with Hyprland.
I've hidden the code block inside a `<details>` element to avoid taking too much space in the readme.

I also considered documenting the `flameshot screen --number N --edit` more prominently in the "Example commands" section but ended up deciding against it because the "Capture Active Monitor" setting already exists and should cover most cases.
The Wayland DEs where it doesn't work probably require more tinkering in addition to `--edit`, that's why I added a full Hyprland config.

Please let me know if you disagree and would like me to add a `flameshot screen --number N --edit` line to the "Example commands" section too.