### PR TITLE
[CI] Add Windows ARM 64 Portable and Installer GitHub Action Build and Cross Compile Appveyer Build

### DIFF
--- a/.github/workflows/Windows-pack.yml
+++ b/.github/workflows/Windows-pack.yml
@@ -26,7 +26,7 @@ env:
 jobs:
   windows-pack:
     name: VS 2022 ${{ matrix.config.arch }}-${{ matrix.type }}
-    runs-on: windows-2022
+    runs-on: ${{ matrix.config.runner }}
     env:
       VCINSTALLDIR: C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC
       # 2025.02.14
@@ -41,11 +41,21 @@ jobs:
         config:
           - {
             arch: x64,
+            runner: windows-2022,
             generator: "-G'Visual Studio 17 2022' -A x64",
             vcpkg_triplet: x64-windows,
             qt_arch: win64_msvc2022_64,
             qt_arch_install: msvc2022_64,
             pak_arch: win64
+          }
+          - {
+            arch: arm64,
+            runner: windows-11-arm,
+            generator: "-G'Visual Studio 17 2022' -A ARM64",
+            vcpkg_triplet: arm64-windows,
+            qt_arch: win64_msvc2022_arm64_cross_compiled,
+            qt_arch_install: msvc2022_arm64,
+            pak_arch: arm64
           }
         type: [portable, installer]
     steps:
@@ -106,6 +116,11 @@ jobs:
           version: ${{ matrix.qt_ver }}
           cache: 'true'
           cache-key-prefix: install-qt-action-${{ matrix.qt_ver }}
+          # Force the x86_64 "windows" host repository: the ARM64 Qt libraries
+          # are only published there as the cross-compiled package, not under
+          # the auto-detected "windows_arm64" host. --autodesktop (default)
+          # pulls the matching x64 host tools, which run under emulation.
+          host: 'windows'
           target:  ${{ matrix.qt_target }}
           arch: ${{ matrix.config.qt_arch }}
           modules: 'qtimageformats'
@@ -125,6 +140,20 @@ jobs:
         working-directory: build
         shell: pwsh
         run: cmake --build . --config Release
+
+      - name: Install WiX (Windows ARM64)
+        # windows-2022 ships WiX 3 preinstalled, but the windows-11-arm image
+        # does not. CPack's WIX generator needs candle/light (WiX v3); fetch the
+        # official binaries and add them to PATH. The x86 tools run under
+        # emulation on ARM64.
+        if: matrix.config.arch == 'arm64' && matrix.type == 'installer'
+        shell: pwsh
+        run: |
+          $zip = "$env:RUNNER_TEMP\wix314-binaries.zip"
+          $dest = "$env:RUNNER_TEMP\wix"
+          Invoke-WebRequest -Uri "https://github.com/wixtoolset/wix3/releases/download/wix3141rtm/wix314-binaries.zip" -OutFile $zip
+          Expand-Archive -Path $zip -DestinationPath $dest -Force
+          Add-Content -Path $env:GITHUB_PATH -Value $dest
 
       - name: CPack
         working-directory: build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,8 +166,20 @@ if(WIN32)
   # Include all dynamically linked runtime libraries such as MSVCRxxx.dll
   include(InstallRequiredSystemLibraries)
 
+  # Determine the packaging architecture so that x64 and ARM64 artifacts are
+  # named distinctly and the WiX installer targets the correct platform.
+  # CMAKE_GENERATOR_PLATFORM is "x64" or "ARM64" when building with the
+  # Visual Studio generator and the "-A" option.
+  if(CMAKE_GENERATOR_PLATFORM MATCHES "[Aa][Rr][Mm]64")
+    set(FLAMESHOT_PACKAGE_ARCH "arm64")
+  else()
+    set(FLAMESHOT_PACKAGE_ARCH "win64")
+  endif()
+  # Drives the default <name>-<version>-<system> file name used by CPack.
+  set(CPACK_SYSTEM_NAME "${FLAMESHOT_PACKAGE_ARCH}")
+
   if(USE_PORTABLE_CONFIG)
