### PR TITLE
Fix screen size calculation in `ScreenGrabber::cropToMonitor`

### DIFF
--- a/src/utils/screengrabber.cpp
+++ b/src/utils/screengrabber.cpp
@@ -489,8 +489,10 @@ QPixmap ScreenGrabber::cropToMonitor(const QPixmap& fullScreenshot,
     qreal targetDpr = targetScreen->devicePixelRatio();
 
     // Calculate total logical dimensions and minimum coordinates
-    int minX = 0, minY = 0;
-    int maxX = 0, maxY = 0;
+    // NB: The monitorIndex check at the start ensures we have at least one
+    // screen.
+    int minX = INT_MAX, minY = INT_MAX;
+    int maxX = INT_MIN, maxY = INT_MIN;
 
     for (QScreen* screen : screens) {
         QRect geo = screen->geometry();


### PR DESCRIPTION
Unfixed code:

https://github.com/flameshot-org/flameshot/blob/c47870ac95cdce9e63c19198b1f1c0bf57504cf6/src/utils/screengrabber.cpp#L491-L501

Because the variables are initialised to 0, `minX/Y` can't go above 0 and `maxX/Y` can't go below 0, even if the monitor geometries do, resulting in improper scaling in compositors that don't place monitors at the origin (e.g. niri).

This PR changes the variables to `INT_MIN`/`INT_MAX` so the calculation works properly.

Fixes #4725