### PR TITLE
Add keyboard controls to monitor selector

### DIFF
--- a/src/utils/monitorpreview.cpp
+++ b/src/utils/monitorpreview.cpp
@@ -16,38 +16,48 @@ MonitorPreview::MonitorPreview(int monitorIndex,
                                QWidget* parent)
   : QWidget(parent)
   , m_monitorIndex(monitorIndex)
+  , m_selected(false)
+  , m_mouseHovered(false)
+  , m_imageLabel(nullptr)
+  , m_keyLabel(nullptr)
+  , m_textLabel(nullptr)
 {
     QVBoxLayout* layout = new QVBoxLayout(this);
     layout->setContentsMargins(10, 10, 10, 10);
     layout->setSpacing(10);
 
-    QLabel* imageLabel = new QLabel(this);
-    imageLabel->setAlignment(Qt::AlignCenter);
-    imageLabel->setPixmap(thumbnail);
-    imageLabel->setStyleSheet(
-      "QLabel { background-color: black; border-radius: 8px; }");
-    imageLabel->setScaledContents(false);
+    m_imageLabel = new QLabel(this);
+    m_imageLabel->setAlignment(Qt::AlignCenter);
+    m_imageLabel->setPixmap(thumbnail);
+    m_imageLabel->setScaledContents(false);
 
-    m_textLabel = new QLabel(tr("Monitor %1: %2\nClick to select")
-                               .arg(m_monitorIndex + 1)
-                               .arg(screen->name()),
-                             this);
+    if (m_monitorIndex < 9) {
+        m_keyLabel =
+          new QLabel(QString::number(m_monitorIndex + 1), m_imageLabel);
+        m_keyLabel->setAlignment(Qt::AlignCenter);
+        m_keyLabel->setFixedSize(28, 28);
+        m_keyLabel->move(8, 8);
+        m_keyLabel->raise();
+        m_keyLabel->setAttribute(Qt::WA_TransparentForMouseEvents);
+    }
+
+    const QString labelText =
+      m_monitorIndex < 9 ? tr("Monitor %1: %2\nClick or press %1 to select")
+                             .arg(m_monitorIndex + 1)
+                             .arg(screen->name())
+                         : tr("Monitor %1: %2\nClick to select")
+                             .arg(m_monitorIndex + 1)
+                             .arg(screen->name());
+    m_textLabel = new QLabel(labelText, this);
     m_textLabel->setAlignment(Qt::AlignCenter);
 
-    layout->addWidget(imageLabel);
+    layout->addWidget(m_imageLabel);
     layout->addWidget(m_textLabel);
 
     m_uiColor = ConfigHandler().uiColor();
     m_contrastColor = ColorUtils::contrastColor(m_uiColor);
 
-    // Apply initial themed background to text label only
-    QString normalStyle =
-      QString("QLabel { color: white; background-color: rgba(%1, %2, %3, 200); "
-              "padding: 5px; font-size: 12pt; border-radius: 3px; }")
-        .arg(m_uiColor.red())
-        .arg(m_uiColor.green())
-        .arg(m_uiColor.blue());
-    m_textLabel->setStyleSheet(normalStyle);
+    updateStyle();
 }
 
 void MonitorPreview::mousePressEvent(QMouseEvent* event)
