### PR TITLE
Add side panel widget to manually edit geometry

### DIFF
--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -1271,6 +1271,13 @@ void CaptureWidget::initPanel()
             this,
             &CaptureWidget::setDrawColor);
     connect(m_sidePanel,
+            &SidePanelWidget::geometryChangeRequested,
+            this,
+            [this](QRect const &geometry){
+                if(m_selection)
+                    m_selection->setGeometry(geometry);
+            });
+    connect(m_sidePanel,
             &SidePanelWidget::toolSizeChanged,
             this,
             &CaptureWidget::onToolSizeChanged);
@@ -1352,6 +1359,7 @@ void CaptureWidget::initSelection()
         updateCursor();
         updateSizeIndicator();
         OverlayMessage::pop();
+        m_sidePanel->onGrabAreaChanged(m_context.selection);
     });
     connect(m_selection, &SelectionWidget::geometrySettled, this, [this]() {
         if (m_selection->isVisibleTo(this)) {

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -1273,8 +1273,8 @@ void CaptureWidget::initPanel()
     connect(m_sidePanel,
             &SidePanelWidget::geometryChangeRequested,
             this,
-            [this](QRect const &geometry){
-                if(m_selection)
+            [this](QRect const& geometry) {
+                if (m_selection)
                     m_selection->setGeometry(geometry);
             });
     connect(m_sidePanel,

--- a/src/widgets/panel/CMakeLists.txt
+++ b/src/widgets/panel/CMakeLists.txt
@@ -1,4 +1,4 @@
 # Required to generate MOC
-target_sources(flameshot PRIVATE sidepanelwidget.h utilitypanel.h colorgrabwidget.h)
+target_sources(flameshot PRIVATE sidepanelwidget.h utilitypanel.h colorgrabwidget.h geometryeditlayoutwidget.h)
 
-target_sources(flameshot PRIVATE sidepanelwidget.cpp utilitypanel.cpp colorgrabwidget.cpp)
+target_sources(flameshot PRIVATE sidepanelwidget.cpp utilitypanel.cpp colorgrabwidget.cpp geometryeditlayoutwidget.cpp)

--- a/src/widgets/panel/geometryeditlayoutwidget.cpp
+++ b/src/widgets/panel/geometryeditlayoutwidget.cpp
@@ -1,0 +1,67 @@
+#include "geometryeditlayoutwidget.h"
+
+#include <QGridLayout>
+#include <QLabel>
+#include <QSpinBox>
+
+GeometryEditLayoutWidget::GeometryEditLayoutWidget(QWidget* parent)
+  : QGroupBox("Grab area")
+{
+    auto grid = new QGridLayout(this);
+    auto wl = new QLabel("Width");
+    m_wEditor = new QSpinBox;
+    m_wEditor->setMaximum(3000);
+    m_wEditor->setMinimum(1);
+    m_wEditor->setValue(1280);
+
+    auto hl = new QLabel("Height");
+    m_hEditor = new QSpinBox;
+    m_hEditor->setMaximum(3000);
+    m_hEditor->setMinimum(1);
+    m_hEditor->setValue(1280);
+
+    auto xl = new QLabel("X");
+    m_xEditor = new QSpinBox;
+    m_xEditor->setMaximum(3000);
+    m_xEditor->setMinimum(1);
+    m_xEditor->setValue(1280);
+
+    auto yl = new QLabel("Y");
+    m_yEditor = new QSpinBox;
+    m_yEditor->setMaximum(3000);
+    m_yEditor->setMinimum(1);
+    m_yEditor->setValue(1280);
+
+    grid->addWidget(wl, 0, 0);
+    grid->addWidget(m_wEditor, 0, 1);
+
+    grid->addWidget(hl, 1, 0);
+    grid->addWidget(m_hEditor, 1, 1);
+
+    grid->addWidget(xl, 2, 0);
+    grid->addWidget(m_xEditor, 2, 1);
+
+    grid->addWidget(yl, 3, 0);
+    grid->addWidget(m_yEditor, 3, 1);
+
+    setLayout(grid);
+
+    auto updateCallback = [this]() {
+        emit edited({ m_xEditor->value(),
+                      m_yEditor->value(),
+                      m_wEditor->value(),
+                      m_hEditor->value() });
+    };
+    connect(m_wEditor, &QSpinBox::editingFinished, this, updateCallback);
+    connect(m_hEditor, &QSpinBox::editingFinished, this, updateCallback);
+    connect(m_xEditor, &QSpinBox::editingFinished, this, updateCallback);
+    connect(m_yEditor, &QSpinBox::editingFinished, this, updateCallback);
+}
+
+void GeometryEditLayoutWidget::update(QRect const& g)
+{
+    m_wEditor->setValue(g.width());
+    m_hEditor->setValue(g.height());
+    m_xEditor->setValue(g.x());
+    m_yEditor->setValue(g.y());
+}

--- a/src/widgets/panel/geometryeditlayoutwidget.cpp
+++ b/src/widgets/panel/geometryeditlayoutwidget.cpp
@@ -4,33 +4,39 @@
 #include <QLabel>
 #include <QSpinBox>
 
+int const MIN_POSITION = 0;
+int const MAX_POSITION = 100000;
+
+int const MIN_SIZE = 1;
+int const MAX_SIZE = 100000;
+
 GeometryEditLayoutWidget::GeometryEditLayoutWidget(QWidget* parent)
   : QGroupBox("Grab area")
 {
     auto grid = new QGridLayout(this);
     auto wl = new QLabel("Width");
     m_wEditor = new QSpinBox;
-    m_wEditor->setMaximum(3000);
-    m_wEditor->setMinimum(1);
-    m_wEditor->setValue(1280);
+    m_wEditor->setMaximum(MAX_SIZE);
+    m_wEditor->setMinimum(MIN_SIZE);
+    m_wEditor->setValue(MIN_SIZE);
 
     auto hl = new QLabel("Height");
     m_hEditor = new QSpinBox;
-    m_hEditor->setMaximum(3000);
-    m_hEditor->setMinimum(1);
-    m_hEditor->setValue(1280);
+    m_hEditor->setMaximum(MAX_SIZE);
+    m_hEditor->setMinimum(MIN_SIZE);
+    m_hEditor->setValue(MIN_SIZE);
 
     auto xl = new QLabel("X");
     m_xEditor = new QSpinBox;
-    m_xEditor->setMaximum(3000);
-    m_xEditor->setMinimum(1);
-    m_xEditor->setValue(1280);
+    m_xEditor->setMaximum(MAX_POSITION);
+    m_xEditor->setMinimum(MIN_POSITION);
+    m_xEditor->setValue(MIN_POSITION);
 
     auto yl = new QLabel("Y");
     m_yEditor = new QSpinBox;
-    m_yEditor->setMaximum(3000);
-    m_yEditor->setMinimum(1);
-    m_yEditor->setValue(1280);
+    m_yEditor->setMaximum(MAX_POSITION);
+    m_yEditor->setMinimum(MIN_POSITION);
+    m_yEditor->setValue(MIN_POSITION);
 
     grid->addWidget(wl, 0, 0);
     grid->addWidget(m_wEditor, 0, 1);

--- a/src/widgets/panel/geometryeditlayoutwidget.h
+++ b/src/widgets/panel/geometryeditlayoutwidget.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <QGroupBox>
+
+class QSpinBox;
+
+class GeometryEditLayoutWidget : public QGroupBox
+{
+    Q_OBJECT
+public:
+    explicit GeometryEditLayoutWidget(QWidget* parent = nullptr);
+    void update(QRect const& geometry);
+signals:
+    void edited(QRect const& geometry);
+private:
+    QSpinBox* m_wEditor;
+    QSpinBox* m_hEditor;
+    QSpinBox* m_xEditor;
+    QSpinBox* m_yEditor;
+};

--- a/src/widgets/panel/geometryeditlayoutwidget.h
+++ b/src/widgets/panel/geometryeditlayoutwidget.h
@@ -12,6 +12,7 @@ public:
     void update(QRect const& geometry);
 signals:
     void edited(QRect const& geometry);
+
 private:
     QSpinBox* m_wEditor;
     QSpinBox* m_hEditor;

--- a/src/widgets/panel/sidepanelwidget.cpp
+++ b/src/widgets/panel/sidepanelwidget.cpp
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: 2017-2019 Alejandro Sirgo Rica & Contributors
 
 #include "sidepanelwidget.h"
+#include "geometryeditlayoutwidget.h"
 #include "utils/colorutils.h"
 #include "utils/pathinfo.h"
 #include "widgets/panel/colorgrabwidget.h"
@@ -93,6 +94,13 @@ SidePanelWidget::SidePanelWidget(QPixmap* p, QWidget* parent)
     gridHBoxLayout->addWidget(m_gridSizeSpin);
     m_layout->addLayout(gridHBoxLayout);
 
+    m_geometryEditWidget = new GeometryEditLayoutWidget;
+    m_layout->addWidget(m_geometryEditWidget);
+    connect(m_geometryEditWidget,
+            &GeometryEditLayoutWidget::edited,
+            this,
+            &SidePanelWidget::geometryChangeRequested);
+
     // tool size sigslots
     connect(m_toolSizeSpin,
             static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged),
@@ -152,6 +160,11 @@ void SidePanelWidget::onToolSizeChanged(int t)
     m_toolSize = qBound(0, t, maxToolSize);
     m_toolSizeSlider->setValue(m_toolSize);
     m_toolSizeSpin->setValue(m_toolSize);
+}
+
+void SidePanelWidget::onGrabAreaChanged(QRect const& geometry)
+{
+    m_geometryEditWidget->update(geometry);
 }
 
 void SidePanelWidget::startColorGrab()

--- a/src/widgets/panel/sidepanelwidget.h
+++ b/src/widgets/panel/sidepanelwidget.h
@@ -15,6 +15,7 @@ class ColorGrabWidget;
 class QColorPickingEventFilter;
 class QSlider;
 class QCheckBox;
+class GeometryEditLayoutWidget;
 
 constexpr int maxToolSize = 50;
 constexpr int minSliderWidth = 100;
@@ -36,9 +37,11 @@ signals:
     void hidePanel();
     void displayGridChanged(bool display);
     void gridSizeChanged(int size);
+    void geometryChangeRequested(QRect const& geometry);
 
 public slots:
     void onToolSizeChanged(int tool);
+    void onGrabAreaChanged(QRect const& geometry);
     void onColorChanged(const QColor& color);
     void startColorGrab();
 
@@ -68,4 +71,5 @@ private:
     int m_toolSize{};
     QCheckBox* m_gridCheck{ nullptr };
     QSpinBox* m_gridSizeSpin{ nullptr };
+    GeometryEditLayoutWidget* m_geometryEditWidget;
 };


### PR DESCRIPTION
An attempt to resolve https://github.com/flameshot-org/flameshot/issues/4703

This PR adds a "Grab area" widget in the side panel that allows for manual geometry edits

<img width="1239" height="982" alt="image" src="https://github.com/user-attachments/assets/9b6f38de-5fed-495a-b66e-84a6cd25e899" />
