### PR TITLE
Add arrow style selector

### DIFF
--- a/flameshot.example.ini
+++ b/flameshot.example.ini
@@ -64,6 +64,9 @@
 ;; Last used tool thickness; same thickness shared by Pencil, Line, Arrow, Rectangular Selection, Circle (int)
 ;drawThickness=3
 ;
+;; Arrow style: 0 = default, 1 = curved (int)
+;arrowStyle=0
+;
 ;; Last used font size (int)
 ;drawFontSize=8
 ;

--- a/src/tools/arrow/arrowtool.cpp
+++ b/src/tools/arrow/arrowtool.cpp
@@ -4,11 +4,22 @@
 #include "arrowtool.h"
 #include "utils/confighandler.h"
 
+#include <QComboBox>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QWidget>
 #include <cmath>
 
 namespace {
 const int ArrowWidth = 10;
 const int ArrowHeight = 18;
+const int MinArrowStyle = 0;
+const int MaxArrowStyle = 1;
+
+bool isValidArrowStyle(int style)
+{
+    return style >= MinArrowStyle && style <= MaxArrowStyle;
+}
 
 QPainterPath getArrowHead(QPoint p1, QPoint p2, const int thickness)
 {
@@ -58,11 +69,66 @@ QLine getShorterLine(QPoint p1, QPoint p2, const int thickness)
     return l.toLine();
 }
 
+QPainterPath getCurvedArrowHead(QPointF p1, QPointF p2, const int thickness)
+{
+    QLineF line(p1, p2);
+    if (line.length() <= 0) {
+        return {};
+    }
+
+    const QPointF direction = (p2 - p1) / line.length();
+    const QPointF normal(-direction.y(), direction.x());
+    const QPointF baseCenter =
+      getShorterLine(p1.toPoint(), p2.toPoint(), thickness).p2();
+    const qreal halfWidth = (ArrowWidth + thickness * 2) / 2.0;
+    const qreal baseDistance = QLineF(baseCenter, p2).length();
+    const qreal notchDepth = std::min<qreal>(baseDistance * 0.45, halfWidth);
+
+    const QPointF baseLeft = baseCenter + normal * halfWidth;
+    const QPointF baseRight = baseCenter - normal * halfWidth;
+    const QPointF notch = baseCenter + direction * notchDepth;
+    const QPointF leftControl = baseCenter + normal * halfWidth * 0.25;
+    const QPointF rightControl = baseCenter - normal * halfWidth * 0.25;
+
+    QPainterPath path;
+    path.moveTo(p2);
+    path.lineTo(baseLeft);
+    path.quadTo(leftControl, notch);
+    path.quadTo(rightControl, baseRight);
+    path.lineTo(p2);
+    return path;
+}
+
+QLineF getCurvedArrowShaft(QPointF p1, QPointF p2, const int thickness)
+{
+    QLineF line(p1, p2);
+    if (line.length() <= 0) {
+        return {};
+    }
+
+    const QPointF direction = (p2 - p1) / line.length();
+    QLineF shaft(getShorterLine(p1.toPoint(), p2.toPoint(), thickness));
+    const qreal notchDepth =
+      std::min<qreal>(QLineF(shaft.p2(), p2).length() * 0.45,
+                      (ArrowWidth + thickness * 2) / 2.0);
+    const qreal overlap = std::max<qreal>(1, thickness * 0.5);
+
+    // The curved head has a concave back, so extend the straight shaft
+    // slightly into the head to avoid a visible gap.
+    shaft.setP2(shaft.p2() + direction * (notchDepth + overlap));
+    return shaft;
+}
+
 } // unnamed namespace
 
 ArrowTool::ArrowTool(QObject* parent)
   : AbstractTwoPointTool(parent)
 {
+    const int configuredArrowStyle = ConfigHandler().arrowStyle();
+    if (isValidArrowStyle(configuredArrowStyle)) {
+        m_arrowStyle = static_cast<ArrowStyle>(configuredArrowStyle);
+    }
+
     setPadding(ArrowWidth / 2);
     m_supportsOrthogonalAdj = true;
     m_supportsDiagonalAdj = true;
@@ -135,6 +201,27 @@ QRect ArrowTool::boundingRect() const
     return rect.normalized();
 }
 
