### PR TITLE
Embed the display ICC profile in captures on macOS (#4341)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -230,6 +230,8 @@ if (APPLE)
     target_link_libraries(
             flameshot
             qhotkey
+            "-framework CoreGraphics"
+            "-framework CoreFoundation"
     )
 endif ()
 

--- a/src/core/flameshot.cpp
+++ b/src/core/flameshot.cpp
@@ -48,6 +48,7 @@ constexpr const char* visibleInDockProperty = "_visibleInDock";
 #include "utils/abstractlogger.h"
 #include "utils/confighandler.h"
 #include "utils/screengrabber.h"
+#include "utils/colorprofileprovider.h"
 #include "utils/screenshotsaver.h"
 #include "widgets/capture/capturewidget.h"
 #include "widgets/capturelauncher.h"
@@ -189,11 +190,13 @@ void Flameshot::screen(CaptureRequest req, const int screenNumber)
     bool ok = false;
     QPixmap p;
     QRect geometry;
+    QColorSpace colorSpace;
 
     if (screenNumber < 0) {
         ScreenGrabber grabber;
         p = grabber.grabEntireDesktop(ok);
         if (ok) {
+            colorSpace = grabber.colorSpace();
             QScreen* selectedScreen = grabber.getSelectedScreen();
             if (selectedScreen) {
                 geometry = ScreenGrabber().screenGeometry(selectedScreen);
@@ -208,8 +211,10 @@ void Flameshot::screen(CaptureRequest req, const int screenNumber)
     } else {
         // Specific screen number provided - use grabScreen to bypass selector
         QScreen* screen = qApp->screens()[screenNumber];
-        p = ScreenGrabber().grabScreen(screen, ok);
+        ScreenGrabber grabber;
+        p = grabber.grabScreen(screen, ok);
         if (ok) {
+            colorSpace = grabber.colorSpace();
             geometry = ScreenGrabber().screenGeometry(screen);
         }
     }
@@ -228,7 +233,7 @@ void Flameshot::screen(CaptureRequest req, const int screenNumber)
             // change geometry for pin task
             req.addPinTask(region);
         }
-        exportCapture(p, geometry, req);
+        exportCapture(p, geometry, req, colorSpace);
     } else {
         emit captureFailed();
     }
@@ -241,10 +246,11 @@ void Flameshot::full(const CaptureRequest& req)
     }
 
     bool ok = true;
-    QPixmap p(ScreenGrabber().grabFullDesktop(ok));
+    ScreenGrabber grabber;
+    QPixmap p(grabber.grabFullDesktop(ok));
     if (ok) {
         QRect selection; // `flameshot full` does not support region selection
-        exportCapture(p, selection, req);
+        exportCapture(p, selection, req, grabber.colorSpace());
     } else {
         emit captureFailed();
     }