@@ -59,24 +69,59 @@ void MonitorPreview::mousePressEvent(QMouseEvent* event)
 void MonitorPreview::enterEvent(QEnterEvent* event)
 {
     Q_UNUSED(event)
-    QColor hoverBg = m_contrastColor;
-    QString hoverStyle =
-      QString("QLabel { color: white; background-color: rgba(%1, %2, %3, 220); "
-              "padding: 5px; font-size: 12pt; border-radius: 3px; }")
-        .arg(hoverBg.red())
-        .arg(hoverBg.green())
-        .arg(hoverBg.blue());
-    m_textLabel->setStyleSheet(hoverStyle);
+    m_mouseHovered = true;
+    updateStyle();
 }
 
 void MonitorPreview::leaveEvent(QEvent* event)
 {
     Q_UNUSED(event)
-    QString normalStyle =
-      QString("QLabel { color: white; background-color: rgba(%1, %2, %3, 200); "
+    m_mouseHovered = false;
+    updateStyle();
+}
+
+void MonitorPreview::setSelected(bool selected)
+{
+    if (m_selected == selected) {
+        return;
+    }
+
+    m_selected = selected;
+    updateStyle();
+}
+
+void MonitorPreview::updateStyle()
+{
+    const bool highlighted = m_selected || m_mouseHovered;
+    const QColor backgroundColor = highlighted ? m_contrastColor : m_uiColor;
+    const int textAlpha = highlighted ? 220 : 200;
+    const int borderAlpha = highlighted ? 255 : 0;
+
+    QString textStyle =
+      QString("QLabel { color: white; background-color: rgba(%1, %2, %3, %4); "
               "padding: 5px; font-size: 12pt; border-radius: 3px; }")
-        .arg(m_uiColor.red())
-        .arg(m_uiColor.green())
-        .arg(m_uiColor.blue());
-    m_textLabel->setStyleSheet(normalStyle);
+        .arg(backgroundColor.red())
+        .arg(backgroundColor.green())
+        .arg(backgroundColor.blue())
+        .arg(textAlpha);
+    m_textLabel->setStyleSheet(textStyle);
+
+    QString imageStyle =
+      QString("QLabel { background-color: black; border: 2px solid "
+              "rgba(%1, %2, %3, %4); border-radius: 8px; }")
+        .arg(backgroundColor.red())
+        .arg(backgroundColor.green())
+        .arg(backgroundColor.blue())
+        .arg(borderAlpha);
+    m_imageLabel->setStyleSheet(imageStyle);
+
+    if (m_keyLabel) {
+        QString keyStyle = QString("QLabel { color: white; font-weight: bold; "
+                                   "background-color: rgba(%1, %2, %3, 230); "
+                                   "border-radius: 14px; }")
+                             .arg(backgroundColor.red())
+                             .arg(backgroundColor.green())
+                             .arg(backgroundColor.blue());
+        m_keyLabel->setStyleSheet(keyStyle);
+    }
 }

--- a/src/utils/monitorpreview.h
+++ b/src/utils/monitorpreview.h
@@ -20,6 +20,7 @@ public:
                    QWidget* parent = nullptr);
 
     int monitorIndex() const { return m_monitorIndex; }
+    void setSelected(bool selected);
 
 signals:
     void monitorSelected(int index);
@@ -30,8 +31,14 @@ protected:
     void leaveEvent(QEvent* event) override;
 
 private:
+    void updateStyle();
+
     int m_monitorIndex;
+    bool m_selected;
+    bool m_mouseHovered;
     QColor m_uiColor;
     QColor m_contrastColor;
+    QLabel* m_imageLabel;
+    QLabel* m_keyLabel;
     QLabel* m_textLabel;
 };

--- a/src/utils/screengrabber.cpp
+++ b/src/utils/screengrabber.cpp
@@ -40,6 +40,7 @@ bool ScreenGrabber::m_monitorSelectionActive = false;
 ScreenGrabber::ScreenGrabber(QObject* parent)
   : QObject(parent)
   , m_selectedMonitor(-1)