-    set(CPACK_PACKAGE_FILE_NAME "${PROJECT_NAME}-${PROJECT_VERSION}-win64")
+    set(CPACK_PACKAGE_FILE_NAME "${PROJECT_NAME}-${PROJECT_VERSION}-${FLAMESHOT_PACKAGE_ARCH}")
     set(CPACK_GENERATOR ZIP)
 
   else()
@@ -193,6 +205,14 @@ if(WIN32)
     set(CPACK_RESOURCE_FILE_README "${CMAKE_SOURCE_DIR}/README.md")
 
     set(CPACK_WIX_UPGRADE_GUID "26D8062A-66D9-48D9-8924-42090FB9B3F9")
+
+    # Mark the .msi with the correct target platform (requires CMake >= 3.24).
+    # Without this, an ARM64 build would be packaged as an x64 installer.
+    if(FLAMESHOT_PACKAGE_ARCH STREQUAL "arm64")
+      set(CPACK_WIX_ARCHITECTURE "arm64")
+    else()
+      set(CPACK_WIX_ARCHITECTURE "x64")
+    endif()
   endif()
 elseif(APPLE)
   set(CPACK_INCLUDE_TOPLEVEL_DIRECTORY 0)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,14 @@ clone_folder: c:\projects\source
 environment:
   Qt6_INSTALL_DIR: 'C:\Qt\6.9.3\msvc2022_64'
   PATH: '%Qt6_INSTALL_DIR%\bin;%PATH%'
+  # Build both the native x64 release and an ARM64 cross-compile. Each matrix
+  # row becomes its own AppVeyor job.
+  matrix:
+    - ARCH: x64
+    - ARCH: arm64
 
+# Default (x64) build. Unchanged from the original signed-release pipeline.
+# The arm64 job overrides install/build_script in the `for:` section below.
 build_script:
   # Build installer (non-portable)
 - cmd: |-
@@ -26,6 +33,73 @@ build_script:
     copy C:\projects\source\build-portable\src\Release\*.exe C:\projects\source\build\artifact\.
     7z a -tzip C:\projects\source\build\artifact.zip C:\projects\source\build\artifact\
 
