### PR TITLE
Fix macOS tray menu crash after capture

### DIFF
--- a/src/widgets/trayicon.cpp
+++ b/src/widgets/trayicon.cpp
@@ -27,13 +27,7 @@ TrayIcon::TrayIcon(QObject* parent)
 
     setToolTip(QStringLiteral("Flameshot"));
 #if defined(Q_OS_MACOS)
-    // Because of the following issues on MacOS "Catalina":
-    // https://bugreports.qt.io/browse/QTBUG-86393
-    // https://developer.apple.com/forums/thread/126072
     auto currentMacOsVersion = QOperatingSystemVersion::current();
-    if (currentMacOsVersion >= QOperatingSystemVersion::MacOSBigSur) {
-        setContextMenu(m_menu);
-    }
 #else
     setContextMenu(m_menu);
 #endif
@@ -49,19 +43,18 @@ TrayIcon::TrayIcon(QObject* parent)
     setIcon(icon);
 
 #if defined(Q_OS_MACOS)
-    if (currentMacOsVersion < QOperatingSystemVersion::MacOSBigSur) {
-        // Because of the following issues on MacOS "Catalina":
-        // https://bugreports.qt.io/browse/QTBUG-86393
-        // https://developer.apple.com/forums/thread/126072
-        auto trayIconActivated = [this](QSystemTrayIcon::ActivationReason r) {
-            if (m_menu->isVisible()) {
-                m_menu->hide();
-            } else {
-                m_menu->popup(QCursor::pos());
-            }
-        };
-        connect(this, &QSystemTrayIcon::activated, this, trayIconActivated);
-    }
+    // Keep the menu detached from QSystemTrayIcon::setContextMenu on macOS.
+    // Older macOS versions already needed the manual popup workaround, and the
+    // native NSStatusItem menu path can abort on newer macOS versions after a
+    // capture has completed.
+    auto trayIconActivated = [this](QSystemTrayIcon::ActivationReason r) {
+        if (m_menu->isVisible()) {
+            m_menu->hide();
+        } else {
+            m_menu->popup(QCursor::pos());
+        }
+    };
+    connect(this, &QSystemTrayIcon::activated, this, trayIconActivated);
 #else
     connect(this, &TrayIcon::activated, this, [this](ActivationReason r) {
         if (r == Trigger) {


### PR DESCRIPTION
## Summary

| Item | Details |
| --- | --- |
| Problem | On macOS 27 with Qt 6.11, Flameshot can abort when opening the tray menu after completing a capture. |
| Root cause seen locally | The crash report points to Qt's Cocoa platform plugin while AppKit is opening the native `NSStatusItem` menu path (`libqcocoa.dylib` -> `-[NSEvent clickCount]`). |
| Fix | Keep the macOS tray menu detached from `QSystemTrayIcon::setContextMenu()` and use the existing manual `QMenu::popup()` path for all macOS versions. |
| Scope | macOS tray menu behavior only. Non-macOS behavior is unchanged. |

## Details

Flameshot already used a manual popup workaround for older macOS versions. This extends that approach to newer macOS versions as well, avoiding the native status item context menu path that aborted in local testing after a screenshot was taken.

## Testing

| Check | Result |
| --- | --- |
| `cmake --build build --parallel` | Passes locally on macOS 27 / arm64 / Qt 6.11.0. |
| Manual reproduction | Before this change: screenshot once, then click the Flameshot menu bar icon -> crash. |
| Manual verification | After this change: screenshot once, then click the Flameshot menu bar icon repeatedly -> no crash. |
| Installed app signature check | Verified locally after installing and signing the app bundle. |

## Disclosure

This PR was prepared with AI-assisted crash-report analysis and local debugging. The change is intentionally small, was reviewed against the crash stack, and was manually verified on the affected macOS setup.