+QWidget* ArrowTool::configurationWidget()
+{
+    auto* widget = new QWidget();
+    auto* layout = new QHBoxLayout(widget);
+    auto* label = new QLabel(tr("Arrow style:"), widget);
+    auto* styleSelector = new QComboBox(widget);
+
+    styleSelector->addItem(tr("Default"));
+    styleSelector->addItem(tr("Curved"));
+    styleSelector->setCurrentIndex(static_cast<int>(m_arrowStyle));
+    connect(styleSelector,
+            qOverload<int>(&QComboBox::currentIndexChanged),
+            this,
+            &ArrowTool::setArrowStyle);
+
+    layout->addWidget(label);
+    layout->addWidget(styleSelector);
+
+    return widget;
+}
+
 CaptureTool* ArrowTool::copy(QObject* parent)
 {
     auto* tool = new ArrowTool(parent);
@@ -145,7 +232,8 @@ CaptureTool* ArrowTool::copy(QObject* parent)
 void ArrowTool::copyParams(const ArrowTool* from, ArrowTool* to)
 {
     AbstractTwoPointTool::copyParams(from, to);
-    to->m_arrowPath = this->m_arrowPath;
+    to->m_arrowPath = from->m_arrowPath;
+    to->m_arrowStyle = from->m_arrowStyle;
 }
 
 void ArrowTool::process(QPainter& painter, const QPixmap& pixmap)
@@ -157,12 +245,28 @@ void ArrowTool::process(QPainter& painter, const QPixmap& pixmap)
 
     Q_UNUSED(pixmap)
     painter.setPen(QPen(color(), size()));
-    painter.drawLine(getShorterLine(head, tail, size()));
-    m_arrowPath = getArrowHead(head, tail, size());
+    if (m_arrowStyle == ArrowStyle::Default) {
+        painter.drawLine(getShorterLine(head, tail, size()));
+        m_arrowPath = getArrowHead(head, tail, size());
+        painter.fillPath(m_arrowPath, QBrush(color()));
+        return;
+    }
+
+    painter.drawLine(getCurvedArrowShaft(head, tail, size()));
+    m_arrowPath = getCurvedArrowHead(head, tail, size());
     painter.fillPath(m_arrowPath, QBrush(color()));
 }
 
 void ArrowTool::pressed(CaptureContext& context)
 {
     Q_UNUSED(context)
+}
+
+void ArrowTool::setArrowStyle(int style)
+{
+    if (!isValidArrowStyle(style)) {
+        style = static_cast<int>(ArrowStyle::Default);
+    }
+    m_arrowStyle = static_cast<ArrowStyle>(style);
+    ConfigHandler().setArrowStyle(style);
 }

--- a/src/tools/arrow/arrowtool.cpp
+++ b/src/tools/arrow/arrowtool.cpp
@@ -111,10 +111,11 @@ QLineF getCurvedArrowShaft(QPointF p1, QPointF p2, const int thickness)
     const qreal notchDepth =
       std::min<qreal>(QLineF(shaft.p2(), p2).length() * 0.45,
                       (ArrowWidth + thickness * 2) / 2.0);
-    const qreal overlap = std::max<qreal>(1, thickness * 0.5);
+    constexpr qreal overlap = 1.0;
 
     // The curved head has a concave back, so extend the straight shaft
-    // slightly into the head to avoid a visible gap.
+    // slightly into the head to avoid a visible gap without leaking past
+    // the head outline at large thicknesses.
     shaft.setP2(shaft.p2() + direction * (notchDepth + overlap));
     return shaft;
 }
@@ -252,6 +253,7 @@ void ArrowTool::process(QPainter& painter, const QPixmap& pixmap)
         return;
     }
 
+    painter.setPen(QPen(color(), size(), Qt::SolidLine, Qt::FlatCap));
     painter.drawLine(getCurvedArrowShaft(head, tail, size()));
     m_arrowPath = getCurvedArrowHead(head, tail, size());
     painter.fillPath(m_arrowPath, QBrush(color()));

--- a/src/tools/arrow/arrowtool.h
+++ b/src/tools/arrow/arrowtool.h
@@ -18,6 +18,7 @@ public:
     QString name() const override;
     QString description() const override;
     QRect boundingRect() const override;
+    QWidget* configurationWidget() override;
 
     CaptureTool* copy(QObject* parent = nullptr) override;
     void process(QPainter& painter, const QPixmap& pixmap) override;
@@ -29,6 +30,16 @@ protected:
 public slots:
     void pressed(CaptureContext& context) override;
 
+private slots:
+    void setArrowStyle(int style);
+
 private:
+    enum class ArrowStyle
+    {
+        Default = 0,
+        Curved = 1,
+    };
+
     QPainterPath m_arrowPath;
+    ArrowStyle m_arrowStyle = ArrowStyle::Default;
 };

--- a/src/utils/confighandler.cpp
+++ b/src/utils/confighandler.cpp
@@ -136,6 +136,7 @@ static QMap<class QString, QSharedPointer<ValueHandler>>
     OPTION("showSelectionGeometryHideTime", LowerBoundedInt  ( 0, 3000       )),
     OPTION("jpegQuality"                 , BoundedInt        ( 0,100,75      )),
     OPTION("reverseArrow"                ,Bool               ( false         )),
+    OPTION("arrowStyle"                  ,BoundedInt         ( 0, 1, 0       )),
     OPTION("insecurePixelate"            ,Bool               ( false         )),
 #if defined(Q_OS_WIN)
     // Not visible on settings dialog

--- a/src/utils/confighandler.h
+++ b/src/utils/confighandler.h
@@ -139,6 +139,7 @@ public:
     CONFIG_GETTER_SETTER(showSelectionGeometry, setShowSelectionGeometry, int)
     CONFIG_GETTER_SETTER(jpegQuality, setJpegQuality, int)
     CONFIG_GETTER_SETTER(reverseArrow, setReverseArrow, bool)
+    CONFIG_GETTER_SETTER(arrowStyle, setArrowStyle, int)
     CONFIG_GETTER_SETTER(insecurePixelate, setInsecurePixelate, bool)
     CONFIG_GETTER_SETTER(showSelectionGeometryHideTime,
                          showSelectionGeometryHideTime,


### PR DESCRIPTION
Addresses #1960.

This PR adds an Arrow-only style selector in the Tool Settings panel with two options:

- Default: existing arrow rendering
- Curved: straight shaft with a curved/concave arrow head matching the requested style

The selected style is persisted through config as `arrowStyle`.

I kept the scope limited to the Arrow tool and did not add custom SVG loading or additional styles like segmented arrows. The UI direction was discussed in the issue, and @mmahmoudian suggested getting @borgmanJeremy’s input before investing in a larger/right-click selector approach.

@borgmanJeremy, if you have any thoughts on the UI approach or the scope here, I would appreciate your input.