### PR TITLE
Fix capture when logical min/max coordinates are not zero

### DIFF
--- a/src/utils/screengrabber.cpp
+++ b/src/utils/screengrabber.cpp
@@ -489,8 +489,8 @@ QPixmap ScreenGrabber::cropToMonitor(const QPixmap& fullScreenshot,
     qreal targetDpr = targetScreen->devicePixelRatio();
 
     // Calculate total logical dimensions and minimum coordinates
-    int minX = 0, minY = 0;
-    int maxX = 0, maxY = 0;
+    int minX = INT_MAX, minY = INT_MAX;
+    int maxX = INT_MIN, maxY = INT_MIN;
 
     for (QScreen* screen : screens) {
         QRect geo = screen->geometry();


### PR DESCRIPTION
The issue might occur when you have a monitor with negative coordinates, or when all monitors start at coordinates larger than 0x0 (for me, it was 3840x0).

