### PR TITLE
Commit text on Esc in text tool

### DIFF
--- a/src/tools/capturetool.h
+++ b/src/tools/capturetool.h
@@ -78,7 +78,9 @@ public:
         // increase tool size for all tools
         REQ_INCREASE_TOOL_SIZE,
         // decrease tool size for all tools
-        REQ_DECREASE_TOOL_SIZE
+        REQ_DECREASE_TOOL_SIZE,
+        // Commit the active tool.
+        REQ_COMMIT_CURRENT_TOOL
     };
 
     explicit CaptureTool(QObject* parent = nullptr)

--- a/src/tools/text/texttool.cpp
+++ b/src/tools/text/texttool.cpp
@@ -108,6 +108,12 @@ QWidget* TextTool::widget()
     m_widget->setText(m_text);
     m_widget->selectAll();
     connect(m_widget, &TextWidget::textUpdated, this, &TextTool::updateText);
+    connect(
+      m_widget,
+      &TextWidget::editingFinished,
+      this,
+      [this]() { emit requestAction(REQ_COMMIT_CURRENT_TOOL); },
+      Qt::QueuedConnection);
     return m_widget;
 }
 

--- a/src/tools/text/textwidget.cpp
+++ b/src/tools/text/textwidget.cpp
@@ -3,6 +3,9 @@
 
 #include "textwidget.h"
 
+#include <QEvent>
+#include <QKeyEvent>
+
 TextWidget::TextWidget(QWidget* parent)
   : QTextEdit(parent)
 {
@@ -12,6 +15,30 @@ TextWidget::TextWidget(QWidget* parent)
     setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
     setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
     setContextMenuPolicy(Qt::NoContextMenu);
+}
+
+bool TextWidget::event(QEvent* e)
+{
+    if (e->type() == QEvent::ShortcutOverride) {
+        auto* keyEvent = static_cast<QKeyEvent*>(e);
+        if (keyEvent->key() == Qt::Key_Escape) {
+            keyEvent->accept();
+            return true;
+        }
+    }
+
+    return QTextEdit::event(e);
+}
+
+void TextWidget::keyPressEvent(QKeyEvent* e)
+{
+    if (e->key() == Qt::Key_Escape) {
+        emit editingFinished();
+        e->accept();
+        return;
+    }
+
+    QTextEdit::keyPressEvent(e);
 }
 
 void TextWidget::showEvent(QShowEvent* e)

--- a/src/tools/text/textwidget.h
+++ b/src/tools/text/textwidget.h
@@ -5,6 +5,9 @@
 
 #include <QTextEdit>
 
+class QEvent;
+class QKeyEvent;
+
 class TextWidget : public QTextEdit
 {
     Q_OBJECT
@@ -15,11 +18,14 @@ public:
     void setFont(const QFont& f);
 
 protected:
-    void showEvent(QShowEvent* e);
-    void resizeEvent(QResizeEvent* e);
+    bool event(QEvent* e) override;
+    void keyPressEvent(QKeyEvent* e) override;
+    void showEvent(QShowEvent* e) override;
+    void resizeEvent(QResizeEvent* e) override;
 
 signals:
     void textUpdated(const QString& s);
+    void editingFinished();
 
 public slots:
     void setTextColor(const QColor& c);

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -1493,6 +1493,18 @@ void CaptureWidget::handleToolSignal(CaptureTool::Request r)
         case CaptureTool::REQ_DECREASE_TOOL_SIZE:
             setToolSize(m_context.toolSize - 1);
             break;
+        case CaptureTool::REQ_COMMIT_CURRENT_TOOL: {
+            const bool editingExistingTool =
+              m_activeTool && m_activeTool->editMode();
+            if (commitCurrentTool()) {
+                if (editingExistingTool) {
+                    m_panel->setToolWidget(nullptr);
+                }
+                drawToolsData();
+                updateLayersPanel();
+            }
+            break;
+        }
         default:
             break;
     }


### PR DESCRIPTION
This addresses #2499.

The fix is scoped to the Text tool: when the active text editor receives `Esc`, it consumes the shortcut and requests the same commit path used when clicking outside the text box. This keeps the typed text and exits editing mode without changing the existing `Esc` behavior for in-progress drawing operations like lines, shapes, or arrows.