### PR TITLE
Fail fast when the screenshot portal cannot take the capture

### DIFF
--- a/src/utils/screengrabber.cpp
+++ b/src/utils/screengrabber.cpp
@@ -29,6 +29,7 @@
 #if !(defined(Q_OS_MACOS) || defined(Q_OS_WIN))
 #include "request.h"
 #include <QDBusInterface>
+#include <QDBusMessage>
 #include <QDBusReply>
 #include <QDir>
 #include <QUrl>
@@ -49,7 +50,9 @@ ScreenGrabber::ScreenGrabber(QObject* parent)
     QImageReader::setAllocationLimit(1024);
 }
 
-void ScreenGrabber::freeDesktopPortal(bool& ok, QPixmap& res)
+ScreenGrabber::PortalStatus ScreenGrabber::freeDesktopPortal(
+  QPixmap& res,
+  QString& errorDetail)
 {
 
 #if !(defined(Q_OS_MACOS) || defined(Q_OS_WIN))
@@ -57,10 +60,9 @@ void ScreenGrabber::freeDesktopPortal(bool& ok, QPixmap& res)
     auto service = QStringLiteral("org.freedesktop.portal.Desktop");
 
     if (!connectionInterface->isServiceRegistered(service)) {
-        ok = false;
-        AbstractLogger::error() << tr(
-          "Could not locate the `org.freedesktop.portal.Desktop` service");
-        return;
+        errorDetail =
+          tr("Could not locate the `org.freedesktop.portal.Desktop` service");
+        return PortalStatus::Unavailable;
     }
 
     QDBusInterface screenshotInterface(
@@ -131,11 +133,23 @@ void ScreenGrabber::freeDesktopPortal(bool& ok, QPixmap& res)
           QStringLiteral("x11:0x%1").arg(parentDummy.winId(), 0, 16);
     }
 
-    screenshotInterface.call(
+    QDBusMessage reply = screenshotInterface.call(
       QStringLiteral("Screenshot"),
       parentWindow,
       QMap<QString, QVariant>({ { "handle_token", QVariant(token) },
                                 { "interactive", QVariant(false) } }));
+
+    if (reply.type() == QDBusMessage::ErrorMessage) {
+        // No backend provides org.freedesktop.portal.Screenshot (or the
+        // portal rejected the request outright); the Response signal will
+        // never arrive, so fail now instead of waiting for the timeout.
+        QObject::disconnect(conn);
+        request->deleteLater();
+        errorDetail =
+          tr("The `org.freedesktop.portal.Screenshot` request failed: %1")
+            .arg(reply.errorMessage());
+        return PortalStatus::Unavailable;
+    }
 
     loop.exec();
     timeout.stop();
@@ -144,20 +158,17 @@ void ScreenGrabber::freeDesktopPortal(bool& ok, QPixmap& res)
     request->deleteLater();
 
     if (timedOut) {
-        ok = false;
-
-        AbstractLogger::error()
-          << tr("The xdg-desktop-portal backend did not respond "
-                "If you are on wayland make sure an xdg-desktop-portal backend "
-                "for your desktop is "
-                "installed and properly configured.\n \n"
-                "If on X11 enable Legacy X11 method in the General Settings");
-        return;
+        errorDetail =
+          tr("The xdg-desktop-portal backend did not respond "
+             "If you are on wayland make sure an xdg-desktop-portal backend "
+             "for your desktop is "
+             "installed and properly configured.\n \n"
+             "If on X11 enable Legacy X11 method in the General Settings");
+        return PortalStatus::Failed;
     }
 
     if (res.isNull()) {
-        ok = false;
-        return;
+        return PortalStatus::Failed;
     }
 
 #ifdef FLAMESHOT_DEBUG_CAPTURE
@@ -166,6 +177,43 @@ void ScreenGrabber::freeDesktopPortal(bool& ok, QPixmap& res)
                   .arg(res.height())
                   .arg(res.devicePixelRatio());
 #endif
+    return PortalStatus::Success;
+#else
+    Q_UNUSED(res)
+    Q_UNUSED(errorDetail)
+    return PortalStatus::Failed;
+#endif
+}
+
+QPixmap ScreenGrabber::unixScreenshot(bool& ok)
+{
+#if defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)
+    QPixmap screenshot;
+
+    if (!m_info.waylandDetected() && ConfigHandler().useX11LegacyScreenshot()) {
+        screenshot = x11LegacyScreenshot();
+        ok = !screenshot.isNull();
+        if (!ok) {
+            AbstractLogger::error() << tr("Unable to capture screen");
+        }
+        return screenshot;
+    }
+
+    QString portalError;
+    const PortalStatus status = freeDesktopPortal(screenshot, portalError);
+    ok = status == PortalStatus::Success;
+
+    if (!ok) {
+        if (!portalError.isEmpty()) {
+            AbstractLogger::error() << portalError;
+        }
+        AbstractLogger::error() << tr("Unable to capture screen");
+    }
+
+    return screenshot;
+#else
+    ok = false;
+    return QPixmap();
 #endif
 }
 
@@ -258,19 +306,9 @@ QPixmap ScreenGrabber::grabEntireDesktop(bool& ok, int preSelectedMonitor)
     return screenshot;
 
 #elif defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)
-    if (!m_info.waylandDetected() && ConfigHandler().useX11LegacyScreenshot()) {
-        screenshot = x11LegacyScreenshot();
-        ok = !screenshot.isNull();
-        if (!ok) {
-            AbstractLogger::error() << tr("Unable to capture screen");
-            return QPixmap();
-        }
-    } else {
-        freeDesktopPortal(ok, screenshot);
-        if (!ok) {
-            AbstractLogger::error() << tr("Unable to capture screen");
-            return QPixmap();
-        }
+    screenshot = unixScreenshot(ok);
+    if (!ok) {
+        return QPixmap();
     }
 #elif defined(Q_OS_WIN)
     screenshot = windowsScreenshot(wid);
@@ -317,18 +355,7 @@ QPixmap ScreenGrabber::grabFullDesktop(bool& ok)
     }
     painter.end();
 #elif defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)
-    if (!m_info.waylandDetected() && ConfigHandler().useX11LegacyScreenshot()) {
-        screenshot = x11LegacyScreenshot();
-        ok = !screenshot.isNull();
-        if (!ok) {
-            AbstractLogger::error() << tr("Unable to capture screen");
-        }
-    } else {
-        freeDesktopPortal(ok, screenshot);
-        if (!ok) {
-            AbstractLogger::error() << tr("Unable to capture screen");
-        }
-    }
+    screenshot = unixScreenshot(ok);
 #elif defined(Q_OS_WIN)
     screenshot = windowsScreenshot(0);
 #endif

--- a/src/utils/screengrabber.h
+++ b/src/utils/screengrabber.h
@@ -19,11 +19,17 @@ class ScreenGrabber : public QObject
     Q_OBJECT
 public:
     explicit ScreenGrabber(QObject* parent = nullptr);
+    enum class PortalStatus
+    {
+        Success,
+        Unavailable,
+        Failed
+    };
     QPixmap grabEntireDesktop(bool& ok, int preSelectedMonitor = -1);
     QPixmap grabFullDesktop(bool& ok);
     QRect screenGeometry(QScreen* screen);
     QPixmap grabScreen(QScreen* screenNumber, bool& ok);
-    void freeDesktopPortal(bool& ok, QPixmap& res);
+    PortalStatus freeDesktopPortal(QPixmap& res, QString& errorDetail);
     QRect desktopGeometry();
     QRect logicalDesktopGeometry();
     int getSelectedMonitor() const { return m_selectedMonitor; }
@@ -39,6 +45,7 @@ private:
     QPixmap cropToMonitor(const QPixmap& fullScreenshot, int monitorIndex);
     QPixmap windowsScreenshot(int wid);
     QPixmap x11LegacyScreenshot();
+    QPixmap unixScreenshot(bool& ok);
 
     DesktopInfo m_info;
     QPixmap Screenshot;


### PR DESCRIPTION
Improves the error reporting behind the timeouts in #4639.

Since v14, every capture on Linux goes through the org.freedesktop.portal.Screenshot portal. Flameshot never checks the reply of the Screenshot D-Bus call. On systems where no portal backend provides that interface (misconfigured portals on Wayland, or X11 window managers, since xdg-desktop-portal-gtk 1.14 dropped its screenshot backend), the call fails within milliseconds, but flameshot keeps waiting for a Response signal that can never arrive and then reports a misleading "Screenshot portal timed out" error.

This change checks the reply and fails immediately with the real D-Bus error instead of a fake timeout. It does not change which systems can take screenshots. It makes the failures diagnosable, which is what the reports in #4639 mostly lack. The causes there include missing portal backends and an upstream Hyprland grim hang that really does time out.

Tested on EndeavourOS with i3 (X11, xdg-desktop-portal-gtk only, so no Screenshot interface on the bus). Before the change, `flameshot full` hung for 15 seconds and then failed. With it, the command fails in under a second and prints the real error, "No such interface org.freedesktop.portal.Screenshot". The useX11LegacyScreenshot path still captures normally. Systems with a working portal are unaffected.

A few notes for review:

- The unixScreenshot() helper folds two identical call sites into one. I think it belongs here, because both call sites need the new error handling. If you want a minimal diff for a point release, I'm happy to split it.
- The portal spec says clients should listen on the request handle from the reply, since portals before 0.9 return a different path than the token predicts. I left that out on purpose. Portals that old predate 2017, and the re-subscription is racy anyway.
- The new error string is one more burden for translators. If you would rather reword it, no objection.
- I have a follow-up branch that falls back to the native X11 grab when the portal is unavailable. I plan to propose it separately, since it touches the Legacy X11 policy discussed in #4733 and should not hold this diagnostic fix hostage.

Claude Code (an AI tool) wrote this patch. I directed the work and read the diff, but I don't know this codebase well and my C++ is rusty, so my review was shallow. Review accordingly. I did test it on my machine, which hits this bug. Master hangs for 15 seconds and fails, and this branch reports the real error in under a second.