+# ---------------------------------------------------------------------------
+# ARM64 cross-compile job. The build host stays x64; only the *target* is
+# ARM64 (the Qt package is literally "..._arm64_cross_compiled"). Because the
+# host is native x64, WiX/candle and windeployqt run without emulation.
+# ---------------------------------------------------------------------------
+for:
+  - matrix:
+      only:
+        - ARCH: arm64
+    install:
+      - ps: |
+          # The VS2022 image may not ship the ARM64 MSVC cross toolset. Add it
+          # (quick no-op if already present). Remove this step if the image
+          # already includes "VC.Tools.ARM64".
+          $vsInstaller = "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vs_installer.exe"
+          if (Test-Path $vsInstaller) {
+            Start-Process -FilePath $vsInstaller -Wait -ArgumentList `
+              'modify','--installPath','C:\Program Files\Microsoft Visual Studio\2022\Community',
+              '--add','Microsoft.VisualStudio.Component.VC.Tools.ARM64','--quiet','--norestart'
+          }
+
+          # Install the cross-compiled ARM64 Qt plus its x64 host tools
+          # (--autodesktop) via aqt. This mirrors the GitHub install-qt step.
+          python -m pip install --upgrade pip aqtinstall
+          python -m aqt install-qt windows desktop 6.9.3 win64_msvc2022_arm64_cross_compiled `
+            --autodesktop --outputdir C:\Qt --modules qtimageformats
+
+          # ARM64 OpenSSL (no prebuilt system copy for arm64 on the image).
+          C:\Tools\vcpkg\vcpkg.exe install openssl:arm64-windows
+    build_script:
+      - ps: |
+          $ErrorActionPreference = "Stop"
+          $src    = "C:\projects\source"
+          $qtArm  = "C:\Qt\6.9.3\msvc2022_arm64"   # target libs (CMAKE_PREFIX_PATH)
+          $qtHost = "C:\Qt\6.9.3\msvc2022_64"      # host tools  (QT_HOST_PATH)
+          $env:OPENSSL_ROOT_DIR = "C:\Tools\vcpkg\installed\arm64-windows"
+
+          # Cross args shared by both configs. -A ARM64 selects the
+          # Hostx64/arm64 cross compiler; QT_HOST_PATH provides host moc/rcc.
+          $common = @(
+            "-G", "Visual Studio 17 2022", "-A", "ARM64",
+            "-DCMAKE_PREFIX_PATH=$qtArm",
+            "-DQT_HOST_PATH=$qtHost",
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DENABLE_OPENSSL=ON"
+          )
+
+          # Installer (non-portable) -> CPack WiX produces Flameshot-*-arm64.msi
+          cmake -S $src -B $src\build @common -DUSE_PORTABLE_CONFIG=OFF
+          if ($LASTEXITCODE) { throw "configure (installer) failed" }
+          cmake --build $src\build --parallel 2 --config Release
+          if ($LASTEXITCODE) { throw "build (installer) failed" }
+          cpack --config $src\build\CPackConfig.cmake -G WIX -B $src\build\package
+          if ($LASTEXITCODE) { throw "cpack failed" }
+
+          # Portable
+          cmake -S $src -B $src\build-portable @common -DUSE_PORTABLE_CONFIG=ON
+          if ($LASTEXITCODE) { throw "configure (portable) failed" }
+          cmake --build $src\build-portable --parallel 2 --config Release
+          if ($LASTEXITCODE) { throw "build (portable) failed" }
+
+          # Combine into the same artifact.zip the x64 job produces.
+          New-Item -ItemType Directory -Force -Path $src\build\artifact | Out-Null
+          Copy-Item $src\build\package\*.msi              $src\build\artifact\
+          Copy-Item $src\build-portable\src\Release\*.exe $src\build\artifact\
+          7z a -tzip $src\build\artifact.zip $src\build\artifact\
+
 artifacts:
 - path: build\artifact.zip
   name: artifact
@@ -36,3 +110,9 @@ deploy:
   #url: https://app.signpath.io/API/v1/042f605f-b378-45d8-ad16-b7695b071036/Integrations/AppVeyor?ProjectSlug=flameshot&SigningPolicySlug=release-signing
   authorization:
     secure: UGxEQ/cEpACvBCjp1lSeZOMkB49/GRpm+PGG9asArdbaVHmLuPuso//tRhNDZJXY5nL4E+/FaaFqV9tBIkYbUQ==
+  # Only sign/deploy the established x64 release on the upstream repo; arm64
+  # just uploads artifacts, and forks never attempt to deploy (their secure
+  # token is empty and the SignPath project belongs to upstream).
+  on:
+    ARCH: x64
+    APPVEYOR_REPO_NAME: flameshot-org/flameshot

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,7 +31,7 @@ build_script:
     mkdir C:\projects\source\build\artifact
     copy C:\projects\source\build\package\*.msi C:\projects\source\build\artifact\.
     copy C:\projects\source\build-portable\src\Release\*.exe C:\projects\source\build\artifact\.
-    7z a -tzip C:\projects\source\build\artifact.zip C:\projects\source\build\artifact\
+    7z a -tzip C:\projects\source\build\artifact-x64.zip C:\projects\source\build\artifact\
 
 # ---------------------------------------------------------------------------
 # ARM64 cross-compile job. The build host stays x64; only the *target* is
@@ -98,10 +98,10 @@ for:
           New-Item -ItemType Directory -Force -Path $src\build\artifact | Out-Null
           Copy-Item $src\build\package\*.msi              $src\build\artifact\
           Copy-Item $src\build-portable\src\Release\*.exe $src\build\artifact\
-          7z a -tzip $src\build\artifact.zip $src\build\artifact\
+          7z a -tzip $src\build\artifact-arm64.zip $src\build\artifact\
 
 artifacts:
-- path: build\artifact.zip
+- path: build\artifact-*.zip
   name: artifact
 
 deploy:
@@ -110,9 +110,10 @@ deploy:
   #url: https://app.signpath.io/API/v1/042f605f-b378-45d8-ad16-b7695b071036/Integrations/AppVeyor?ProjectSlug=flameshot&SigningPolicySlug=release-signing
   authorization:
     secure: UGxEQ/cEpACvBCjp1lSeZOMkB49/GRpm+PGG9asArdbaVHmLuPuso//tRhNDZJXY5nL4E+/FaaFqV9tBIkYbUQ==
-  # Only sign/deploy the established x64 release on the upstream repo; arm64
-  # just uploads artifacts, and forks never attempt to deploy (their secure
-  # token is empty and the SignPath project belongs to upstream).
+  # Sign/deploy both arch artifacts, but only on the upstream repo. Forks never
+  # attempt to deploy (their secure token is empty and the SignPath project
+  # belongs to upstream). Each job uploads a distinctly named zip
+  # (artifact-x64.zip / artifact-arm64.zip) so the two signing requests don't
+  # collide.
   on:
-    ARCH: x64
     APPVEYOR_REPO_NAME: flameshot-org/flameshot

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -64,7 +64,10 @@ for:
           C:\Tools\vcpkg\vcpkg.exe install openssl:arm64-windows
     build_script:
       - ps: |
-          $ErrorActionPreference = "Stop"
+          # NOTE: do NOT set $ErrorActionPreference = "Stop" here. Native tools
+          # (cmake/cpack/7z) write progress to stderr, which PowerShell turns
+          # into NativeCommandError records; with Stop that aborts the build even
+          # on success (exit 0). Real failures are caught via $LASTEXITCODE below.
           $src    = "C:\projects\source"
           $qtArm  = "C:\Qt\6.9.3\msvc2022_arm64"   # target libs (CMAKE_PREFIX_PATH)
           $qtHost = "C:\Qt\6.9.3\msvc2022_64"      # host tools  (QT_HOST_PATH)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -395,10 +395,67 @@ if (WIN32)
         list(APPEND WINDEPLOYQT_SEARCH_PATHS "${prefix}/bin")
     endforeach()
     list(APPEND WINDEPLOYQT_SEARCH_PATHS "$ENV{QTDIR}/bin")
-    
+
+    # The ARM64 Qt is a cross-compiled package and does NOT ship windeployqt.exe;
+    # the tool only exists in the x86_64 host Qt. We must therefore run the host
+    # windeployqt but point it at the ARM64 qtpaths via --qtpaths, otherwise it
+    # deploys the host's x64 Qt libraries.
+    if(CMAKE_GENERATOR_PLATFORM MATCHES "[Aa][Rr][Mm]64")
+        # Candidate ARM64 (target) Qt roots, as exported by install-qt-action.
+        # NOTE: the CMAKE_PREFIX_PATH *variable* is usually empty here (it is an
+        # environment variable), so QT_ROOT_DIR/QTDIR are the reliable sources.
+        # The env values use native backslashes, so normalise them first.
+        set(_arm64_qt_bins "")
+        foreach(_raw "$ENV{QT_ROOT_DIR}" "$ENV{QTDIR}" ${CMAKE_PREFIX_PATH})
+            if(_raw)
+                file(TO_CMAKE_PATH "${_raw}" _qt_root)
+                list(APPEND _arm64_qt_bins "${_qt_root}/bin")
+                # The host Qt (which has windeployqt.exe) is installed as a
+                # sibling of the target: …/msvc2022_64 next to …/msvc2022_arm64.
+                string(REPLACE "msvc2022_arm64" "msvc2022_64" _host_root "${_qt_root}")
+                list(APPEND WINDEPLOYQT_SEARCH_PATHS "${_host_root}/bin")
+            endif()
+        endforeach()
+        if(DEFINED ENV{QT_HOST_PATH})
+            file(TO_CMAKE_PATH "$ENV{QT_HOST_PATH}" _host_path)
+            list(APPEND WINDEPLOYQT_SEARCH_PATHS "${_host_path}/bin")
+        endif()
+
+        # The cross-compiled ARM64 package ships qtpaths as a .bat wrapper
+        # (qtpaths.bat) rather than an .exe, so find_program (which only resolves
+        # executables) cannot see it. Look for the wrapper explicitly, restricted
+        # to the ARM64 bins so we never pick up the host's x64 qtpaths. Pointing
+        # the host windeployqt at it via --qtpaths makes it deploy ARM64 libs.
+        foreach(_bin ${_arm64_qt_bins})
+            foreach(_name qtpaths6.bat qtpaths.bat qtpaths6.exe qtpaths.exe)
+                if(NOT WINDEPLOYQT_QTPATHS AND EXISTS "${_bin}/${_name}")
+                    set(WINDEPLOYQT_QTPATHS "${_bin}/${_name}")
+                endif()
+            endforeach()
+        endforeach()
+    endif()
+
     find_program(WINDEPLOYQT_EXE windeployqt.exe
         PATHS ${WINDEPLOYQT_SEARCH_PATHS}
     )
+
+    if(CMAKE_GENERATOR_PLATFORM MATCHES "[Aa][Rr][Mm]64")
+        if(WINDEPLOYQT_QTPATHS)
+            message(STATUS "windeployqt ARM64 target qtpaths: ${WINDEPLOYQT_QTPATHS}")
+            set(WINDEPLOYQT_QTPATHS_ARG --qtpaths "${WINDEPLOYQT_QTPATHS}")
+        else()
+            set(_arm64_bin_listing "")
+            foreach(_bin ${_arm64_qt_bins})
+                file(GLOB _g "${_bin}/qtpaths*" "${_bin}/*.bat")
+                list(APPEND _arm64_bin_listing ${_g})
+            endforeach()
+            message(FATAL_ERROR
+                "ARM64 build: could not locate the target qtpaths (.bat/.exe). "
+                "Without it windeployqt deploys x64 Qt libraries. Searched bins: "
+                "'${_arm64_qt_bins}'. qtpaths*/*.bat present there: "
+                "'${_arm64_bin_listing}'.")
+        endif()
+    endif()
 
     if(WINDEPLOYQT_EXE)
         message(STATUS "windeployqt found: ${WINDEPLOYQT_EXE}")
@@ -414,7 +471,7 @@ if (WIN32)
                 POST_BUILD
                 COMMAND ${CMAKE_COMMAND} -E remove_directory ${CMAKE_BINARY_DIR}/windeployqt_stuff
                 COMMAND
-                ${WINDEPLOYQT_EXE} ${BINARIES_TYPE} --no-translations --compiler-runtime --no-system-d3d-compiler
+                ${WINDEPLOYQT_EXE} ${WINDEPLOYQT_QTPATHS_ARG} ${BINARIES_TYPE} --no-translations --compiler-runtime --no-system-d3d-compiler
                 --no-quick-import --dir ${CMAKE_BINARY_DIR}/windeployqt_stuff $<TARGET_FILE:flameshot>
                 # copy translations manually QM_FILES
                 COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/windeployqt_stuff/translations


### PR DESCRIPTION
With the rising popularity of Windows ARM 64 devices, such as the latest Surface / Snapdragon X laptops, recently released Snapdragon X2 devices and soon to be released Nvidia N1X SOC (Spark) users are increasingly expecting native applications.

Built and tested the GitHub build Windows ARM setup/portable artifacts from my fork using my Snapdragon X2 Elite Extreme based Asus Zenbook A16 running Windows 11 ARM 26H1 using Windows Sandbox (clean environment with no VC++ runtime).

https://github.com/talynone/flameshot/actions/runs/27823493434

This pull request fulfills the following request:
https://github.com/flameshot-org/flameshot/issues/3101

Screenshot of Flameshot running as Windows ARM native application:

<img width="1130" height="713" alt="image" src="https://github.com/user-attachments/assets/943e6f8c-df49-4131-a92f-339700e2da1f" />

@borgmanJeremy As requested this includes a modified working appveyor that also cross compiles to Windows ARM. The installer artifact it creates was tested in my appveyer and run/verified on Windows ARM sandbox:

https://ci.appveyor.com/project/talynone/flameshot/builds/54246303

I changed the artifact name from artifact.zip to include the processor architecture (artifact-x64.zip and artifact-arm64.zip) hopefully that's ok.
