### PR TITLE
Fix screen capture ignoring GUI last-region setting

### DIFF
--- a/src/core/capturerequest.cpp
+++ b/src/core/capturerequest.cpp
@@ -2,12 +2,7 @@
 // SPDX-FileCopyrightText: 2017-2019 Alejandro Sirgo Rica & Contributors
 
 #include "capturerequest.h"
-#include "config/cacheutils.h"
-#include "utils/confighandler.h"
 
-#include <QApplication>
-#include <QClipboard>
-#include <QDateTime>
 #include <stdexcept>
 #include <utility>
 
@@ -22,12 +17,6 @@ CaptureRequest::CaptureRequest(CaptureRequest::CaptureMode mode,
   , m_selectedMonitor(-1)
   , m_hasSelectedMonitor(false)
 {
-
-    ConfigHandler config;
-    if (m_mode == CaptureRequest::CaptureMode::GRAPHICAL_MODE &&
-        config.saveLastRegion()) {
-        setInitialSelection(getLastRegion());
-    }
 }
 
 CaptureRequest::CaptureMode CaptureRequest::captureMode() const

--- a/src/core/capturerequest.cpp
+++ b/src/core/capturerequest.cpp
@@ -16,8 +16,7 @@ CaptureRequest::CaptureRequest(CaptureRequest::CaptureMode mode,
   , m_data(std::move(data))
   , m_selectedMonitor(-1)
   , m_hasSelectedMonitor(false)
-{
-}
+{}
 
 CaptureRequest::CaptureMode CaptureRequest::captureMode() const
 {

--- a/src/core/flameshot.cpp
+++ b/src/core/flameshot.cpp
@@ -42,6 +42,7 @@ constexpr const char* visibleInDockProperty = "_visibleInDock";
 #include <CoreGraphics/CoreGraphics.h>
 #endif
 
+#include "config/cacheutils.h"
 #include "config/configresolver.h"
 #include "config/configwindow.h"
 #include "core/qguiappcurrentscreen.h"
@@ -125,6 +126,13 @@ CaptureWidget* Flameshot::gui(const CaptureRequest& req)
         return nullptr;
     }
 
+    CaptureRequest request = req;
+    if (request.captureMode() == CaptureRequest::GRAPHICAL_MODE &&
+        request.initialSelection().isNull() &&
+        ConfigHandler().saveLastRegion()) {
+        request.setInitialSelection(getLastRegion());
+    }
+
 #if defined(Q_OS_MACOS)
     // This is required on MacOS because of Mission Control. If you'll switch to
     // another Desktop you cannot take a new screenshot from the tray, you have
@@ -157,7 +165,7 @@ CaptureWidget* Flameshot::gui(const CaptureRequest& req)
             return nullptr;
         }
 
-        m_captureWindow = new CaptureWidget(req);
+        m_captureWindow = new CaptureWidget(request);
 
 #ifdef Q_OS_WIN
         m_captureWindow->show();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -500,7 +500,7 @@ int main(int argc, char* argv[])
         if (!region.isEmpty()) {
             auto selectionRegion = Region().value(region).toRect();
             req.setInitialSelection(selectionRegion);
-        } else if (useLastRegion) {
+        } else if (useLastRegion || ConfigHandler().saveLastRegion()) {
             req.setInitialSelection(getLastRegion());
         }
         if (clipboard) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -500,7 +500,7 @@ int main(int argc, char* argv[])
         if (!region.isEmpty()) {
             auto selectionRegion = Region().value(region).toRect();
             req.setInitialSelection(selectionRegion);
-        } else if (useLastRegion || ConfigHandler().saveLastRegion()) {
+        } else if (useLastRegion) {
             req.setInitialSelection(getLastRegion());
         }
         if (clipboard) {

--- a/src/utils/screengrabber.cpp
+++ b/src/utils/screengrabber.cpp
@@ -238,6 +238,12 @@ QPixmap ScreenGrabber::grabEntireDesktop(bool& ok, int preSelectedMonitor)
         ok = false;
         return QPixmap();
     }
+    m_selectedMonitor = QGuiApplication::screens().indexOf(currentScreen);
+    if (m_selectedMonitor < 0) {
+        AbstractLogger::error() << tr("Unable to get current screen");
+        ok = false;
+        return QPixmap();
+    }
     const QRect geom = currentScreen->geometry();
     screenshot = currentScreen->grabWindow(
       wid, geom.x(), geom.y(), geom.width(), geom.height());


### PR DESCRIPTION
Addresses #4312.

This PR makes **Use last region for GUI mode** apply only to `flameshot gui`.

Before this change, the last region was applied inside `CaptureRequest` for graphical requests. Because of that, `flameshot screen` could reuse the previous GUI region instead of capturing the full screen.

Now the last-region setting is handled only in the `gui` command path. The `screen` command ignores it, as discussed in the issue.

While testing the original reproduction steps on macOS, I also found that `flameshot screen` without `--number` was aborting. The screenshot was grabbed, but the selected monitor was not stored, so the command failed afterward. This PR stores the current monitor index in the macOS screen path so the original `flameshot screen` command works.

Regression risk should be low:
- The behavior matches the maintainer direction that only `gui` should use the last-region setting.
- The macOS monitor fix only affects macOS.
- Linux and Windows screen capture paths are not changed by the macOS-specific fix.

Tested on macOS 26.3 arm64:
- `gui` reuses the last region when the setting is enabled.
- `screen` ignores the last GUI region and captures the full monitor.
- `screen` without `--number` no longer aborts.