+  , m_highlightedMonitorPreview(-1)
   , m_monitorSelectionLoop(nullptr)
   , m_userCancelled(false)
 {
@@ -165,6 +166,7 @@ QPixmap ScreenGrabber::selectMonitorAndCrop(const QPixmap& fullScreenshot,
     // Only screenshot the monitor where the tray activated the screenshot
     return cropToMonitor(fullScreenshot, 0);
 #else
+
     // If there's only one monitor, skip selection
     const QList<QScreen*> screens = QGuiApplication::screens();
     if (screens.size() == 1) {
@@ -211,6 +213,8 @@ QPixmap ScreenGrabber::selectMonitorAndCrop(const QPixmap& fullScreenshot,
     m_monitorSelectionLoop = nullptr;
 
     delete container;
+    m_monitorPreviews.clear();
+    m_highlightedMonitorPreview = -1;
     m_monitorSelectionActive = false;
 
     if (m_selectedMonitor >= 0) {
@@ -387,6 +391,8 @@ QScreen* ScreenGrabber::getSelectedScreen() const
 QWidget* ScreenGrabber::createMonitorPreviews(const QPixmap& fullScreenshot)
 {
     const QList<QScreen*> screens = QGuiApplication::screens();
+    m_monitorPreviews.clear();
+    m_highlightedMonitorPreview = -1;
 
 #ifdef FLAMESHOT_DEBUG_CAPTURE
     qDebug() << tr("=== All Screen Information ===");
@@ -435,16 +441,23 @@ QWidget* ScreenGrabber::createMonitorPreviews(const QPixmap& fullScreenshot)
         MonitorPreview* preview =
           new MonitorPreview(i, screen, thumbnail, monitorPreviews);
 
-        connect(
-          preview, &MonitorPreview::monitorSelected, this, [this](int index) {
-              m_selectedMonitor = index;
-              if (m_monitorSelectionLoop) {
-                  m_monitorSelectionLoop->quit();
-              }
-          });
+        connect(preview,
+                &MonitorPreview::monitorSelected,
+                this,
+                [this](int index) { selectMonitor(index); });
 
+        m_monitorPreviews.append(preview);
         containerLayout->addWidget(preview);
     }
+
+    int initialPreviewIndex = 0;
+    QScreen* currentScreen = QGuiAppCurrentScreen().currentScreen();
+    int currentMonitorIndex = screens.indexOf(currentScreen);
+    int currentPreviewIndex = previewIndexForMonitor(currentMonitorIndex);
+    if (currentPreviewIndex >= 0) {
+        initialPreviewIndex = currentPreviewIndex;
+    }
+    setHighlightedMonitorPreview(initialPreviewIndex);
 
     monitorPreviews->setLayout(containerLayout);
     monitorPreviews->adjustSize();
@@ -456,21 +469,118 @@ QWidget* ScreenGrabber::createMonitorPreviews(const QPixmap& fullScreenshot)
                           center.y() - monitorPreviews->height() / 2);
 
     monitorPreviews->show();
+    monitorPreviews->raise();
+    monitorPreviews->activateWindow();
+    monitorPreviews->setFocus(Qt::ActiveWindowFocusReason);
     return monitorPreviews;
+}
+
+void ScreenGrabber::cancelMonitorSelection()
+{
+    m_selectedMonitor = -1;
+    m_userCancelled = true;
+    if (m_monitorSelectionLoop) {
+        m_monitorSelectionLoop->quit();
+    }
+}
+
+void ScreenGrabber::moveHighlightedMonitorPreview(int offset)
+{
+    if (m_monitorPreviews.isEmpty()) {
+        return;
+    }
+
+    int nextPreviewIndex = m_highlightedMonitorPreview;
+    if (nextPreviewIndex < 0) {
+        nextPreviewIndex = 0;
+    } else {
+        nextPreviewIndex += offset;
+    }
+
+    setHighlightedMonitorPreview(nextPreviewIndex);
+}
+
+int ScreenGrabber::previewIndexForMonitor(int monitorIndex) const
+{
+    for (int i = 0; i < m_monitorPreviews.size(); ++i) {
+        if (m_monitorPreviews[i]->monitorIndex() == monitorIndex) {
+            return i;
+        }
+    }
+
+    return -1;
+}
+
+void ScreenGrabber::selectHighlightedMonitorPreview()
+{
+    if (m_highlightedMonitorPreview < 0 ||
+        m_highlightedMonitorPreview >= m_monitorPreviews.size()) {
+        return;
+    }
+
+    selectMonitor(
+      m_monitorPreviews[m_highlightedMonitorPreview]->monitorIndex());
+}
+
+void ScreenGrabber::selectMonitor(int monitorIndex)
+{
+    m_selectedMonitor = monitorIndex;
+    if (m_monitorSelectionLoop) {
+        m_monitorSelectionLoop->quit();
+    }
+}
+
+void ScreenGrabber::setHighlightedMonitorPreview(int previewIndex)
+{
+    if (m_monitorPreviews.isEmpty()) {
+        m_highlightedMonitorPreview = -1;
+        return;
+    }
+
+    const int previewCount = m_monitorPreviews.size();
+    int normalizedIndex = previewIndex % previewCount;
+    if (normalizedIndex < 0) {
+        normalizedIndex += previewCount;
+    }
+
+    for (int i = 0; i < previewCount; ++i) {
+        m_monitorPreviews[i]->setSelected(i == normalizedIndex);
+    }
+    m_highlightedMonitorPreview = normalizedIndex;
 }
 
 bool ScreenGrabber::eventFilter(QObject* obj, QEvent* event)
 {
     if (event->type() == QEvent::KeyPress) {
         QKeyEvent* keyEvent = static_cast<QKeyEvent*>(event);
-        if (keyEvent->key() == Qt::Key_Escape) {
-            // User cancelled selection
-            m_selectedMonitor = -1;
-            m_userCancelled = true;
-            if (m_monitorSelectionLoop) {
-                m_monitorSelectionLoop->quit();
-            }
-            return true;
+        switch (keyEvent->key()) {
+            case Qt::Key_Escape:
+                cancelMonitorSelection();
+                return true;
+            case Qt::Key_Left:
+            case Qt::Key_Up:
+            case Qt::Key_Backtab:
+                moveHighlightedMonitorPreview(-1);
+                return true;
+            case Qt::Key_Right:
+            case Qt::Key_Down:
+            case Qt::Key_Tab:
+                moveHighlightedMonitorPreview(1);
+                return true;
+            case Qt::Key_Return:
+            case Qt::Key_Enter:
+            case Qt::Key_Space:
+                selectHighlightedMonitorPreview();
+                return true;
+            default:
+                if (keyEvent->key() >= Qt::Key_1 &&
+                    keyEvent->key() <= Qt::Key_9) {
+                    int monitorIndex = keyEvent->key() - Qt::Key_1;
+                    if (previewIndexForMonitor(monitorIndex) >= 0) {
+                        selectMonitor(monitorIndex);
+                    }
+                    return true;
+                }
         }
     }
     return QObject::eventFilter(obj, event);

--- a/src/utils/screengrabber.h
+++ b/src/utils/screengrabber.h
@@ -13,6 +13,7 @@
 
 class QEventLoop;
 class QWidget;
+class MonitorPreview;
 
 class ScreenGrabber : public QObject
 {
@@ -36,6 +37,12 @@ protected:
 private:
     void adjustDevicePixelRatio(QPixmap& pixmap);
     QWidget* createMonitorPreviews(const QPixmap& fullScreenshot);
+    void cancelMonitorSelection();
+    void moveHighlightedMonitorPreview(int offset);
+    int previewIndexForMonitor(int monitorIndex) const;
+    void selectHighlightedMonitorPreview();
+    void selectMonitor(int monitorIndex);
+    void setHighlightedMonitorPreview(int previewIndex);
     QPixmap cropToMonitor(const QPixmap& fullScreenshot, int monitorIndex);
     QPixmap windowsScreenshot(int wid);
     QPixmap x11LegacyScreenshot();
@@ -43,6 +50,8 @@ private:
     DesktopInfo m_info;
     QPixmap Screenshot;
     int m_selectedMonitor;
+    int m_highlightedMonitorPreview;
+    QList<MonitorPreview*> m_monitorPreviews;
     QEventLoop* m_monitorSelectionLoop;
     bool m_userCancelled;
     static bool m_monitorSelectionActive;


### PR DESCRIPTION
Addresses #4721.

I implemented keyboard support for the multi-monitor selection dialog:

- Added visible number badges for monitors 1-9.
- Added direct monitor selection with number keys 1-9.
- Added keyboard navigation with Tab and arrow keys.
- Added confirmation with Enter / Space.
- Kept Escape cancellation and mouse-click selection behavior.

I would appreciate extra testing and feedback on Linux and Windows, since the normal monitor selection dialog is not shown on macOS in the current code path. To test the behavior locally on macOS, I temporarily bypassed the macOS-specific early return so I could exercise the selector UI, but that workaround is not included in this PR. The submitted change keeps the existing macOS behavior intact and only updates the shared monitor selector logic used where the selector is normally active.