### PR TITLE
Fall back to native X11 capture when the portal is unavailable

### DIFF
--- a/src/utils/screengrabber.cpp
+++ b/src/utils/screengrabber.cpp
@@ -204,6 +204,16 @@ QPixmap ScreenGrabber::unixScreenshot(bool& ok)
     const PortalStatus status = freeDesktopPortal(screenshot, portalError);
     ok = status == PortalStatus::Success;
 
+    if (status == PortalStatus::Unavailable && !m_info.waylandDetected()) {
+        // The portal cannot take screenshots here, which is common on X11
+        // window managers such as i3 or XMonad, so take the native X11
+        // grab instead.
+        AbstractLogger::info(AbstractLogger::Stderr | AbstractLogger::LogFile)
+          << tr("Screenshot portal unavailable, using direct X11 capture");
+        screenshot = x11LegacyScreenshot();
+        ok = !screenshot.isNull();
+    }
+
     if (!ok) {
         if (!portalError.isEmpty()) {
             AbstractLogger::error() << portalError;


### PR DESCRIPTION
This PR depends on #4826 and stacks on its branch. GitHub has no way to express that relationship for PRs from a fork, so until #4826 merges, the diff below includes both commits. Please review only the last one, "Fall back to native X11 capture when the portal is unavailable". I will rebase once #4826 is merged.

That PR reports portal failures properly. This branch handles the X11 desktops that have no portal at all.

On X11 window managers without a Screenshot portal backend (i3, XMonad, Xfce, openbox and friends), v14 cannot take a screenshot until the user discovers the Legacy X11 option. v13 handled these systems out of the box. With this change, when the portal reports that it cannot take the capture at all, flameshot takes the native X11 grab instead and logs an info line (terminal and log file only) saying so. Cancelled portal dialogs and genuine timeouts do not trigger the fallback, and systems with a working portal never reach it.

I know this touches a deliberate decision. In #4733, borgmanJeremy described the Legacy X11 option as a temporary concession for desktops without a functioning portal, to be removed once portal coverage is good enough. I would argue this change fits that plan rather than fighting it. The fallback engages only on the systems that concession exists for, and it retires itself as portal coverage improves. The log line also shows up in bug reports, so you can see how many portal-less systems are still out there. The alternative is that v13 users on those desktops upgrade into a broken default and a config scavenger hunt, which is how several reports in #4639 read.

Two caveats. The legacy grab has at least one open rendering bug (the shifted output described near the end of #4639, on AwesomeWM with window gaps), so the fallback routes users onto an imperfect path. And if you would rather keep the fallback behind explicit opt-in, this patch reduces easily to a better error message pointing at the option.

Tested on EndeavourOS with i3, where the portal has no Screenshot interface. `flameshot full`, `flameshot screen`, and `flameshot gui` all capture in under a second through the fallback, and the log line appears once per capture.

Claude Code (an AI tool) wrote this patch. I directed the work and read the diff, but I don't know this codebase well and my C++ is rusty, so my review was shallow. Review accordingly.
