### PR TITLE
ci: update linux distro build matrix

### DIFF
--- a/.github/workflows/Linux-pack.yml
+++ b/.github/workflows/Linux-pack.yml
@@ -190,12 +190,6 @@ jobs:
               symbol: 44,
               arch: x86_64
             }
-          - {
-              name: 'opensuse-leap-16.0',
-              os: opensuse-leap,
-              symbol: '16.0',
-              arch: x86_64
-            }
     steps:
       - name: Checkout Source code
         if: github.event_name == 'push'

--- a/.github/workflows/Linux-pack.yml
+++ b/.github/workflows/Linux-pack.yml
@@ -37,16 +37,9 @@ jobs:
       matrix:
         dist:
           - {
-              name: debian-12,
+              name: debian-13,
               os: debian,
-              symbol: bookworm,
-              arch: amd64,
-              runs-on: ubuntu-latest
-            }
-          - {
-              name: ubuntu-22.04,
-              os: ubuntu,
-              symbol: jammy,
+              symbol: trixie,
               arch: amd64,
               runs-on: ubuntu-latest
             }
@@ -58,30 +51,37 @@ jobs:
               runs-on: ubuntu-latest
             }
           - {
-              name: debian-12,
+              name: ubuntu-26.04,
+              os: ubuntu,
+              symbol: resolute,
+              arch: amd64,
+              runs-on: ubuntu-latest
+            }
+          - {
+              name: debian-13,
               os: debian,
-              symbol: bookworm,
+              symbol: trixie,
               arch: arm64,
               runs-on: ubuntu-24.04-arm
             }
           - {
-              name: debian-12,
+              name: debian-13,
               os: debian,
-              symbol: bookworm,
+              symbol: trixie,
               arch: armhf,
               runs-on: ubuntu-24.04-arm
             }
           - {
-              name: ubuntu-22.04,
+              name: ubuntu-24.04,
               os: ubuntu,
-              symbol: jammy,
+              symbol: noble,
               arch: arm64,
               runs-on: ubuntu-24.04-arm
             }
           - {
-              name: ubuntu-24.04,
+              name: ubuntu-26.04,
               os: ubuntu,
-              symbol: noble,
+              symbol: resolute,
               arch: arm64,
               runs-on: ubuntu-24.04-arm
             }
@@ -179,15 +179,21 @@ jobs:
       matrix:
         dist:
           - {
-              name: fedora-41,
+              name: fedora-43,
               os: fedora,
-              symbol: 41,
+              symbol: 43,
               arch: x86_64
             }
           - {
-              name: fedora-42,
+              name: fedora-44,
               os: fedora,
-              symbol: 42,
+              symbol: 44,
+              arch: x86_64
+            }
+          - {
+              name: 'opensuse-leap-16.0',
+              os: opensuse-leap,
+              symbol: '16.0',
               arch: x86_64
             }
     steps:

--- a/packaging/rpm/flameshot.spec
+++ b/packaging/rpm/flameshot.spec
@@ -44,7 +44,11 @@ Requires: hicolor-icon-theme
 %if 0%{?suse_version}
 Requires: qt6-svg
 %else
+%if 0%{?fedora} || 0%{?rhel}
+Requires: qt6-qtsvg%{?_isa}
+%else
 Requires: qt6-svg%{?_isa}
+%endif
 %endif
 
 %if 0%{?suse_version}


### PR DESCRIPTION
- add debian 13 amd64/arm64/armhf, drop debian 12
- add fedora 43/44 amd64
- add ubuntu 26.04 amd64/arm64, drop ubuntu 22.04
- add opensuse leap 16.0 amd64