@@ -448,7 +454,8 @@ void Flameshot::requestCapture(const CaptureRequest& request)
 
 void Flameshot::exportCapture(const QPixmap& capture,
                               QRect& selection,
-                              const CaptureRequest& req)
+                              const CaptureRequest& req,
+                              const QColorSpace& colorSpace)
 {
     using CR = CaptureRequest;
     int tasks = req.tasks(), mode = req.captureMode();
@@ -463,7 +470,12 @@ void Flameshot::exportCapture(const QPixmap& capture,
     if (tasks & CR::PRINT_RAW) {
         QByteArray byteArray;
         QBuffer buffer(&byteArray);
-        capture.save(&buffer, "PNG");
+        if (colorSpace.isValid()) {
+            ColorProfileProvider::tagged(capture, colorSpace)
+              .save(&buffer, "PNG");
+        } else {
+            capture.save(&buffer, "PNG");
+        }
         if (QFile file; file.open(stdout, QIODevice::WriteOnly)) {
             file.write(byteArray);
             file.close();
@@ -472,18 +484,18 @@ void Flameshot::exportCapture(const QPixmap& capture,
 
     if (tasks & CR::SAVE) {
         if (req.path().isEmpty()) {
-            saveToFilesystemGUI(capture);
+            saveToFilesystemGUI(capture, colorSpace);
         } else {
-            saveToFilesystem(capture, path);
+            saveToFilesystem(capture, path, "", colorSpace);
         }
     }
 
     if (tasks & CR::COPY) {
-        FlameshotDaemon::copyToClipboard(capture);
+        FlameshotDaemon::copyToClipboard(capture, colorSpace);
     }
 
     if (tasks & CR::PIN) {
-        FlameshotDaemon::createPin(capture, selection);
+        FlameshotDaemon::createPin(capture, selection, colorSpace);
         if (mode == CR::SCREEN_MODE || mode == CR::FULLSCREEN_MODE) {
             AbstractLogger::info()
               << QObject::tr("Full screen screenshot pinned to screen");

--- a/src/core/flameshot.h
+++ b/src/core/flameshot.h
@@ -5,6 +5,7 @@
 
 #include "core/capturerequest.h"
 
+#include <QColorSpace>
 #include <QObject>
 #include <QPointer>
 #include <QVersionNumber>
@@ -78,7 +79,8 @@ public slots:
     void requestCapture(const CaptureRequest& request);
     void exportCapture(const QPixmap& p,
                        QRect& selection,
-                       const CaptureRequest& req);
+                       const CaptureRequest& req,
+                       const QColorSpace& colorSpace = {});
 
 private:
     Flameshot();

--- a/src/core/flameshotdaemon.cpp
+++ b/src/core/flameshotdaemon.cpp
@@ -111,10 +111,12 @@ void FlameshotDaemon::start()
     }
 }
 
-void FlameshotDaemon::createPin(const QPixmap& capture, QRect geometry)
+void FlameshotDaemon::createPin(const QPixmap& capture,
+                                QRect geometry,
+                                const QColorSpace& colorSpace)
 {
     if (instance()) {
-        instance()->attachPin(capture, geometry);
+        instance()->attachPin(capture, geometry, colorSpace);
         return;
     }
 
@@ -134,10 +136,11 @@ void FlameshotDaemon::createPin(const QPixmap& capture, QRect geometry)
 #endif
 }
 
-void FlameshotDaemon::copyToClipboard(const QPixmap& capture)
+void FlameshotDaemon::copyToClipboard(const QPixmap& capture,
+                                      const QColorSpace& colorSpace)
 {
     if (instance()) {
-        instance()->attachScreenshotToClipboard(capture);
+        instance()->attachScreenshotToClipboard(capture, colorSpace);
         return;
     }
 
@@ -297,9 +300,11 @@ void FlameshotDaemon::quitIfIdle()
 
 // SERVICE METHODS
 
-void FlameshotDaemon::attachPin(const QPixmap& pixmap, QRect geometry)
+void FlameshotDaemon::attachPin(const QPixmap& pixmap,
+                                QRect geometry,
+                                const QColorSpace& colorSpace)
 {
-    auto* pinWidget = new PinWidget(pixmap, geometry);
+    auto* pinWidget = new PinWidget(pixmap, geometry, colorSpace);
     m_widgets.append(pinWidget);
     connect(pinWidget, &QObject::destroyed, this, [=, this]() {
         m_widgets.removeOne(pinWidget);
@@ -310,7 +315,8 @@ void FlameshotDaemon::attachPin(const QPixmap& pixmap, QRect geometry)
     pinWidget->activateWindow();
 }
 
-void FlameshotDaemon::attachScreenshotToClipboard(const QPixmap& pixmap)
+void FlameshotDaemon::attachScreenshotToClipboard(const QPixmap& pixmap,
+                                                  const QColorSpace& colorSpace)
 {
     m_hostingClipboard = true;
     QClipboard* clipboard = QApplication::clipboard();
@@ -318,7 +324,7 @@ void FlameshotDaemon::attachScreenshotToClipboard(const QPixmap& pixmap)
     // This variable is necessary because the signal doesn't get blocked on
     // windows for some reason
     m_clipboardSignalBlocked = true;
-    saveToClipboard(pixmap);
+    saveToClipboard(pixmap, colorSpace);
     clipboard->blockSignals(false);
 }
 

--- a/src/core/flameshotdaemon.h
+++ b/src/core/flameshotdaemon.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QByteArray>
+#include <QColorSpace>
 #include <QObject>
 
 #if !(defined(Q_OS_MACOS) || defined(Q_OS_WIN))
@@ -26,8 +27,11 @@ class FlameshotDaemon : public QObject
 public:
     static void start();
     static FlameshotDaemon* instance();
-    static void createPin(const QPixmap& capture, QRect geometry);
-    static void copyToClipboard(const QPixmap& capture);
+    static void createPin(const QPixmap& capture,
+                          QRect geometry,
+                          const QColorSpace& colorSpace = {});
+    static void copyToClipboard(const QPixmap& capture,
+                                const QColorSpace& colorSpace = {});
     static void copyToClipboard(const QString& text,
                                 const QString& notification = "");
     static bool isThisInstanceHostingWidgets();
@@ -61,8 +65,11 @@ signals:
 private:
     FlameshotDaemon();
     void quitIfIdle();
-    void attachPin(const QPixmap& pixmap, QRect geometry);
-    void attachScreenshotToClipboard(const QPixmap& pixmap);
+    void attachPin(const QPixmap& pixmap,
+                   QRect geometry,
+                   const QColorSpace& colorSpace = {});
+    void attachScreenshotToClipboard(const QPixmap& pixmap,
+                                     const QColorSpace& colorSpace = {});
 
     void attachPin(const QByteArray& data);
     void attachScreenshotToClipboard(const QByteArray& screenshot);

--- a/src/tools/capturecontext.h
+++ b/src/tools/capturecontext.h
@@ -5,6 +5,7 @@
 
 #include "core/capturerequest.h"
 
+#include <QColorSpace>
 #include <QPainter>
 #include <QPixmap>
 #include <QPoint>
@@ -16,6 +17,8 @@ struct CaptureContext
     QPixmap screenshot;
     // unmodified screenshot
     QPixmap origScreenshot;
+    // ICC color profile of the captured display (invalid when unknown)
+    QColorSpace colorSpace;
     // Selection area
     QRect selection;
     // Selected tool color

--- a/src/tools/launcher/applauncherwidget.cpp
+++ b/src/tools/launcher/applauncherwidget.cpp
@@ -2,8 +2,10 @@
 // SPDX-FileCopyrightText: 2017-2019 Alejandro Sirgo Rica & Contributors
 
 #include "applauncherwidget.h"
+#include "core/qguiappcurrentscreen.h"
 #include "tools/launcher/launcheritemdelegate.h"
 #include "tools/launcher/terminallauncher.h"
+#include "utils/colorprofileprovider.h"
 #include "utils/confighandler.h"
 #include "utils/filenamehandler.h"
 #include "utils/globalvalues.h"
@@ -124,7 +126,14 @@ void AppLauncherWidget::launch(const QModelIndex& index)
             return;
         }
         m_tempFile->close();
-        bool ok = m_pixmap.save(m_tempFile->fileName());
+        // Tag the temp image with the current display's profile so apps opened
+        // with it see the same colors as the native screenshot tool (#4341).
+        const QColorSpace colorSpace = ColorProfileProvider::forScreen(
+          QGuiAppCurrentScreen().currentScreen());
+        bool ok = colorSpace.isValid()
+                    ? ColorProfileProvider::tagged(m_pixmap, colorSpace)
+                        .save(m_tempFile->fileName())
+                    : m_pixmap.save(m_tempFile->fileName());
         if (!ok) {
             QMessageBox::about(
               this, tr("Error"), tr("Unable to write in") + QDir::tempPath());

--- a/src/tools/pin/pinwidget.cpp
+++ b/src/tools/pin/pinwidget.cpp
@@ -27,9 +27,11 @@ constexpr qreal MIN_SIZE = 100.0;
 
 PinWidget::PinWidget(const QPixmap& pixmap,
                      const QRect& geometry,
+                     const QColorSpace& colorSpace,
                      QWidget* parent)
   : QWidget(parent)
   , m_pixmap(pixmap)
+  , m_colorSpace(colorSpace)
   , m_layout(new QVBoxLayout(this))
   , m_label(new QLabel())
   , m_shadowEffect(new QGraphicsDropShadowEffect(this))
@@ -328,11 +330,11 @@ void PinWidget::showContextMenu(const QPoint& pos)
 
 void PinWidget::copyToClipboard()
 {
-    saveToClipboard(m_pixmap);
+    saveToClipboard(m_pixmap, m_colorSpace);
 }
 void PinWidget::saveToFile()
 {
     hide();
-    saveToFilesystemGUI(m_pixmap);
+    saveToFilesystemGUI(m_pixmap, m_colorSpace);
     show();
 }

--- a/src/tools/pin/pinwidget.h
+++ b/src/tools/pin/pinwidget.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <QColorSpace>
 #include <QWidget>
 
 class QLabel;
@@ -17,6 +18,7 @@ class PinWidget : public QWidget
 public:
     explicit PinWidget(const QPixmap& pixmap,
                        const QRect& geometry,
+                       const QColorSpace& colorSpace = {},
                        QWidget* parent = nullptr);
 
 protected:
@@ -43,6 +45,7 @@ private:
     void decreaseOpacity();
 
     QPixmap m_pixmap;
+    QColorSpace m_colorSpace;
     QVBoxLayout* m_layout;
     QLabel* m_label;
     QGraphicsDropShadowEffect* m_shadowEffect;

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -24,6 +24,7 @@ target_sources(
           desktopinfo.cpp
           pathinfo.cpp
           colorutils.cpp
+          colorprofileprovider.cpp
           history.cpp
           strfparse.cpp
 )

--- a/src/utils/colorprofileprovider.cpp
+++ b/src/utils/colorprofileprovider.cpp
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2017-2019 Alejandro Sirgo Rica & Contributors
+
+#include "colorprofileprovider.h"
+
+#include <QPixmap>
+#include <QScreen>
+
+#if defined(Q_OS_MACOS)
+#include <CoreGraphics/CoreGraphics.h>
+
+namespace {
+
+// Match a Qt screen to a CoreGraphics display by comparing their top-left
+// origin in the global (points) coordinate space. Falls back to the main
+// display when no match is found.
+CGDirectDisplayID displayForScreen(const QScreen* screen)
+{
+    if (screen != nullptr) {
+        const QRect geom = screen->geometry();
+        const uint32_t maxDisplays = 16;
+        CGDirectDisplayID ids[maxDisplays];
+        uint32_t count = 0;
+        if (CGGetActiveDisplayList(maxDisplays, ids, &count) ==
+            kCGErrorSuccess) {
+            for (uint32_t i = 0; i < count; ++i) {
+                const CGRect bounds = CGDisplayBounds(ids[i]);
+                if (qRound(bounds.origin.x) == geom.x() &&
+                    qRound(bounds.origin.y) == geom.y()) {
+                    return ids[i];
+                }
+            }
+        }
+    }
+    return CGMainDisplayID();
+}
+
+QColorSpace iccFromColorSpace(CGColorSpaceRef cg)
+{
+    if (cg == nullptr) {
+        return {};
+    }
+    CFDataRef data = CGColorSpaceCopyICCData(cg);
+    if (data == nullptr) {
+        return {};
+    }
+    const QByteArray icc(reinterpret_cast<const char*>(CFDataGetBytePtr(data)),
+                         static_cast<int>(CFDataGetLength(data)));
+    CFRelease(data);
+    return QColorSpace::fromIccProfile(icc);
+}
+
+} // namespace
+
+QColorSpace ColorProfileProvider::forScreen(const QScreen* screen)
+{
+    const CGDirectDisplayID display = displayForScreen(screen);
+    CGColorSpaceRef cg = CGDisplayCopyColorSpace(display);
+    const QColorSpace platformProfile = iccFromColorSpace(cg);
+    const bool wideGamut = (cg != nullptr) && CGColorSpaceIsWideGamutRGB(cg);
+    if (cg != nullptr) {
+        CGColorSpaceRelease(cg);
+    }
+    return resolve(platformProfile, wideGamut);
+}
+
+#else  // Non-macOS: not implemented yet, leave captures untagged as before.
+
+QColorSpace ColorProfileProvider::forScreen(const QScreen* /*screen*/)
+{
+    return {};
+}
+
+#endif
+
+QColorSpace ColorProfileProvider::resolve(const QColorSpace& platformProfile,
+                                          bool wideGamut)
+{
+    if (platformProfile.isValid()) {
+        return platformProfile;
+    }
+    if (wideGamut) {
+        return QColorSpace(QColorSpace::DisplayP3);
+    }
+    return {};
+}
+
+QImage ColorProfileProvider::tagged(const QPixmap& pixmap,
+                                    const QColorSpace& colorSpace)
+{
+    QImage image = pixmap.toImage();
+    if (colorSpace.isValid()) {
+        image.setColorSpace(colorSpace);
+    }
+    return image;
+}

--- a/src/utils/colorprofileprovider.h
+++ b/src/utils/colorprofileprovider.h
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2017-2019 Alejandro Sirgo Rica & Contributors
+
+#pragma once
+
+#include <QColorSpace>
+#include <QImage>
+
+class QPixmap;
+class QScreen;
+
+/**
+ * Resolves and applies the display's ICC color profile so that saved
+ * screenshots are tagged the same way the native macOS screenshot tool tags
+ * them (see issue #4341). Without the tag, color-managed apps assume sRGB and
+ * wide-gamut captures look desaturated.
+ *
+ * This is currently a macOS-only fix: on other platforms forScreen() returns an
+ * invalid QColorSpace and tagging is a no-op, leaving behavior unchanged.
+ */
+class ColorProfileProvider
+{
+public:
+    /**
+     * The color space of the given screen's display, or an invalid QColorSpace
+     * when it cannot be determined (or the platform is not supported).
+     */
+    static QColorSpace forScreen(const QScreen* screen);
+
+    /**
+     * Pure fallback chain, exposed for testing: a valid platform profile is
+     * used as-is; otherwise Display P3 for wide-gamut displays; otherwise an
+     * invalid color space (i.e. leave untagged, sRGB being the universal
+     * default).
+     */
+    static QColorSpace resolve(const QColorSpace& platformProfile,
+                               bool wideGamut);
+
+    /**
+     * Returns the pixmap as a QImage, tagged with @p colorSpace when it is
+     * valid (otherwise untagged). Tagging only labels the pixels; it does not
+     * convert them, so it is cheap and lossless.
+     */
+    static QImage tagged(const QPixmap& pixmap, const QColorSpace& colorSpace);
+};

--- a/src/utils/screengrabber.cpp
+++ b/src/utils/screengrabber.cpp
@@ -2,6 +2,7 @@
 #include "screengrabber.h"
 #include "core/qguiappcurrentscreen.h"
 #include "utils/abstractlogger.h"
+#include "utils/colorprofileprovider.h"
 #include "utils/confighandler.h"
 #include "utils/monitorpreview.h"
 #include "utils/systemnotification.h"
@@ -242,6 +243,7 @@ QPixmap ScreenGrabber::grabEntireDesktop(bool& ok, int preSelectedMonitor)
     screenshot = currentScreen->grabWindow(
       wid, geom.x(), geom.y(), geom.width(), geom.height());
     screenshot.setDevicePixelRatio(currentScreen->devicePixelRatio());
+    m_colorSpace = ColorProfileProvider::forScreen(currentScreen);
     return screenshot;
 
 #elif defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)
@@ -285,7 +287,14 @@ QPixmap ScreenGrabber::grabFullDesktop(bool& ok)
     QPixmap screenshot;
 
 #if defined(Q_OS_MACOS)
-    // On macOS, composite all screens into a single pixmap.
+    // On macOS, composite all screens into a single pixmap. Screens may have
+    // different color profiles, but the composite can carry only one. Convert
+    // each screen into a common target space (the primary display's) before
+    // compositing, then tag the result with that target so every region is
+    // correct — not just the primary one.
+    const QColorSpace target =
+      ColorProfileProvider::forScreen(QGuiApplication::primaryScreen());
+    m_colorSpace = target;
     const QList<QScreen*> screens = QGuiApplication::screens();
     QRect totalGeom;
     for (QScreen* s : screens) {
@@ -304,6 +313,14 @@ QPixmap ScreenGrabber::grabFullDesktop(bool& ok)
         QRect geom = s->geometry();
         QPixmap p = s->grabWindow(0);
         QPoint offset = geom.topLeft() - totalGeom.topLeft();
+        // Only screens whose profile differs from the target need a real
+        // (per-pixel) conversion; matching screens are drawn as-is.
+        const QColorSpace src = ColorProfileProvider::forScreen(s);
+        if (target.isValid() && src.isValid() && src != target) {
+            QImage img = p.toImage();
+            img.setColorSpace(src);
+            p = QPixmap::fromImage(img.convertedToColorSpace(target));
+        }
         painter.drawPixmap(offset, p);
     }
     painter.end();
@@ -351,6 +368,7 @@ QPixmap ScreenGrabber::grabScreen(QScreen* screen, bool& ok)
     p = grabEntireDesktop(ok, screenIndex);
 #else
     ok = true;
+    m_colorSpace = ColorProfileProvider::forScreen(screen);
     return screen->grabWindow(
       0, geometry.x(), geometry.y(), geometry.width(), geometry.height());
 #endif

--- a/src/utils/screengrabber.h
+++ b/src/utils/screengrabber.h
@@ -5,6 +5,7 @@
 
 #include "utils/desktopinfo.h"
 
+#include <QColorSpace>
 #include <QEvent>
 #include <QList>
 #include <QObject>
@@ -28,6 +29,9 @@ public:
     QRect logicalDesktopGeometry();
     int getSelectedMonitor() const { return m_selectedMonitor; }
     QScreen* getSelectedScreen() const;
+    // ICC color profile of the most recently grabbed display (invalid when
+    // unknown / not implemented for the platform).
+    QColorSpace colorSpace() const { return m_colorSpace; }
     QPixmap selectMonitorAndCrop(const QPixmap& fullScreenshot, bool& ok);
 
 protected:
@@ -42,6 +46,7 @@ private:
 
     DesktopInfo m_info;
     QPixmap Screenshot;
+    QColorSpace m_colorSpace;
     int m_selectedMonitor;
     QEventLoop* m_monitorSelectionLoop;
     bool m_userCancelled;

--- a/src/utils/screenshotsaver.cpp
+++ b/src/utils/screenshotsaver.cpp
@@ -4,6 +4,7 @@
 #include "screenshotsaver.h"
 #include "core/flameshotdaemon.h"
 #include "utils/abstractlogger.h"
+#include "utils/colorprofileprovider.h"
 #include "utils/confighandler.h"
 #include "utils/desktopinfo.h"
 #include "utils/filenamehandler.h"
@@ -38,7 +39,8 @@
 
 bool saveToFilesystem(const QPixmap& capture,
                       const QString& path,
-                      const QString& messagePrefix)
+                      const QString& messagePrefix,
+                      const QColorSpace& colorSpace)
 {
     QString completePath = FileNameHandler().properScreenshotPath(
       path, ConfigHandler().saveAsFileExtension());
@@ -48,7 +50,14 @@ bool saveToFilesystem(const QPixmap& capture,
     if (file.open(QIODevice::WriteOnly)) {
         QString saveExtension;
         saveExtension = QFileInfo(completePath).suffix().toLower();
-        if (saveExtension == "jpg" || saveExtension == "jpeg") {
+        const bool isJpeg = saveExtension == "jpg" || saveExtension == "jpeg";
+        if (colorSpace.isValid()) {
+            const QImage tagged =
+              ColorProfileProvider::tagged(capture, colorSpace);
+            okay = isJpeg
+                     ? tagged.save(&file, nullptr, ConfigHandler().jpegQuality())
+                     : tagged.save(&file);
+        } else if (isJpeg) {
             okay = capture.save(&file, nullptr, ConfigHandler().jpegQuality());
         } else {
             okay = capture.save(&file);
@@ -111,15 +120,19 @@ QString ShowSaveFileDialog(const QString& title, const QString& directory)
     }
 }
 
-void saveToClipboardMime(const QPixmap& capture, const QString& imageType)
+void saveToClipboardMime(const QPixmap& capture,
+                         const QString& imageType,
+                         const QColorSpace& colorSpace)
 {
+    const QImage source = ColorProfileProvider::tagged(capture, colorSpace);
+
     QByteArray array;
     QBuffer buffer{ &array };
     QImageWriter imageWriter{ &buffer, imageType.toUpper().toUtf8() };
     if (imageType == "jpeg") {
         imageWriter.setQuality(ConfigHandler().jpegQuality());
     }
-    imageWriter.write(capture.toImage());
+    imageWriter.write(source);
 
     QPixmap formattedPixmap;
     bool isLoaded =
@@ -134,12 +147,12 @@ void saveToClipboardMime(const QPixmap& capture, const QString& imageType)
         // setImageData provides the image in a native pasteboard format
         // (public.tiff) that macOS can always access. Also include the
         // original format bytes for apps that prefer PNG/JPEG.
-        mimeData->setImageData(formattedPixmap.toImage());
+        mimeData->setImageData(source);
         mimeData->setData("image/" + imageType, array);
         QApplication::clipboard()->setMimeData(mimeData);
 #elif defined(USE_WAYLAND_CLIPBOARD)
         if (QGuiApplication::platformName() == "wayland") {
-            mimeData->setImageData(formattedPixmap.toImage());
+            mimeData->setImageData(source);
             mimeData->setData(QStringLiteral("x-kde-force-image-copy"),
                               QByteArray());
             KSystemClipboard::instance()->setMimeData(mimeData,
@@ -161,7 +174,7 @@ void saveToClipboardMime(const QPixmap& capture, const QString& imageType)
 
 // If data is saved to the clipboard before the notification is sent via
 // dbus, the application freezes.
-void saveToClipboard(const QPixmap& capture)
+void saveToClipboard(const QPixmap& capture, const QColorSpace& colorSpace)
 {
     // If we are able to properly save the file, save the file and copy to
     // clipboard.
@@ -169,7 +182,8 @@ void saveToClipboard(const QPixmap& capture)
         (!ConfigHandler().savePath().isEmpty())) {
         saveToFilesystem(capture,
                          ConfigHandler().savePath(),
-                         QObject::tr("Capture saved to clipboard."));
+                         QObject::tr("Capture saved to clipboard."),
+                         colorSpace);
     } else {
         AbstractLogger() << QObject::tr("Capture saved to clipboard.");
     }
@@ -177,10 +191,11 @@ void saveToClipboard(const QPixmap& capture)
     // On macOS, setPixmap uses lazy clipboard which fails when the
     // process exits ("Cannot keep promise"). Always use serialized bytes.
     saveToClipboardMime(capture,
-                        ConfigHandler().useJpgForClipboard() ? "jpeg" : "png");
+                        ConfigHandler().useJpgForClipboard() ? "jpeg" : "png",
+                        colorSpace);
 #else
     if (ConfigHandler().useJpgForClipboard()) {
-        saveToClipboardMime(capture, "jpeg");
+        saveToClipboardMime(capture, "jpeg", colorSpace);
     } else {
 #if defined(Q_OS_UNIX)
         if (DesktopInfo().waylandDetected()) {
@@ -269,7 +284,7 @@ bool saveToClipboardGnomeWorkaround(const QPixmap& pixmap, QWidget* keepAlive)
     return true;
 }
 
-bool saveToFilesystemGUI(const QPixmap& capture)
+bool saveToFilesystemGUI(const QPixmap& capture, const QColorSpace& colorSpace)
 {
     bool okay = false;
     ConfigHandler config;
@@ -303,7 +318,14 @@ bool saveToFilesystemGUI(const QPixmap& capture)
     if (file.open(QIODevice::WriteOnly)) {
         QString saveExtension;
         saveExtension = QFileInfo(savePath).suffix().toLower();
-        if (saveExtension == "jpg" || saveExtension == "jpeg") {
+        const bool isJpeg = saveExtension == "jpg" || saveExtension == "jpeg";
+        if (colorSpace.isValid()) {
+            const QImage tagged =
+              ColorProfileProvider::tagged(capture, colorSpace);
+            okay = isJpeg
+                     ? tagged.save(&file, nullptr, ConfigHandler().jpegQuality())
+                     : tagged.save(&file);
+        } else if (isJpeg) {
             okay = capture.save(&file, nullptr, ConfigHandler().jpegQuality());
         } else {
             okay = capture.save(&file);

--- a/src/utils/screenshotsaver.h
+++ b/src/utils/screenshotsaver.h
@@ -3,17 +3,25 @@
 
 #pragma once
 
+#include <QColorSpace>
 #include <QString>
 #include <QWidget>
 
 class QPixmap;
 
+// The optional colorSpace embeds an ICC profile in the written image when valid
+// (see ColorProfileProvider); an invalid color space keeps the previous,
+// untagged behavior.
 bool saveToFilesystem(const QPixmap& capture,
                       const QString& path,
-                      const QString& messagePrefix = "");
+                      const QString& messagePrefix = "",
+                      const QColorSpace& colorSpace = {});
 QString ShowSaveFileDialog(const QString& title, const QString& directory);
-void saveToClipboardMime(const QPixmap& capture, const QString& imageType);
-void saveToClipboard(const QPixmap& capture);
+void saveToClipboardMime(const QPixmap& capture,
+                         const QString& imageType,
+                         const QColorSpace& colorSpace = {});
+void saveToClipboard(const QPixmap& capture, const QColorSpace& colorSpace = {});
 // GNOME Wayland: keeps the widget alive until clipboard data is fetched
 bool saveToClipboardGnomeWorkaround(const QPixmap& pixmap, QWidget* keepAlive);
-bool saveToFilesystemGUI(const QPixmap& capture);
+bool saveToFilesystemGUI(const QPixmap& capture,
+                         const QColorSpace& colorSpace = {});

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -126,6 +126,7 @@ CaptureWidget::CaptureWidget(const CaptureRequest& req,
             this->close();
         }
         m_context.origScreenshot = m_context.screenshot;
+        m_context.colorSpace = grabber.colorSpace();
 
         selectedScreen = grabber.getSelectedScreen();
 
@@ -323,7 +324,7 @@ CaptureWidget::~CaptureWidget()
         QRect geometry(m_context.selection);
         geometry.setTopLeft(geometry.topLeft() + m_context.widgetOffset);
         Flameshot::instance()->exportCapture(
-          pixmap(), geometry, m_context.request);
+          pixmap(), geometry, m_context.request, m_context.colorSpace);
     } else {
         emit Flameshot::instance()->captureFailed();
     }


### PR DESCRIPTION
_Disclaimer: I'm not a C++/Qt developer. I put this together with AI assistance and tried hard to match the patterns and style already in the codebase, but it needs a review from someone who knows Qt well._

### Problem 

On a wide-gamut/HDR display the captured pixels are in the display's color space, but Flameshot saved the PNG with no ICC profile attached. Without that tag, other apps fall back to assuming sRGB, so the screenshot looks noticeably desaturated next to the one macOS' built-in tool makes — that one embeds the active display profile (`LG HDR 5K`, in my case).

The reason it happens: captures travel through the app as a `QPixmap`, which can't hold a `QColorSpace`, and every place that writes the image writes from that pixmap. So the display profile was never asked for and never written out.

### Fix

The display's color profile is now read once, at capture time, and travels alongside the capture until it's written:

- A small `ColorProfileProvider` asks CoreGraphics for the active display's profile (`CGDisplayCopyColorSpace` → ICC → `QColorSpace`). If that doesn't give us something usable it falls back to Display P3 for wide-gamut screens, and otherwise just leaves the image untagged like before. On non-macOS platforms it returns nothing, so those builds behave exactly as they do today.
- `ScreenGrabber` grabs the profile when it takes the screenshot and hands it on; it rides along on `CaptureContext` since the pixmap itself can't carry it.
- From there it's passed through `exportCapture` to each thing that writes an image, saving to a file, `--raw`, the clipboard, pins (including a pinned image's own copy/save), and the "Open With" temp file. The parameter defaults to empty, so nothing else in the codebase had to change. The actual tagging is just `QImage::setColorSpace`, which labels the pixels without recoloring them — which is what we want, because they're already in the display's space.

### Why macOS only

That's the only platform I could actually reproduce the bug on, so it's the only one I felt comfortable fixing. From what I can tell the same thing can affect wide-gamut displays on Windows and on Linux (X11/Wayland) as well, but I had no way to test there, so I deliberately left those paths untouched. I designed the provider so adding the other platforms later is mostly a matter of filling in `forScreen()` for each — the reasoning, trade-offs and a full test plan are in the write-up attached to #4341.

### Testing

There weren't any C++ tests in the repo yet, so I added a small QtTest suite (`tests/unit/test_colorprofile.cpp`) and hooked it into the CTest step that CI already runs. It's headless and platform-neutral: it covers the tagging helper, the fallback logic, and a PNG round-trip that proves the profile actually ends up embedded (plus a baseline showing an untagged image stays untagged).

I also checked it for real on my `LG HDR 5K` monitor: before, a saved capture had no profile; now `sips` reports `profile: LG HDR 5K`, same as the native screenshot tool.

### Known gaps

- Qt only embeds the profile when the `QColorSpace` is valid (matrix-based RGB); unusual display profiles fall back to Display P3.
- Imgur uploads still go out untagged for now. It's behind the `ENABLE_IMGUR` option (off by default), so I couldn't compile or test that path, and it runs through its own separate code rather than `exportCapture`.
- Windows/X11/Wayland are intentionally not addressed here.

