### PR TITLE
bump fedora version in CI

### DIFF
--- a/.github/workflows/Linux-pack.yml
+++ b/.github/workflows/Linux-pack.yml
@@ -179,15 +179,15 @@ jobs:
       matrix:
         dist:
           - {
-              name: fedora-41,
+              name: fedora-43,
               os: fedora,
-              symbol: 41,
+              symbol: 43,
               arch: x86_64
             }
           - {
-              name: fedora-42,
+              name: fedora-44,
               os: fedora,
-              symbol: 42,
+              symbol: 44,
               arch: x86_64
             }
     steps:


### PR DESCRIPTION
I tried to see if this would solve #4784, but it didn't. Alas, I bumped the two fedora versions our CI build for to the two last versions.