### PR TITLE
async-notification

### DIFF
--- a/src/utils/systemnotification.cpp
+++ b/src/utils/systemnotification.cpp
@@ -90,8 +90,13 @@ void SystemNotification::sendMessage(const QString& text,
              << QStringList()                // actions
              << hintsMap                     // hints
              << timeout;                     // timeout
-        m_interface->callWithArgumentList(
-          QDBus::AutoDetect, QStringLiteral("Notify"), args);
-    }
+        // Fire-and-forget: an asynchronous call never blocks the event loop, even
+        // when no notification daemon is registered on the session bus (e.g. bare
+        // startx / tiling WM sessions). The previous synchronous callWithArgumentList
+        // stalled the main thread for the QtDBus reply timeout (~25s) after every
+        // capture, freezing further captures until it returned.
+        if (m_interface != nullptr) {
+            m_interface->asyncCallWithArgumentList(QStringLiteral("Notify"), args);
+        }
 #endif
 }

--- a/src/utils/systemnotification.cpp
+++ b/src/utils/systemnotification.cpp
@@ -90,13 +90,15 @@ void SystemNotification::sendMessage(const QString& text,
              << QStringList()                // actions
              << hintsMap                     // hints
              << timeout;                     // timeout
-        // Fire-and-forget: an asynchronous call never blocks the event loop, even
-        // when no notification daemon is registered on the session bus (e.g. bare
-        // startx / tiling WM sessions). The previous synchronous callWithArgumentList
-        // stalled the main thread for the QtDBus reply timeout (~25s) after every
-        // capture, freezing further captures until it returned.
+        // Fire-and-forget: an asynchronous call never blocks the event loop,
+        // even when no notification daemon is registered on the session bus
+        // (e.g. bare startx / tiling WM sessions). The previous synchronous
+        // callWithArgumentList stalled the main thread for the QtDBus reply
+        // timeout (~25s) after every capture, freezing further captures until
+        // it returned.
         if (m_interface != nullptr) {
-            m_interface->asyncCallWithArgumentList(QStringLiteral("Notify"), args);
+            m_interface->asyncCallWithArgumentList(QStringLiteral("Notify"),
+                                                   args);
         }
     }
 #endif

--- a/src/utils/systemnotification.cpp
+++ b/src/utils/systemnotification.cpp
@@ -98,5 +98,6 @@ void SystemNotification::sendMessage(const QString& text,
         if (m_interface != nullptr) {
             m_interface->asyncCallWithArgumentList(QStringLiteral("Notify"), args);
         }
+    }
 #endif
 }


### PR DESCRIPTION
The previous synchronous callWithArgumentList stalled the main thread for the QtDBus reply timeout (~25s) after every capture, freezing further captures until it returned. Probably related to Issue #2425.