### PR TITLE
remove the legacy argument parsing for region argument

### DIFF
--- a/src/utils/valuehandler.cpp
+++ b/src/utils/valuehandler.cpp
@@ -545,17 +545,6 @@ QVariant Region::process(const QVariant& val)
 
     QString str = val.toString();
 
-    if (str == "all") {
-        return ScreenGrabber().desktopGeometry();
-    } else if (str.startsWith("screen")) {
-        bool ok;
-        int number = str.mid(6).toInt(&ok);
-        if (!ok || number < 0) {
-            return {};
-        }
-        return ScreenGrabber().screenGeometry(qApp->screens()[number]);
-    }
-
     static const QRegularExpression regex(
       "(-{,1}\\d+)"   // number (any sign)
       "[x,\\.\\s]"    // separator ('x', ',', '.', or whitespace)


### PR DESCRIPTION
This was brought to our attention by @geeknik via security advisory report GHSA-rmr8-cfxx-3757 with adjusted severity of 0.0/10: `CVSS:4.0/AV:L/AC:L/AT:N/PR:N/UI:A/VC:N/VI:N/VA:N/SC:N/SI:N/SA:N`

giving any value starting with `screen` or `all` cause segfault. Considering that we have `full` and `screen` subcommands, I believe this part of the code is no longer needed and can be removed.

Thank you @geeknik for bringing this to our attention.