### PR TITLE
Simplify Hyprland example

### DIFF
--- a/docs/UsageHyprlandSwayWlroots.md
+++ b/docs/UsageHyprlandSwayWlroots.md
@@ -13,7 +13,7 @@ Below is a simple setup that you can use as a starting point:
 hl.bind("Print", function()
     local mon = hl.get_active_monitor()
     local n = mon and mon.id or 0
-    hl.dispatch(hl.dsp.exec_cmd("flameshot screen --number " .. n .. " --edit"))
+    hl.exec_cmd("flameshot screen --number " .. n .. " --edit")
 end)
 
 -- WINDOW RULES


### PR DESCRIPTION
This is a follow-up to #4734 

My previous PR used `hl.dispatch` because I didn't know `hl.exec_cmd` existed.
The modified example behaves identically, and it's simpler to read/understand.