### PR TITLE
Feature: Add configurable capture shortcut and cursor capture option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,7 +140,7 @@ include(cmake/StaticAnalyzers.cmake)
 # ToDo: Check if this is used anywhere
 option(BUILD_STATIC_LIBS ON)
 
-if(WIN32 OR APPLE)
+if(WIN32 OR APPLE OR CMAKE_SYSTEM_NAME STREQUAL "Linux")
   FetchContent_Declare(
     qHotKey
     GIT_REPOSITORY https://github.com/flameshot-org/QHotkey

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,9 +20,16 @@ set(QT_DEFAULT_MAJOR_VERSION 6 CACHE STRING "")
 set(QT_VERSION_MAJOR 6 CACHE STRING "")
 #BUILD_SHARED_LIBS used by QHotkey and QtColorWidgets
 option(BUILD_SHARED_LIBS OFF)
-#QHOTKEY_INSTALL used by QHotkey; must be disabled on Windows
-if(WIN32)
-set(QHOTKEY_INSTALL OFF CACHE BOOL "qHotkey install")
+# QHotkey is embedded into Flameshot. Do not install it or build examples as
+# separate package artifacts on any platform.
+set(QHOTKEY_INSTALL OFF CACHE BOOL "Disable QHotkey install rules" FORCE)
+set(QHOTKEY_EXAMPLES OFF CACHE BOOL "Disable QHotkey examples" FORCE)
+
+# Older QHotkey revisions declare compatibility with CMake versions below 3.5.
+# CMake 4 requires the parent project to provide the policy floor explicitly.
+if(CMAKE_VERSION VERSION_GREATER_EQUAL "4.0")
+  set(CMAKE_POLICY_VERSION_MINIMUM 3.5 CACHE STRING
+      "Minimum policy version for bundled dependencies" FORCE)
 endif()
 
 #Needed due to linker error with QtColorWidget
@@ -141,12 +148,32 @@ include(cmake/StaticAnalyzers.cmake)
 option(BUILD_STATIC_LIBS ON)
 
 if(WIN32 OR APPLE OR CMAKE_SYSTEM_NAME STREQUAL "Linux")
-  FetchContent_Declare(
-    qHotKey
-    GIT_REPOSITORY https://github.com/flameshot-org/QHotkey
-    GIT_TAG master
-  )
-  FetchContent_MakeAvailable(QHotKey)
+  # Distribution builders commonly disable network access during CMake
+  # configuration. They can provide QHotkey as a pre-fetched source tree.
+  set(FLAMESHOT_QHOTKEY_SOURCE_DIR "" CACHE PATH
+      "Path to a pre-fetched QHotkey source tree")
+
+  if(FLAMESHOT_QHOTKEY_SOURCE_DIR)
+    if(NOT EXISTS "${FLAMESHOT_QHOTKEY_SOURCE_DIR}/CMakeLists.txt")
+      message(FATAL_ERROR
+              "FLAMESHOT_QHOTKEY_SOURCE_DIR does not contain CMakeLists.txt: "
+              "${FLAMESHOT_QHOTKEY_SOURCE_DIR}")
+    endif()
+    add_subdirectory("${FLAMESHOT_QHOTKEY_SOURCE_DIR}"
+                     "${CMAKE_BINARY_DIR}/_deps/qhotkey-build"
+                     EXCLUDE_FROM_ALL)
+  elseif(EXISTS "${CMAKE_SOURCE_DIR}/external/QHotkey/CMakeLists.txt")
+    add_subdirectory("${CMAKE_SOURCE_DIR}/external/QHotkey"
+                     "${CMAKE_BINARY_DIR}/_deps/qhotkey-build"
+                     EXCLUDE_FROM_ALL)
+  else()
+    FetchContent_Declare(
+      qHotKey
+      GIT_REPOSITORY https://github.com/flameshot-org/QHotkey
+      GIT_TAG master
+    )
+    FetchContent_MakeAvailable(QHotKey)
+  endif()
 endif()
 
 add_subdirectory(src)

--- a/README.md
+++ b/README.md
@@ -248,9 +248,9 @@ These shortcuts are available in GUI mode:
 
 ### Global
 
-- Windows: <kbd>Prt Sc</kbd> (fixed, cannot be changed) and <kbd>Win</kbd> + <kbd>Shift</kbd> + <kbd>X</kbd> (can be changed in the settings)
-- macOS: <kbd>cmd</kbd> + <kbd>Shift</kbd> + <kbd>X</kbd> (can be changed in the settings)
-- Linux: Flameshot doesn't yet support <kbd>Prt Sc</kbd> out of the box, but you can set this up with a bit of configuration:
+- Windows: <kbd>Prt Sc</kbd> by default (changes apply immediately)
+- macOS: <kbd>cmd</kbd> + <kbd>Shift</kbd> + <kbd>X</kbd> by default (changes apply immediately)
+- Linux X11/XWayland: <kbd>Prt Sc</kbd> by default (changes apply immediately). On native Wayland, configure the desktop environment to run `flameshot gui` because the compositor owns global shortcuts:
 
 #### On KDE Plasma desktop
 

--- a/data/translations/Internationalization_bg.ts
+++ b/data/translations/Internationalization_bg.ts
@@ -959,6 +959,16 @@ Please solve them manually in the configuration file.</source>
         <translation>Показване на известия</translation>
     </message>
     <message>
+        <location filename="../../src/config/generalconf.cpp" line="341"/>
+        <source>Show mouse cursor in screenshots</source>
+        <translation>Показване на показалеца на мишката в екранните снимки</translation>
+    </message>
+    <message>
+        <location filename="../../src/config/generalconf.cpp" line="343"/>
+        <source>Include the current Windows mouse cursor in captured images</source>
+        <translation>Включване на текущия показалец на мишката на Windows в заснетите изображения</translation>
+    </message>
+    <message>
         <location filename="../../src/config/generalconf.cpp" line="339"/>
         <source>Show tray icon</source>
         <translation>Показване в лентата за известия</translation>
@@ -2558,6 +2568,11 @@ You may need to escape the &apos;#&apos; sign as in &apos;\#FFF&apos;</source>
         <translation>Клавишни комбинации</translation>
     </message>
     <message>
+        <location filename="../../src/config/shortcutswidget.cpp" line="51"/>
+        <source>On native Wayland, global shortcuts are controlled by the desktop environment. Configure the same key there to run 'flameshot gui'. Changes here apply immediately on X11/XWayland.</source>
+        <translation>При нативен Wayland глобалните клавишни комбинации се управляват от средата на работния плот. Настройте същия клавиш там да стартира 'flameshot gui'. Промените тук се прилагат веднага при X11/XWayland.</translation>
+    </message>
+    <message>
         <location filename="../../src/config/shortcutswidget.cpp" line="61"/>
         <source>Available shortcuts in the screen capture mode.</source>
         <translation>Налични клавишни комбинации в режим заснемане на екрана.</translation>
@@ -2710,8 +2725,9 @@ You may need to escape the &apos;#&apos; sign as in &apos;\#FFF&apos;</source>
         <translation type="vanished">Премахване на текущия инструмент</translation>
     </message>
     <message>
-        <location filename="../../src/config/shortcutswidget.cpp" line="213"/>
-        <location filename="../../src/config/shortcutswidget.cpp" line="222"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="233"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="238"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="244"/>
         <source>Capture screen</source>
         <translation>Заснемане на екрана</translation>
     </message>

--- a/data/translations/Internationalization_ca.ts
+++ b/data/translations/Internationalization_ca.ts
@@ -963,6 +963,16 @@ Solucioneu-les manualment al fitxer de configuració.</translation>
         <translation>Mostra les notificacions d&apos;escriptori</translation>
     </message>
     <message>
+        <location filename="../../src/config/generalconf.cpp" line="341"/>
+        <source>Show mouse cursor in screenshots</source>
+        <translation>Mostra el cursor del ratolí a les captures de pantalla</translation>
+    </message>
+    <message>
+        <location filename="../../src/config/generalconf.cpp" line="343"/>
+        <source>Include the current Windows mouse cursor in captured images</source>
+        <translation>Inclou el cursor actual del ratolí de Windows a les imatges capturades</translation>
+    </message>
+    <message>
         <location filename="../../src/config/generalconf.cpp" line="339"/>
         <source>Show tray icon</source>
         <translation>Mostra la icona de la safata</translation>
@@ -2565,6 +2575,11 @@ You may need to escape the &apos;#&apos; sign as in &apos;\#FFF&apos;</source>
         <translation>Tecles d&apos;Accés Ràpid</translation>
     </message>
     <message>
+        <location filename="../../src/config/shortcutswidget.cpp" line="51"/>
+        <source>On native Wayland, global shortcuts are controlled by the desktop environment. Configure the same key there to run 'flameshot gui'. Changes here apply immediately on X11/XWayland.</source>
+        <translation>A Wayland natiu, les dreceres globals les controla l'entorn d'escriptori. Configureu-hi la mateixa tecla per executar 'flameshot gui'. Els canvis fets aquí s'apliquen immediatament a X11/XWayland.</translation>
+    </message>
+    <message>
         <location filename="../../src/config/shortcutswidget.cpp" line="61"/>
         <source>Available shortcuts in the screen capture mode.</source>
         <translation>Dreceres disponibles en el mode de captura de pantalla.</translation>
@@ -2717,8 +2732,9 @@ You may need to escape the &apos;#&apos; sign as in &apos;\#FFF&apos;</source>
         <translation type="obsolete">Delete current tool</translation>
     </message>
     <message>
-        <location filename="../../src/config/shortcutswidget.cpp" line="213"/>
-        <location filename="../../src/config/shortcutswidget.cpp" line="222"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="233"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="238"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="244"/>
         <source>Capture screen</source>
         <translation>Captura la pantalla</translation>
     </message>

--- a/data/translations/Internationalization_cs.ts
+++ b/data/translations/Internationalization_cs.ts
@@ -1022,6 +1022,16 @@ Vyřešte je, prosím, ručně v souboru s nastavením.</translation>
         <translation>Ukázat oznámení na ploše</translation>
     </message>
     <message>
+        <location filename="../../src/config/generalconf.cpp" line="341"/>
+        <source>Show mouse cursor in screenshots</source>
+        <translation>Zobrazit kurzor myši na snímcích obrazovky</translation>
+    </message>
+    <message>
+        <location filename="../../src/config/generalconf.cpp" line="343"/>
+        <source>Include the current Windows mouse cursor in captured images</source>
+        <translation>Zahrnout aktuální kurzor myši systému Windows do zachycených obrázků</translation>
+    </message>
+    <message>
         <location filename="../../src/config/generalconf.cpp" line="339"/>
         <source>Show tray icon</source>
         <translation>Ukázat ikonu v oznamovací oblasti panelu</translation>
@@ -2616,6 +2626,11 @@ Možná budete muset napsat před &apos;#&apos; opačné (obrácené) lomítko, 
         <translation>Klávesové zkratky</translation>
     </message>
     <message>
+        <location filename="../../src/config/shortcutswidget.cpp" line="51"/>
+        <source>On native Wayland, global shortcuts are controlled by the desktop environment. Configure the same key there to run 'flameshot gui'. Changes here apply immediately on X11/XWayland.</source>
+        <translation>V nativním Waylandu spravuje globální klávesové zkratky desktopové prostředí. Nastavte v něm stejnou klávesu pro spuštění „flameshot gui“. Změny zde se projeví okamžitě v X11/XWaylandu.</translation>
+    </message>
+    <message>
         <location filename="../../src/config/shortcutswidget.cpp" line="61"/>
         <source>Available shortcuts in the screen capture mode.</source>
         <translation>Dostupné zkratky v režimu zachytávání obrazovky.</translation>
@@ -2768,10 +2783,11 @@ Možná budete muset napsat před &apos;#&apos; opačné (obrácené) lomítko, 
         <translation type="obsolete">Delete current tool</translation>
     </message>
     <message>
-        <location filename="../../src/config/shortcutswidget.cpp" line="213"/>
-        <location filename="../../src/config/shortcutswidget.cpp" line="222"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="233"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="238"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="244"/>
         <source>Capture screen</source>
-        <translation type="unfinished">Zachytit obrazovku</translation>
+        <translation>Zachytit obrazovku</translation>
     </message>
     <message>
         <location filename="../../src/config/shortcutswidget.cpp" line="215"/>

--- a/data/translations/Internationalization_da.ts
+++ b/data/translations/Internationalization_da.ts
@@ -959,6 +959,16 @@ Please solve them manually in the configuration file.</translation>
         <translation>Show desktop notifications</translation>
     </message>
     <message>
+        <location filename="../../src/config/generalconf.cpp" line="341"/>
+        <source>Show mouse cursor in screenshots</source>
+        <translation>Vis musemarkøren på skærmbilleder</translation>
+    </message>
+    <message>
+        <location filename="../../src/config/generalconf.cpp" line="343"/>
+        <source>Include the current Windows mouse cursor in captured images</source>
+        <translation>Medtag den aktuelle Windows-musemarkør i de optagne billeder</translation>
+    </message>
+    <message>
         <location filename="../../src/config/generalconf.cpp" line="339"/>
         <source>Show tray icon</source>
         <translation>Show tray icon</translation>
@@ -2517,6 +2527,11 @@ You may need to escape the &apos;#&apos; sign as in &apos;\#FFF&apos;</translati
         <translation>Hot Keys</translation>
     </message>
     <message>
+        <location filename="../../src/config/shortcutswidget.cpp" line="51"/>
+        <source>On native Wayland, global shortcuts are controlled by the desktop environment. Configure the same key there to run 'flameshot gui'. Changes here apply immediately on X11/XWayland.</source>
+        <translation>På indbygget Wayland styres globale genveje af skrivebordsmiljøet. Konfigurer den samme tast dér til at køre 'flameshot gui'. Ændringer her træder straks i kraft på X11/XWayland.</translation>
+    </message>
+    <message>
         <location filename="../../src/config/shortcutswidget.cpp" line="61"/>
         <source>Available shortcuts in the screen capture mode.</source>
         <translation>Available shortcuts in the screen capture mode.</translation>
@@ -2627,10 +2642,11 @@ You may need to escape the &apos;#&apos; sign as in &apos;\#FFF&apos;</translati
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/config/shortcutswidget.cpp" line="213"/>
-        <location filename="../../src/config/shortcutswidget.cpp" line="222"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="233"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="238"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="244"/>
         <source>Capture screen</source>
-        <translation type="unfinished">Capture screen</translation>
+        <translation>Tag skærmbillede</translation>
     </message>
     <message>
         <location filename="../../src/config/shortcutswidget.cpp" line="215"/>

--- a/data/translations/Internationalization_de_DE.ts
+++ b/data/translations/Internationalization_de_DE.ts
@@ -975,6 +975,16 @@ Bitte beseitige sie manuell in der Konfigurationsdatei.</translation>
         <translation>Desktopbenachrichtigungen anzeigen</translation>
     </message>
     <message>
+        <location filename="../../src/config/generalconf.cpp" line="341"/>
+        <source>Show mouse cursor in screenshots</source>
+        <translation>Mauszeiger in Bildschirmaufnahmen anzeigen</translation>
+    </message>
+    <message>
+        <location filename="../../src/config/generalconf.cpp" line="343"/>
+        <source>Include the current Windows mouse cursor in captured images</source>
+        <translation>Den aktuellen Windows-Mauszeiger in aufgenommene Bilder einfügen</translation>
+    </message>
+    <message>
         <location filename="../../src/config/generalconf.cpp" line="339"/>
         <source>Show tray icon</source>
         <translation>Taskleistensymbol zeigen</translation>
@@ -2590,6 +2600,11 @@ Eventuell muss das &apos;#&apos; Zeichen als &apos;\#FFF&apos; maskiert werden</
         <translation>Tastenkürzel</translation>
     </message>
     <message>
+        <location filename="../../src/config/shortcutswidget.cpp" line="51"/>
+        <source>On native Wayland, global shortcuts are controlled by the desktop environment. Configure the same key there to run 'flameshot gui'. Changes here apply immediately on X11/XWayland.</source>
+        <translation>Unter nativem Wayland werden globale Tastenkürzel von der Desktop-Umgebung verwaltet. Konfigurieren Sie dort dieselbe Taste zum Ausführen von „flameshot gui“. Änderungen hier werden unter X11/XWayland sofort wirksam.</translation>
+    </message>
+    <message>
         <location filename="../../src/config/shortcutswidget.cpp" line="61"/>
         <source>Available shortcuts in the screen capture mode.</source>
         <translation>Verfügbare Tastenkürzel im Aufnahmemodus.</translation>
@@ -2742,8 +2757,9 @@ Eventuell muss das &apos;#&apos; Zeichen als &apos;\#FFF&apos; maskiert werden</
         <translation type="vanished">Aktuelles Werkzeug löschen</translation>
     </message>
     <message>
-        <location filename="../../src/config/shortcutswidget.cpp" line="213"/>
-        <location filename="../../src/config/shortcutswidget.cpp" line="222"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="233"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="238"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="244"/>
         <source>Capture screen</source>
         <translation>Bildschirm aufnehmen</translation>
     </message>

--- a/data/translations/Internationalization_el.ts
+++ b/data/translations/Internationalization_el.ts
@@ -967,6 +967,16 @@ Please solve them manually in the configuration file.</source>
         <translation>Εμφάνιση ειδοποιήσεων στην επιφάνειας εργασίας</translation>
     </message>
     <message>
+        <location filename="../../src/config/generalconf.cpp" line="341"/>
+        <source>Show mouse cursor in screenshots</source>
+        <translation>Εμφάνιση του δείκτη του ποντικιού στα στιγμιότυπα οθόνης</translation>
+    </message>
+    <message>
+        <location filename="../../src/config/generalconf.cpp" line="343"/>
+        <source>Include the current Windows mouse cursor in captured images</source>
+        <translation>Συμπερίληψη του τρέχοντος δείκτη ποντικιού των Windows στις εικόνες που καταγράφονται</translation>
+    </message>
+    <message>
         <location filename="../../src/config/generalconf.cpp" line="339"/>
         <source>Show tray icon</source>
         <translation>Εμφάνιση εικονιδίου tray</translation>
@@ -2549,6 +2559,11 @@ You may need to escape the &apos;#&apos; sign as in &apos;\#FFF&apos;</source>
         <translation>Hot Keys</translation>
     </message>
     <message>
+        <location filename="../../src/config/shortcutswidget.cpp" line="51"/>
+        <source>On native Wayland, global shortcuts are controlled by the desktop environment. Configure the same key there to run 'flameshot gui'. Changes here apply immediately on X11/XWayland.</source>
+        <translation>Στο εγγενές Wayland, οι καθολικές συντομεύσεις ελέγχονται από το περιβάλλον επιφάνειας εργασίας. Ρυθμίστε εκεί το ίδιο πλήκτρο ώστε να εκτελεί το «flameshot gui». Οι αλλαγές εδώ εφαρμόζονται αμέσως σε X11/XWayland.</translation>
+    </message>
+    <message>
         <location filename="../../src/config/shortcutswidget.cpp" line="61"/>
         <source>Available shortcuts in the screen capture mode.</source>
         <translation>Διαθέσιμες συντομεύσεις στη λειτουργία λήψης οθόνης.</translation>
@@ -2701,8 +2716,9 @@ You may need to escape the &apos;#&apos; sign as in &apos;\#FFF&apos;</source>
         <translation type="vanished">Διαγραφή τρέχοντος εργαλείου</translation>
     </message>
     <message>
-        <location filename="../../src/config/shortcutswidget.cpp" line="213"/>
-        <location filename="../../src/config/shortcutswidget.cpp" line="222"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="233"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="238"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="244"/>
         <source>Capture screen</source>
         <translation>Καταγραφή οθόνης</translation>
     </message>

--- a/data/translations/Internationalization_en.ts
+++ b/data/translations/Internationalization_en.ts
@@ -784,6 +784,16 @@ Please solve them manually in the configuration file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../src/config/generalconf.cpp" line="341"/>
+        <source>Show mouse cursor in screenshots</source>
+        <translation>Show mouse cursor in screenshots</translation>
+    </message>
+    <message>
+        <location filename="../../src/config/generalconf.cpp" line="343"/>
+        <source>Include the current Windows mouse cursor in captured images</source>
+        <translation>Include the current Windows mouse cursor in captured images</translation>
+    </message>
+    <message>
         <location filename="../../src/config/generalconf.cpp" line="315"/>
         <source>Enable desktop notifications</source>
         <translation type="unfinished"></translation>
@@ -1977,6 +1987,11 @@ You may need to escape the &apos;#&apos; sign as in &apos;\#FFF&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../src/config/shortcutswidget.cpp" line="51"/>
+        <source>On native Wayland, global shortcuts are controlled by the desktop environment. Configure the same key there to run 'flameshot gui'. Changes here apply immediately on X11/XWayland.</source>
+        <translation>On native Wayland, global shortcuts are controlled by the desktop environment. Configure the same key there to run 'flameshot gui'. Changes here apply immediately on X11/XWayland.</translation>
+    </message>
+    <message>
         <location filename="../../src/config/shortcutswidget.cpp" line="61"/>
         <source>Available shortcuts in the screen capture mode.</source>
         <translation type="unfinished"></translation>
@@ -2087,10 +2102,11 @@ You may need to escape the &apos;#&apos; sign as in &apos;\#FFF&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/config/shortcutswidget.cpp" line="213"/>
-        <location filename="../../src/config/shortcutswidget.cpp" line="222"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="233"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="238"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="244"/>
         <source>Capture screen</source>
-        <translation type="unfinished"></translation>
+        <translation>Capture screen</translation>
     </message>
     <message>
         <location filename="../../src/config/shortcutswidget.cpp" line="215"/>

--- a/data/translations/Internationalization_es.ts
+++ b/data/translations/Internationalization_es.ts
@@ -978,6 +978,16 @@ Por favor, resuélvelos manualmente en el archivo de configuración.</translatio
         <translation>Mostrar notificaciones del escritorio</translation>
     </message>
     <message>
+        <location filename="../../src/config/generalconf.cpp" line="341"/>
+        <source>Show mouse cursor in screenshots</source>
+        <translation>Mostrar el cursor del ratón en las capturas de pantalla</translation>
+    </message>
+    <message>
+        <location filename="../../src/config/generalconf.cpp" line="343"/>
+        <source>Include the current Windows mouse cursor in captured images</source>
+        <translation>Incluir el cursor actual del ratón de Windows en las imágenes capturadas</translation>
+    </message>
+    <message>
         <location filename="../../src/config/generalconf.cpp" line="339"/>
         <source>Show tray icon</source>
         <translation>Mostrar icono en la bandeja</translation>
@@ -2572,6 +2582,11 @@ Puede ser que necesites preceder el símbolo &quot;#&quot; con &quot;\&quot;, co
         <translation>Teclas de Acceso Rápido</translation>
     </message>
     <message>
+        <location filename="../../src/config/shortcutswidget.cpp" line="51"/>
+        <source>On native Wayland, global shortcuts are controlled by the desktop environment. Configure the same key there to run 'flameshot gui'. Changes here apply immediately on X11/XWayland.</source>
+        <translation>En Wayland nativo, los atajos globales los controla el entorno de escritorio. Configure allí la misma tecla para ejecutar «flameshot gui». Los cambios realizados aquí se aplican inmediatamente en X11/XWayland.</translation>
+    </message>
+    <message>
         <location filename="../../src/config/shortcutswidget.cpp" line="61"/>
         <source>Available shortcuts in the screen capture mode.</source>
         <translation>Atajos disponibles en el modo captura de pantalla.</translation>
@@ -2724,8 +2739,9 @@ Puede ser que necesites preceder el símbolo &quot;#&quot; con &quot;\&quot;, co
         <translation type="vanished">Eliminar herramienta actual</translation>
     </message>
     <message>
-        <location filename="../../src/config/shortcutswidget.cpp" line="213"/>
-        <location filename="../../src/config/shortcutswidget.cpp" line="222"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="233"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="238"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="244"/>
         <source>Capture screen</source>
         <translation>Capturar pantalla</translation>
     </message>

--- a/data/translations/Internationalization_et.ts
+++ b/data/translations/Internationalization_et.ts
@@ -963,6 +963,16 @@ Palun lahenda vead käsitsi seadistusfailis.</translation>
         <translation>Näita töölaua teavitusi</translation>
     </message>
     <message>
+        <location filename="../../src/config/generalconf.cpp" line="341"/>
+        <source>Show mouse cursor in screenshots</source>
+        <translation>Näita ekraanipiltidel hiirekursorit</translation>
+    </message>
+    <message>
+        <location filename="../../src/config/generalconf.cpp" line="343"/>
+        <source>Include the current Windows mouse cursor in captured images</source>
+        <translation>Kaasa jäädvustatud piltidele Windowsi praegune hiirekursor</translation>
+    </message>
+    <message>
         <location filename="../../src/config/generalconf.cpp" line="339"/>
         <source>Show tray icon</source>
         <translation>Näita süsteemisalve ikooni</translation>
@@ -2528,6 +2538,11 @@ You may need to escape the &apos;#&apos; sign as in &apos;\#FFF&apos;</source>
         <translation>Kiirklahvid</translation>
     </message>
     <message>
+        <location filename="../../src/config/shortcutswidget.cpp" line="51"/>
+        <source>On native Wayland, global shortcuts are controlled by the desktop environment. Configure the same key there to run 'flameshot gui'. Changes here apply immediately on X11/XWayland.</source>
+        <translation>Waylandi omarežiimis haldab globaalseid kiirklahve töölauakeskkond. Seadista seal sama klahv käsu „flameshot gui” käivitamiseks. Siinsed muudatused rakenduvad X11/XWaylandi puhul kohe.</translation>
+    </message>
+    <message>
         <location filename="../../src/config/shortcutswidget.cpp" line="61"/>
         <source>Available shortcuts in the screen capture mode.</source>
         <translation>Ekraanitõmmise vaates kasutatavad kiirklahvid.</translation>
@@ -2680,8 +2695,9 @@ You may need to escape the &apos;#&apos; sign as in &apos;\#FFF&apos;</source>
         <translation type="obsolete">Delete current tool</translation>
     </message>
     <message>
-        <location filename="../../src/config/shortcutswidget.cpp" line="213"/>
-        <location filename="../../src/config/shortcutswidget.cpp" line="222"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="233"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="238"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="244"/>
         <source>Capture screen</source>
         <translation>Tee ekraanitõmmis</translation>
     </message>

--- a/data/translations/Internationalization_eu.ts
+++ b/data/translations/Internationalization_eu.ts
@@ -1014,6 +1014,16 @@ Mesedez, konpon itzazu eskuz konfigurazio fitxategian.</translation>
         <translation>Bistaratu mahaigaineko jakinarazpenak</translation>
     </message>
     <message>
+        <location filename="../../src/config/generalconf.cpp" line="341"/>
+        <source>Show mouse cursor in screenshots</source>
+        <translation>Erakutsi saguaren kurtsorea pantaila-argazkietan</translation>
+    </message>
+    <message>
+        <location filename="../../src/config/generalconf.cpp" line="343"/>
+        <source>Include the current Windows mouse cursor in captured images</source>
+        <translation>Sartu uneko Windows saguaren kurtsorea hartutako irudietan</translation>
+    </message>
+    <message>
         <location filename="../../src/config/generalconf.cpp" line="339"/>
         <source>Show tray icon</source>
         <translation>Bistaratu ikonoa erretiluan</translation>
@@ -2628,6 +2638,11 @@ Baliteke &apos;#&apos; karakterea ihes egin behar izatea, &apos;\#FFF&apos;n bez
         <translation>Laster-teklak</translation>
     </message>
     <message>
+        <location filename="../../src/config/shortcutswidget.cpp" line="51"/>
+        <source>On native Wayland, global shortcuts are controlled by the desktop environment. Configure the same key there to run 'flameshot gui'. Changes here apply immediately on X11/XWayland.</source>
+        <translation>Wayland natiboan, mahaigaineko inguruneak kontrolatzen ditu lasterbide globalak. Konfiguratu tekla bera han 'flameshot gui' exekutatzeko. Hemengo aldaketak berehala aplikatzen dira X11/XWayland-en.</translation>
+    </message>
+    <message>
         <location filename="../../src/config/shortcutswidget.cpp" line="61"/>
         <source>Available shortcuts in the screen capture mode.</source>
         <translation>Argazki-hartze moduan erabili daitezken laster-teklak.</translation>
@@ -2780,8 +2795,9 @@ Baliteke &apos;#&apos; karakterea ihes egin behar izatea, &apos;\#FFF&apos;n bez
         <translation type="vanished">Ezabatu uneko tresna</translation>
     </message>
     <message>
-        <location filename="../../src/config/shortcutswidget.cpp" line="213"/>
-        <location filename="../../src/config/shortcutswidget.cpp" line="222"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="233"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="238"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="244"/>
         <source>Capture screen</source>
         <translation>Egin pantailaren argazkia</translation>
     </message>

--- a/data/translations/Internationalization_fa.ts
+++ b/data/translations/Internationalization_fa.ts
@@ -961,6 +961,16 @@ Please solve them manually in the configuration file.</source>
         <translation>نمایش آگاهی‌های میزکار</translation>
     </message>
     <message>
+        <location filename="../../src/config/generalconf.cpp" line="341"/>
+        <source>Show mouse cursor in screenshots</source>
+        <translation>نمایش نشانگر ماوس در نماگرفت‌ها</translation>
+    </message>
+    <message>
+        <location filename="../../src/config/generalconf.cpp" line="343"/>
+        <source>Include the current Windows mouse cursor in captured images</source>
+        <translation>افزودن نشانگر فعلی ماوس ویندوز به تصاویر گرفته‌شده</translation>
+    </message>
+    <message>
         <location filename="../../src/config/generalconf.cpp" line="339"/>
         <source>Show tray icon</source>
         <translation>نمایش آیکون در سینی</translation>
@@ -2559,6 +2569,11 @@ You may need to escape the &apos;#&apos; sign as in &apos;\#FFF&apos;</source>
         <translation>کلیدهای داغ</translation>
     </message>
     <message>
+        <location filename="../../src/config/shortcutswidget.cpp" line="51"/>
+        <source>On native Wayland, global shortcuts are controlled by the desktop environment. Configure the same key there to run 'flameshot gui'. Changes here apply immediately on X11/XWayland.</source>
+        <translation>در Wayland بومی، میان‌برهای سراسری توسط محیط میزکار کنترل می‌شوند. همان کلید را در آنجا برای اجرای «flameshot gui» تنظیم کنید. تغییرات اینجا در X11/XWayland بلافاصله اعمال می‌شوند.</translation>
+    </message>
+    <message>
         <location filename="../../src/config/shortcutswidget.cpp" line="61"/>
         <source>Available shortcuts in the screen capture mode.</source>
         <translation>میان‌برهایی که در حالت نماگرفت از صفحه در دسترس هستند.</translation>
@@ -2711,10 +2726,11 @@ You may need to escape the &apos;#&apos; sign as in &apos;\#FFF&apos;</source>
         <translation type="vanished">حذف ابزار فعلی</translation>
     </message>
     <message>
-        <location filename="../../src/config/shortcutswidget.cpp" line="213"/>
-        <location filename="../../src/config/shortcutswidget.cpp" line="222"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="233"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="238"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="244"/>
         <source>Capture screen</source>
-        <translation>نماگرفت از صفحه</translation>
+        <translation>گرفتن نماگرفت از صفحه</translation>
     </message>
     <message>
         <location filename="../../src/config/shortcutswidget.cpp" line="215"/>

--- a/data/translations/Internationalization_fi.ts
+++ b/data/translations/Internationalization_fi.ts
@@ -967,6 +967,16 @@ Ratkaise ne käsin muuttamalla asetustiedostoa.</translation>
         <translation>Näytä ilmoitukset</translation>
     </message>
     <message>
+        <location filename="../../src/config/generalconf.cpp" line="341"/>
+        <source>Show mouse cursor in screenshots</source>
+        <translation>Näytä hiiren osoitin kuvakaappauksissa</translation>
+    </message>
+    <message>
+        <location filename="../../src/config/generalconf.cpp" line="343"/>
+        <source>Include the current Windows mouse cursor in captured images</source>
+        <translation>Sisällytä Windowsin nykyinen hiiren osoitin kaapattuihin kuviin</translation>
+    </message>
+    <message>
         <location filename="../../src/config/generalconf.cpp" line="339"/>
         <source>Show tray icon</source>
         <translation>Näytä kuvake paneelissa</translation>
@@ -2541,6 +2551,11 @@ Sinun on ehkä vältettävä &quot;#&quot; merkkiä kuten &quot;\#FFF&quot;</tra
         <translation>Pikanäppäimet</translation>
     </message>
     <message>
+        <location filename="../../src/config/shortcutswidget.cpp" line="51"/>
+        <source>On native Wayland, global shortcuts are controlled by the desktop environment. Configure the same key there to run 'flameshot gui'. Changes here apply immediately on X11/XWayland.</source>
+        <translation>Natiivissa Waylandissa työpöytäympäristö hallitsee yleisiä pikanäppäimiä. Määritä siellä sama näppäin suorittamaan komento ”flameshot gui”. Tässä tehdyt muutokset tulevat heti voimaan X11/XWaylandissa.</translation>
+    </message>
+    <message>
         <location filename="../../src/config/shortcutswidget.cpp" line="61"/>
         <source>Available shortcuts in the screen capture mode.</source>
         <translation>Saatavilla olevat pikanäppäimet kaappaustilassa.</translation>
@@ -2693,8 +2708,9 @@ Sinun on ehkä vältettävä &quot;#&quot; merkkiä kuten &quot;\#FFF&quot;</tra
         <translation type="vanished">Poista nykyinen työkalu</translation>
     </message>
     <message>
-        <location filename="../../src/config/shortcutswidget.cpp" line="213"/>
-        <location filename="../../src/config/shortcutswidget.cpp" line="222"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="233"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="238"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="244"/>
         <source>Capture screen</source>
         <translation>Kaappaa näyttö</translation>
     </message>

--- a/data/translations/Internationalization_fr.ts
+++ b/data/translations/Internationalization_fr.ts
@@ -982,6 +982,16 @@ Veuillez résoudre ce problème manuellement depuis le fichier de configuration.
         <translation>Afficher les notifications du bureau</translation>
     </message>
     <message>
+        <location filename="../../src/config/generalconf.cpp" line="341"/>
+        <source>Show mouse cursor in screenshots</source>
+        <translation>Afficher le pointeur de la souris dans les captures d’écran</translation>
+    </message>
+    <message>
+        <location filename="../../src/config/generalconf.cpp" line="343"/>
+        <source>Include the current Windows mouse cursor in captured images</source>
+        <translation>Inclure le pointeur de souris Windows actuel dans les images capturées</translation>
+    </message>
+    <message>
         <location filename="../../src/config/generalconf.cpp" line="339"/>
         <source>Show tray icon</source>
         <translation>Afficher les icônes de la barre d&apos;état</translation>
@@ -2577,6 +2587,11 @@ Vous devrez probablement remplacer le signe &apos;#&apos; par &apos;\#FFF&apos;<
         <translation>Raccourcis clavier</translation>
     </message>
     <message>
+        <location filename="../../src/config/shortcutswidget.cpp" line="51"/>
+        <source>On native Wayland, global shortcuts are controlled by the desktop environment. Configure the same key there to run 'flameshot gui'. Changes here apply immediately on X11/XWayland.</source>
+        <translation>Sous Wayland natif, les raccourcis globaux sont gérés par l’environnement de bureau. Configurez-y la même touche pour exécuter « flameshot gui ». Les modifications effectuées ici s’appliquent immédiatement sous X11/XWayland.</translation>
+    </message>
+    <message>
         <location filename="../../src/config/shortcutswidget.cpp" line="61"/>
         <source>Available shortcuts in the screen capture mode.</source>
         <translation>Raccourcis disponibles en mode capture d&apos;écran.</translation>
@@ -2729,10 +2744,11 @@ Vous devrez probablement remplacer le signe &apos;#&apos; par &apos;\#FFF&apos;<
         <translation type="vanished">Effacer l&apos;outil actuel</translation>
     </message>
     <message>
-        <location filename="../../src/config/shortcutswidget.cpp" line="213"/>
-        <location filename="../../src/config/shortcutswidget.cpp" line="222"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="233"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="238"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="244"/>
         <source>Capture screen</source>
-        <translation>Capturer l&apos;écran</translation>
+        <translation>Capturer l’écran</translation>
     </message>
     <message>
         <location filename="../../src/config/shortcutswidget.cpp" line="215"/>

--- a/data/translations/Internationalization_ga.ts
+++ b/data/translations/Internationalization_ga.ts
@@ -963,6 +963,16 @@ Réitigh iad de láimh sa chomhad cumraíochta.</translation>
         <translation>Taispeáin fógraí deisce</translation>
     </message>
     <message>
+        <location filename="../../src/config/generalconf.cpp" line="341"/>
+        <source>Show mouse cursor in screenshots</source>
+        <translation>Taispeáin cúrsóir na luiche i ngabhálacha scáileáin</translation>
+    </message>
+    <message>
+        <location filename="../../src/config/generalconf.cpp" line="343"/>
+        <source>Include the current Windows mouse cursor in captured images</source>
+        <translation>Cuir cúrsóir reatha luiche Windows sna híomhánna gabhtha</translation>
+    </message>
+    <message>
         <location filename="../../src/config/generalconf.cpp" line="339"/>
         <source>Show tray icon</source>
         <translation>Taispeáin deilbhín tráidire</translation>
@@ -2566,6 +2576,11 @@ B&apos;fhéidir go mbeidh ort éalú ón gcomhartha &apos;#&apos; mar atá i &ap
         <translation>Eochracha Te</translation>
     </message>
     <message>
+        <location filename="../../src/config/shortcutswidget.cpp" line="51"/>
+        <source>On native Wayland, global shortcuts are controlled by the desktop environment. Configure the same key there to run 'flameshot gui'. Changes here apply immediately on X11/XWayland.</source>
+        <translation>Ar Wayland dúchasach, is é timpeallacht na deisce a rialaíonn aicearraí domhanda. Cumraigh an eochair chéanna ansin chun 'flameshot gui' a rith. Cuirtear athruithe anseo i bhfeidhm láithreach ar X11/XWayland.</translation>
+    </message>
+    <message>
         <location filename="../../src/config/shortcutswidget.cpp" line="61"/>
         <source>Available shortcuts in the screen capture mode.</source>
         <translation>Aicearraí atá ar fáil sa mhodh gabhála scáileáin.</translation>
@@ -2718,8 +2733,9 @@ B&apos;fhéidir go mbeidh ort éalú ón gcomhartha &apos;#&apos; mar atá i &ap
         <translation type="vanished">Scrios uirlis reatha</translation>
     </message>
     <message>
-        <location filename="../../src/config/shortcutswidget.cpp" line="213"/>
-        <location filename="../../src/config/shortcutswidget.cpp" line="222"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="233"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="238"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="244"/>
         <source>Capture screen</source>
         <translation>Gabháil an scáileán</translation>
     </message>

--- a/data/translations/Internationalization_gl.ts
+++ b/data/translations/Internationalization_gl.ts
@@ -959,6 +959,16 @@ Please solve them manually in the configuration file.</translation>
         <translation>Amosar as notificacións no escritorio</translation>
     </message>
     <message>
+        <location filename="../../src/config/generalconf.cpp" line="341"/>
+        <source>Show mouse cursor in screenshots</source>
+        <translation>Mostrar o cursor do rato nas capturas de pantalla</translation>
+    </message>
+    <message>
+        <location filename="../../src/config/generalconf.cpp" line="343"/>
+        <source>Include the current Windows mouse cursor in captured images</source>
+        <translation>Incluír o cursor actual do rato de Windows nas imaxes capturadas</translation>
+    </message>
+    <message>
         <location filename="../../src/config/generalconf.cpp" line="339"/>
         <source>Show tray icon</source>
         <translation>Mostrar icono na barra de tarefas</translation>
@@ -2537,6 +2547,11 @@ You may need to escape the &apos;#&apos; sign as in &apos;\#FFF&apos;</translati
         <translation>Hot Keys</translation>
     </message>
     <message>
+        <location filename="../../src/config/shortcutswidget.cpp" line="51"/>
+        <source>On native Wayland, global shortcuts are controlled by the desktop environment. Configure the same key there to run 'flameshot gui'. Changes here apply immediately on X11/XWayland.</source>
+        <translation>En Wayland nativo, os atallos globais están controlados polo contorno de escritorio. Configure alí a mesma tecla para executar «flameshot gui». Os cambios feitos aquí aplícanse inmediatamente en X11/XWayland.</translation>
+    </message>
+    <message>
         <location filename="../../src/config/shortcutswidget.cpp" line="61"/>
         <source>Available shortcuts in the screen capture mode.</source>
         <translation>Available shortcuts in the screen capture mode.</translation>
@@ -2689,10 +2704,11 @@ You may need to escape the &apos;#&apos; sign as in &apos;\#FFF&apos;</translati
         <translation type="obsolete">Delete current tool</translation>
     </message>
     <message>
-        <location filename="../../src/config/shortcutswidget.cpp" line="213"/>
-        <location filename="../../src/config/shortcutswidget.cpp" line="222"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="233"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="238"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="244"/>
         <source>Capture screen</source>
-        <translation type="unfinished">Capture screen</translation>
+        <translation>Capturar a pantalla</translation>
     </message>
     <message>
         <location filename="../../src/config/shortcutswidget.cpp" line="215"/>

--- a/data/translations/Internationalization_grc.ts
+++ b/data/translations/Internationalization_grc.ts
@@ -495,6 +495,16 @@ Press Space to open the side panel.</translation>
         <translation>Show desktop notifications</translation>
     </message>
     <message>
+        <location filename="../../src/config/generalconf.cpp" line="341"/>
+        <source>Show mouse cursor in screenshots</source>
+        <translation>Ἐμφάνισις τοῦ δείκτου τοῦ μυὸς ἐν τοῖς στιγμιοτύποις ὀθόνης</translation>
+    </message>
+    <message>
+        <location filename="../../src/config/generalconf.cpp" line="343"/>
+        <source>Include the current Windows mouse cursor in captured images</source>
+        <translation>Πρόσθεσις τοῦ νῦν δείκτου τοῦ μυὸς τῶν Windows εἰς τὰς ληφθείσας εἰκόνας</translation>
+    </message>
+    <message>
         <location filename="../../src/config/generalconf.cpp" line="239"/>
         <source>Show tray icon</source>
         <translation>Show tray icon</translation>
@@ -1359,6 +1369,18 @@ You may need to escape the &apos;#&apos; sign as in &apos;\#FFF&apos;</translati
         <location filename="../../src/config/shortcutswidget.cpp" line="27"/>
         <source>Hot Keys</source>
         <translation>Hot Keys</translation>
+    </message>
+    <message>
+        <location filename="../../src/config/shortcutswidget.cpp" line="51"/>
+        <source>On native Wayland, global shortcuts are controlled by the desktop environment. Configure the same key there to run 'flameshot gui'. Changes here apply immediately on X11/XWayland.</source>
+        <translation>Ἐν τῷ γνησίῳ Wayland, αἱ καθολικαὶ συντομεύσεις ὑπὸ τοῦ περιβάλλοντος ἐπιφανείας ἐλέγχονται. Ῥύθμισον ἐκεῖ τὸ αὐτὸ πλῆκτρον ἵνα ἐκτελῇ τὸ 'flameshot gui'. Αἱ ἐνταῦθα μεταβολαὶ εὐθὺς ἐνεργοῦνται ἐν X11/XWayland.</translation>
+    </message>
+    <message>
+        <location filename="../../src/config/shortcutswidget.cpp" line="233"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="238"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="244"/>
+        <source>Capture screen</source>
+        <translation>Λῆψις ὀθόνης</translation>
     </message>
     <message>
         <location filename="../../src/config/shortcutswidget.cpp" line="52"/>

--- a/data/translations/Internationalization_he.ts
+++ b/data/translations/Internationalization_he.ts
@@ -971,6 +971,16 @@ Please solve them manually in the configuration file.</source>
         <translation>הצגת התראות שולחן־עבודה</translation>
     </message>
     <message>
+        <location filename="../../src/config/generalconf.cpp" line="341"/>
+        <source>Show mouse cursor in screenshots</source>
+        <translation>הצגת סמן העכבר בצילומי מסך</translation>
+    </message>
+    <message>
+        <location filename="../../src/config/generalconf.cpp" line="343"/>
+        <source>Include the current Windows mouse cursor in captured images</source>
+        <translation>הכללת סמן העכבר הנוכחי של Windows בתמונות שנלכדו</translation>
+    </message>
+    <message>
         <location filename="../../src/config/generalconf.cpp" line="339"/>
         <source>Show tray icon</source>
         <translation>הצגת סמל מגש</translation>
@@ -2577,6 +2587,11 @@ You may need to escape the &apos;#&apos; sign as in &apos;\#FFF&apos;</source>
         <translation>מקשים חמים</translation>
     </message>
     <message>
+        <location filename="../../src/config/shortcutswidget.cpp" line="51"/>
+        <source>On native Wayland, global shortcuts are controlled by the desktop environment. Configure the same key there to run 'flameshot gui'. Changes here apply immediately on X11/XWayland.</source>
+        <translation>ב־Wayland טבעי, קיצורי דרך גלובליים מנוהלים על ידי סביבת שולחן העבודה. יש להגדיר שם את אותו מקש להפעלת 'flameshot gui'. השינויים כאן חלים מיד ב־X11/XWayland.</translation>
+    </message>
+    <message>
         <location filename="../../src/config/shortcutswidget.cpp" line="61"/>
         <source>Available shortcuts in the screen capture mode.</source>
         <translation>קיצורי־דרך זמינים במצב לכידת מסך.</translation>
@@ -2729,8 +2744,9 @@ You may need to escape the &apos;#&apos; sign as in &apos;\#FFF&apos;</source>
         <translation type="vanished">מחיקת כלי נוכחי</translation>
     </message>
     <message>
-        <location filename="../../src/config/shortcutswidget.cpp" line="213"/>
-        <location filename="../../src/config/shortcutswidget.cpp" line="222"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="233"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="238"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="244"/>
         <source>Capture screen</source>
         <translation>לכידת מסך</translation>
     </message>

--- a/data/translations/Internationalization_hu.ts
+++ b/data/translations/Internationalization_hu.ts
@@ -994,6 +994,16 @@ Please solve them manually in the configuration file.</translation>
         <translation>Asztali értesítések megjelenítése</translation>
     </message>
     <message>
+        <location filename="../../src/config/generalconf.cpp" line="341"/>
+        <source>Show mouse cursor in screenshots</source>
+        <translation>Egérmutató megjelenítése a képernyőképeken</translation>
+    </message>
+    <message>
+        <location filename="../../src/config/generalconf.cpp" line="343"/>
+        <source>Include the current Windows mouse cursor in captured images</source>
+        <translation>A Windows aktuális egérmutatójának hozzáadása a rögzített képekhez</translation>
+    </message>
+    <message>
         <location filename="../../src/config/generalconf.cpp" line="339"/>
         <source>Show tray icon</source>
         <translation>Ikon megjelenítése a tálcán</translation>
@@ -2593,6 +2603,11 @@ Lehet, hogy meg kepp adnod egy &apos;\&apos; karaktert a &apos;#&apos; karakter 
         <translation>Gyorsbillentyűk</translation>
     </message>
     <message>
+        <location filename="../../src/config/shortcutswidget.cpp" line="51"/>
+        <source>On native Wayland, global shortcuts are controlled by the desktop environment. Configure the same key there to run 'flameshot gui'. Changes here apply immediately on X11/XWayland.</source>
+        <translation>Natív Wayland alatt a globális gyorsbillentyűket az asztali környezet kezeli. Ott állítsa be ugyanezt a billentyűt a „flameshot gui” futtatásához. Az itt végzett módosítások X11/XWayland alatt azonnal érvénybe lépnek.</translation>
+    </message>
+    <message>
         <location filename="../../src/config/shortcutswidget.cpp" line="61"/>
         <source>Available shortcuts in the screen capture mode.</source>
         <translation>Képernyőfelvétel módban elérhető gyorsbillentyűk.</translation>
@@ -2715,10 +2730,11 @@ Lehet, hogy meg kepp adnod egy &apos;\&apos; karaktert a &apos;#&apos; karakter 
         <translation type="obsolete">Delete current tool</translation>
     </message>
     <message>
-        <location filename="../../src/config/shortcutswidget.cpp" line="213"/>
-        <location filename="../../src/config/shortcutswidget.cpp" line="222"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="233"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="238"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="244"/>
         <source>Capture screen</source>
-        <translation type="unfinished">Képernyő rögzítése</translation>
+        <translation>Képernyő rögzítése</translation>
     </message>
     <message>
         <location filename="../../src/config/shortcutswidget.cpp" line="215"/>

--- a/data/translations/Internationalization_id.ts
+++ b/data/translations/Internationalization_id.ts
@@ -971,6 +971,16 @@ Silakan atasi mereka secara manual di berkas konfigurasi.</translation>
         <translation>Tampilkan notifikasi desktop</translation>
     </message>
     <message>
+        <location filename="../../src/config/generalconf.cpp" line="341"/>
+        <source>Show mouse cursor in screenshots</source>
+        <translation>Tampilkan kursor tetikus pada tangkapan layar</translation>
+    </message>
+    <message>
+        <location filename="../../src/config/generalconf.cpp" line="343"/>
+        <source>Include the current Windows mouse cursor in captured images</source>
+        <translation>Sertakan kursor tetikus Windows saat ini dalam gambar yang diambil</translation>
+    </message>
+    <message>
         <location filename="../../src/config/generalconf.cpp" line="339"/>
         <source>Show tray icon</source>
         <translation>Tampilkan ikon baki</translation>
@@ -2578,6 +2588,11 @@ Anda mungkin perlu untuk escape dari tanda &apos;#&apos; seperti pada &apos;\#FF
         <translation>Tombol Panas</translation>
     </message>
     <message>
+        <location filename="../../src/config/shortcutswidget.cpp" line="51"/>
+        <source>On native Wayland, global shortcuts are controlled by the desktop environment. Configure the same key there to run 'flameshot gui'. Changes here apply immediately on X11/XWayland.</source>
+        <translation>Pada Wayland native, pintasan global dikendalikan oleh lingkungan desktop. Atur tombol yang sama di sana untuk menjalankan 'flameshot gui'. Perubahan di sini langsung berlaku pada X11/XWayland.</translation>
+    </message>
+    <message>
         <location filename="../../src/config/shortcutswidget.cpp" line="61"/>
         <source>Available shortcuts in the screen capture mode.</source>
         <translation>Shortcut yang tersedia di mode capture layar.</translation>
@@ -2730,10 +2745,11 @@ Anda mungkin perlu untuk escape dari tanda &apos;#&apos; seperti pada &apos;\#FF
         <translation type="obsolete">Delete current tool</translation>
     </message>
     <message>
-        <location filename="../../src/config/shortcutswidget.cpp" line="213"/>
-        <location filename="../../src/config/shortcutswidget.cpp" line="222"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="233"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="238"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="244"/>
         <source>Capture screen</source>
-        <translation>Ambil layar</translation>
+        <translation>Tangkap layar</translation>
     </message>
     <message>
         <location filename="../../src/config/shortcutswidget.cpp" line="215"/>

--- a/data/translations/Internationalization_it_IT.ts
+++ b/data/translations/Internationalization_it_IT.ts
@@ -892,6 +892,16 @@ Si prega di risolverli manualmente nel file di configurazione.</translation>
         <translation>Mostra notifiche desktop</translation>
     </message>
     <message>
+        <location filename="../../src/config/generalconf.cpp" line="341"/>
+        <source>Show mouse cursor in screenshots</source>
+        <translation>Mostra il cursore del mouse negli screenshot</translation>
+    </message>
+    <message>
+        <location filename="../../src/config/generalconf.cpp" line="343"/>
+        <source>Include the current Windows mouse cursor in captured images</source>
+        <translation>Includi il cursore del mouse corrente di Windows nelle immagini acquisite</translation>
+    </message>
+    <message>
         <location filename="../../src/config/generalconf.cpp" line="339"/>
         <source>Show tray icon</source>
         <translation>Mostra icona nella barra delle applicazioni</translation>
@@ -2435,6 +2445,11 @@ You may need to escape the &apos;#&apos; sign as in &apos;\#FFF&apos;</translati
         <translation>Tasti di scelta rapida</translation>
     </message>
     <message>
+        <location filename="../../src/config/shortcutswidget.cpp" line="51"/>
+        <source>On native Wayland, global shortcuts are controlled by the desktop environment. Configure the same key there to run 'flameshot gui'. Changes here apply immediately on X11/XWayland.</source>
+        <translation>Su Wayland nativo, le scorciatoie globali sono gestite dall’ambiente desktop. Configura lì lo stesso tasto per eseguire «flameshot gui». Le modifiche apportate qui hanno effetto immediato su X11/XWayland.</translation>
+    </message>
+    <message>
         <location filename="../../src/config/shortcutswidget.cpp" line="61"/>
         <source>Available shortcuts in the screen capture mode.</source>
         <translation>Scorciatoie disponibili nella modalità di cattura dello schermo.</translation>
@@ -2587,8 +2602,9 @@ You may need to escape the &apos;#&apos; sign as in &apos;\#FFF&apos;</translati
         <translation type="vanished">Elimina lo strumento corrente</translation>
     </message>
     <message>
-        <location filename="../../src/config/shortcutswidget.cpp" line="213"/>
-        <location filename="../../src/config/shortcutswidget.cpp" line="222"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="233"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="238"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="244"/>
         <source>Capture screen</source>
         <translation>Cattura schermo</translation>
     </message>

--- a/data/translations/Internationalization_ja.ts
+++ b/data/translations/Internationalization_ja.ts
@@ -962,6 +962,16 @@ Please solve them manually in the configuration file.</translation>
         <translation>デスクトップ通知を表示する</translation>
     </message>
     <message>
+        <location filename="../../src/config/generalconf.cpp" line="341"/>
+        <source>Show mouse cursor in screenshots</source>
+        <translation>スクリーンショットにマウスカーソルを表示</translation>
+    </message>
+    <message>
+        <location filename="../../src/config/generalconf.cpp" line="343"/>
+        <source>Include the current Windows mouse cursor in captured images</source>
+        <translation>キャプチャした画像に現在の Windows マウスカーソルを含める</translation>
+    </message>
+    <message>
         <location filename="../../src/config/generalconf.cpp" line="339"/>
         <source>Show tray icon</source>
         <translation>トレイアイコンを表示する</translation>
@@ -2540,6 +2550,11 @@ You may need to escape the &apos;#&apos; sign as in &apos;\#FFF&apos;</translati
         <translation>Hot Keys</translation>
     </message>
     <message>
+        <location filename="../../src/config/shortcutswidget.cpp" line="51"/>
+        <source>On native Wayland, global shortcuts are controlled by the desktop environment. Configure the same key there to run 'flameshot gui'. Changes here apply immediately on X11/XWayland.</source>
+        <translation>ネイティブ Wayland では、グローバルショートカットはデスクトップ環境によって管理されます。そこで同じキーを「flameshot gui」の実行に設定してください。ここでの変更は X11/XWayland では直ちに反映されます。</translation>
+    </message>
+    <message>
         <location filename="../../src/config/shortcutswidget.cpp" line="61"/>
         <source>Available shortcuts in the screen capture mode.</source>
         <translation type="unfinished">スクリーンキャプチャーモードで利用可能なショートカット。</translation>
@@ -2692,10 +2707,11 @@ You may need to escape the &apos;#&apos; sign as in &apos;\#FFF&apos;</translati
         <translation type="obsolete">Delete current tool</translation>
     </message>
     <message>
-        <location filename="../../src/config/shortcutswidget.cpp" line="213"/>
-        <location filename="../../src/config/shortcutswidget.cpp" line="222"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="233"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="238"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="244"/>
         <source>Capture screen</source>
-        <translation type="unfinished">Capture screen</translation>
+        <translation>画面をキャプチャ</translation>
     </message>
     <message>
         <location filename="../../src/config/shortcutswidget.cpp" line="215"/>

--- a/data/translations/Internationalization_ka.ts
+++ b/data/translations/Internationalization_ka.ts
@@ -962,6 +962,16 @@ Please solve them manually in the configuration file.</translation>
         <translation type="unfinished">ცნობების ჩვენება სამუშაო მაგიდაზე</translation>
     </message>
     <message>
+        <location filename="../../src/config/generalconf.cpp" line="341"/>
+        <source>Show mouse cursor in screenshots</source>
+        <translation>ეკრანის სურათებში მაუსის კურსორის ჩვენება</translation>
+    </message>
+    <message>
+        <location filename="../../src/config/generalconf.cpp" line="343"/>
+        <source>Include the current Windows mouse cursor in captured images</source>
+        <translation>გადაღებულ სურათებში Windows-ის მიმდინარე მაუსის კურსორის ჩართვა</translation>
+    </message>
+    <message>
         <location filename="../../src/config/generalconf.cpp" line="339"/>
         <source>Show tray icon</source>
         <translation type="unfinished">ხატულის ჩვენება სისტემურ პანელზე</translation>
@@ -2532,6 +2542,11 @@ You may need to escape the &apos;#&apos; sign as in &apos;\#FFF&apos;</translati
         <translation>Hot Keys</translation>
     </message>
     <message>
+        <location filename="../../src/config/shortcutswidget.cpp" line="51"/>
+        <source>On native Wayland, global shortcuts are controlled by the desktop environment. Configure the same key there to run 'flameshot gui'. Changes here apply immediately on X11/XWayland.</source>
+        <translation>ნატიურ Wayland-ში გლობალურ მალსახმობებს სამუშაო მაგიდის გარემო მართავს. იქ იგივე ღილაკი დააყენეთ 'flameshot gui'-ის გასაშვებად. აქ შეტანილი ცვლილებები X11/XWayland-ში დაუყოვნებლივ ამოქმედდება.</translation>
+    </message>
+    <message>
         <location filename="../../src/config/shortcutswidget.cpp" line="61"/>
         <source>Available shortcuts in the screen capture mode.</source>
         <translation type="unfinished">გადაღების რეჟიმში ხელმისაწვდომი მალსახმობები.</translation>
@@ -2684,10 +2699,11 @@ You may need to escape the &apos;#&apos; sign as in &apos;\#FFF&apos;</translati
         <translation type="obsolete">Delete current tool</translation>
     </message>
     <message>
-        <location filename="../../src/config/shortcutswidget.cpp" line="213"/>
-        <location filename="../../src/config/shortcutswidget.cpp" line="222"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="233"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="238"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="244"/>
         <source>Capture screen</source>
-        <translation type="unfinished">Capture screen</translation>
+        <translation>ეკრანის გადაღება</translation>
     </message>
     <message>
         <location filename="../../src/config/shortcutswidget.cpp" line="215"/>

--- a/data/translations/Internationalization_ko.ts
+++ b/data/translations/Internationalization_ko.ts
@@ -983,6 +983,16 @@ Please solve them manually in the configuration file.</source>
         <translation>데스크톱 알림 표시</translation>
     </message>
     <message>
+        <location filename="../../src/config/generalconf.cpp" line="341"/>
+        <source>Show mouse cursor in screenshots</source>
+        <translation>스크린샷에 마우스 커서 표시</translation>
+    </message>
+    <message>
+        <location filename="../../src/config/generalconf.cpp" line="343"/>
+        <source>Include the current Windows mouse cursor in captured images</source>
+        <translation>캡처한 이미지에 현재 Windows 마우스 커서 포함</translation>
+    </message>
+    <message>
         <location filename="../../src/config/generalconf.cpp" line="339"/>
         <source>Show tray icon</source>
         <translation>트레이 아이콘 표시</translation>
@@ -2586,6 +2596,11 @@ You may need to escape the &apos;#&apos; sign as in &apos;\#FFF&apos;</source>
         <translation>단축키</translation>
     </message>
     <message>
+        <location filename="../../src/config/shortcutswidget.cpp" line="51"/>
+        <source>On native Wayland, global shortcuts are controlled by the desktop environment. Configure the same key there to run 'flameshot gui'. Changes here apply immediately on X11/XWayland.</source>
+        <translation>네이티브 Wayland에서는 데스크톱 환경이 전역 단축키를 관리합니다. 데스크톱 환경에서 같은 키가 'flameshot gui'를 실행하도록 설정하세요. 여기서 변경한 내용은 X11/XWayland에서 즉시 적용됩니다.</translation>
+    </message>
+    <message>
         <location filename="../../src/config/shortcutswidget.cpp" line="61"/>
         <source>Available shortcuts in the screen capture mode.</source>
         <translation>화면 캡처 모드에서 사용 가능한 단축키입니다.</translation>
@@ -2738,8 +2753,9 @@ You may need to escape the &apos;#&apos; sign as in &apos;\#FFF&apos;</source>
         <translation type="obsolete">Delete current tool</translation>
     </message>
     <message>
-        <location filename="../../src/config/shortcutswidget.cpp" line="213"/>
-        <location filename="../../src/config/shortcutswidget.cpp" line="222"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="233"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="238"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="244"/>
         <source>Capture screen</source>
         <translation>화면 캡처</translation>
     </message>

--- a/data/translations/Internationalization_nb_NO.ts
+++ b/data/translations/Internationalization_nb_NO.ts
@@ -963,6 +963,16 @@ Please solve them manually in the configuration file.</translation>
         <translation type="unfinished">Mostra les notificacions d&apos;escriptori</translation>
     </message>
     <message>
+        <location filename="../../src/config/generalconf.cpp" line="341"/>
+        <source>Show mouse cursor in screenshots</source>
+        <translation>Vis musepekeren i skjermbilder</translation>
+    </message>
+    <message>
+        <location filename="../../src/config/generalconf.cpp" line="343"/>
+        <source>Include the current Windows mouse cursor in captured images</source>
+        <translation>Ta med den gjeldende Windows-musepekeren i bilder som tas</translation>
+    </message>
+    <message>
         <location filename="../../src/config/generalconf.cpp" line="339"/>
         <source>Show tray icon</source>
         <translation type="unfinished">Mostra la icona en la barra de tasques</translation>
@@ -2533,6 +2543,11 @@ You may need to escape the &apos;#&apos; sign as in &apos;\#FFF&apos;</translati
         <translation>Hot Keys</translation>
     </message>
     <message>
+        <location filename="../../src/config/shortcutswidget.cpp" line="51"/>
+        <source>On native Wayland, global shortcuts are controlled by the desktop environment. Configure the same key there to run 'flameshot gui'. Changes here apply immediately on X11/XWayland.</source>
+        <translation>På innebygd Wayland styres globale hurtigtaster av skrivebordsmiljøet. Konfigurer den samme tasten der til å kjøre «flameshot gui». Endringer her trer i kraft umiddelbart på X11/XWayland.</translation>
+    </message>
+    <message>
         <location filename="../../src/config/shortcutswidget.cpp" line="61"/>
         <source>Available shortcuts in the screen capture mode.</source>
         <translation type="unfinished">Dreceres disponibles en el mode de captura de pantalla.</translation>
@@ -2685,10 +2700,11 @@ You may need to escape the &apos;#&apos; sign as in &apos;\#FFF&apos;</translati
         <translation type="obsolete">Delete current tool</translation>
     </message>
     <message>
-        <location filename="../../src/config/shortcutswidget.cpp" line="213"/>
-        <location filename="../../src/config/shortcutswidget.cpp" line="222"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="233"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="238"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="244"/>
         <source>Capture screen</source>
-        <translation type="unfinished">Capture screen</translation>
+        <translation>Ta skjermbilde</translation>
     </message>
     <message>
         <location filename="../../src/config/shortcutswidget.cpp" line="215"/>

--- a/data/translations/Internationalization_nl.ts
+++ b/data/translations/Internationalization_nl.ts
@@ -956,6 +956,16 @@ Please solve them manually in the configuration file.</source>
         <translation>Bureaubladmeldingen tonen</translation>
     </message>
     <message>
+        <location filename="../../src/config/generalconf.cpp" line="341"/>
+        <source>Show mouse cursor in screenshots</source>
+        <translation>Muisaanwijzer weergeven in schermafbeeldingen</translation>
+    </message>
+    <message>
+        <location filename="../../src/config/generalconf.cpp" line="343"/>
+        <source>Include the current Windows mouse cursor in captured images</source>
+        <translation>De huidige Windows-muisaanwijzer opnemen in vastgelegde afbeeldingen</translation>
+    </message>
+    <message>
         <location filename="../../src/config/generalconf.cpp" line="339"/>
         <source>Show tray icon</source>
         <translation>Systeemvakpictogram tonen</translation>
@@ -2499,6 +2509,11 @@ Mogelijk moet je het &apos;#&apos;-teken insluiten. Voorbeeld: &apos;\#FFF&apos;
         <translation>Sneltoetsen</translation>
     </message>
     <message>
+        <location filename="../../src/config/shortcutswidget.cpp" line="51"/>
+        <source>On native Wayland, global shortcuts are controlled by the desktop environment. Configure the same key there to run 'flameshot gui'. Changes here apply immediately on X11/XWayland.</source>
+        <translation>Op native Wayland worden globale sneltoetsen beheerd door de desktopomgeving. Stel daar dezelfde toets in om ‘flameshot gui’ uit te voeren. Wijzigingen hier worden direct toegepast op X11/XWayland.</translation>
+    </message>
+    <message>
         <location filename="../../src/config/shortcutswidget.cpp" line="61"/>
         <source>Available shortcuts in the screen capture mode.</source>
         <translation>Beschikbare sneltoetsen in de vastlegmodus.</translation>
@@ -2609,10 +2624,11 @@ Mogelijk moet je het &apos;#&apos;-teken insluiten. Voorbeeld: &apos;\#FFF&apos;
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/config/shortcutswidget.cpp" line="213"/>
-        <location filename="../../src/config/shortcutswidget.cpp" line="222"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="233"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="238"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="244"/>
         <source>Capture screen</source>
-        <translation type="unfinished">Scherm vastleggen</translation>
+        <translation>Scherm vastleggen</translation>
     </message>
     <message>
         <location filename="../../src/config/shortcutswidget.cpp" line="215"/>

--- a/data/translations/Internationalization_nl_NL.ts
+++ b/data/translations/Internationalization_nl_NL.ts
@@ -974,6 +974,16 @@ Los ze alstublieft handmatig op in het configuratiebestand.</translation>
         <translation>Bureaubladmeldingen tonen</translation>
     </message>
     <message>
+        <location filename="../../src/config/generalconf.cpp" line="341"/>
+        <source>Show mouse cursor in screenshots</source>
+        <translation>Muisaanwijzer weergeven in schermafbeeldingen</translation>
+    </message>
+    <message>
+        <location filename="../../src/config/generalconf.cpp" line="343"/>
+        <source>Include the current Windows mouse cursor in captured images</source>
+        <translation>De huidige Windows-muisaanwijzer opnemen in vastgelegde afbeeldingen</translation>
+    </message>
+    <message>
         <location filename="../../src/config/generalconf.cpp" line="339"/>
         <source>Show tray icon</source>
         <translation>Systeemvakpictogram tonen</translation>
@@ -2585,6 +2595,11 @@ Mogelijk moet je het &apos;#&apos;-teken insluiten. Voorbeeld: &apos;\#FFF&apos;
         <translation>Sneltoetsen</translation>
     </message>
     <message>
+        <location filename="../../src/config/shortcutswidget.cpp" line="51"/>
+        <source>On native Wayland, global shortcuts are controlled by the desktop environment. Configure the same key there to run 'flameshot gui'. Changes here apply immediately on X11/XWayland.</source>
+        <translation>Op native Wayland worden globale sneltoetsen beheerd door de desktopomgeving. Stel daar dezelfde toets in om ‘flameshot gui’ uit te voeren. Wijzigingen hier worden direct toegepast op X11/XWayland.</translation>
+    </message>
+    <message>
         <location filename="../../src/config/shortcutswidget.cpp" line="61"/>
         <source>Available shortcuts in the screen capture mode.</source>
         <translation>Beschikbare sneltoetsen in de vastlegmodus.</translation>
@@ -2737,8 +2752,9 @@ Mogelijk moet je het &apos;#&apos;-teken insluiten. Voorbeeld: &apos;\#FFF&apos;
         <translation type="obsolete">Huidig gereedschap verwijderen</translation>
     </message>
     <message>
-        <location filename="../../src/config/shortcutswidget.cpp" line="213"/>
-        <location filename="../../src/config/shortcutswidget.cpp" line="222"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="233"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="238"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="244"/>
         <source>Capture screen</source>
         <translation>Scherm vastleggen</translation>
     </message>

--- a/data/translations/Internationalization_pl.ts
+++ b/data/translations/Internationalization_pl.ts
@@ -982,6 +982,16 @@ Rozwiąż błędy ręcznie w pliku konfiguracyjnym.</translation>
         <translation>Pokaż powiadomienia ekranowe</translation>
     </message>
     <message>
+        <location filename="../../src/config/generalconf.cpp" line="341"/>
+        <source>Show mouse cursor in screenshots</source>
+        <translation>Pokaż kursor myszy na zrzutach ekranu</translation>
+    </message>
+    <message>
+        <location filename="../../src/config/generalconf.cpp" line="343"/>
+        <source>Include the current Windows mouse cursor in captured images</source>
+        <translation>Dołącz bieżący kursor myszy systemu Windows do przechwyconych obrazów</translation>
+    </message>
+    <message>
         <location filename="../../src/config/generalconf.cpp" line="339"/>
         <source>Show tray icon</source>
         <translation>Pokaż ikonę w centrum akcji</translation>
@@ -2584,6 +2594,11 @@ Może być konieczne opuszczenie znaku &apos;#&apos; jak np.: &apos;\#FFF&apos;<
         <translation>Skróty klawiszowe</translation>
     </message>
     <message>
+        <location filename="../../src/config/shortcutswidget.cpp" line="51"/>
+        <source>On native Wayland, global shortcuts are controlled by the desktop environment. Configure the same key there to run 'flameshot gui'. Changes here apply immediately on X11/XWayland.</source>
+        <translation>W natywnym środowisku Wayland globalnymi skrótami steruje środowisko graficzne. Ustaw w nim ten sam klawisz, aby uruchamiać „flameshot gui”. Zmiany wprowadzone tutaj są natychmiast stosowane w X11/XWayland.</translation>
+    </message>
+    <message>
         <location filename="../../src/config/shortcutswidget.cpp" line="61"/>
         <source>Available shortcuts in the screen capture mode.</source>
         <translation>Dostępne skróty klawiszowe w trybie przechwytywania obrazu.</translation>
@@ -2736,8 +2751,9 @@ Może być konieczne opuszczenie znaku &apos;#&apos; jak np.: &apos;\#FFF&apos;<
         <translation type="vanished">Usuń bieżące narzędzie</translation>
     </message>
     <message>
-        <location filename="../../src/config/shortcutswidget.cpp" line="213"/>
-        <location filename="../../src/config/shortcutswidget.cpp" line="222"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="233"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="238"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="244"/>
         <source>Capture screen</source>
         <translation>Przechwyć ekran</translation>
     </message>

--- a/data/translations/Internationalization_pt.ts
+++ b/data/translations/Internationalization_pt.ts
@@ -963,6 +963,16 @@ Resolva-as manualmente no ficheiro de configuração.</translation>
         <translation>Mostrar notificações na área de trabalho</translation>
     </message>
     <message>
+        <location filename="../../src/config/generalconf.cpp" line="341"/>
+        <source>Show mouse cursor in screenshots</source>
+        <translation>Mostrar o cursor do rato nas capturas de ecrã</translation>
+    </message>
+    <message>
+        <location filename="../../src/config/generalconf.cpp" line="343"/>
+        <source>Include the current Windows mouse cursor in captured images</source>
+        <translation>Incluir o cursor atual do rato do Windows nas imagens capturadas</translation>
+    </message>
+    <message>
         <location filename="../../src/config/generalconf.cpp" line="339"/>
         <source>Show tray icon</source>
         <translation>Mostrar ícone na bandeja</translation>
@@ -2566,6 +2576,11 @@ Você pode ter que invalidar o sinal &apos;#&apos;, por exemplo &apos;\#FFF&apos
         <translation>Teclas de atalho</translation>
     </message>
     <message>
+        <location filename="../../src/config/shortcutswidget.cpp" line="51"/>
+        <source>On native Wayland, global shortcuts are controlled by the desktop environment. Configure the same key there to run 'flameshot gui'. Changes here apply immediately on X11/XWayland.</source>
+        <translation>No Wayland nativo, os atalhos globais são controlados pelo ambiente de trabalho. Configure aí a mesma tecla para executar «flameshot gui». As alterações feitas aqui são aplicadas imediatamente no X11/XWayland.</translation>
+    </message>
+    <message>
         <location filename="../../src/config/shortcutswidget.cpp" line="61"/>
         <source>Available shortcuts in the screen capture mode.</source>
         <translation>Atalhos disponíveis no modo de captura de ecrã.</translation>
@@ -2718,10 +2733,11 @@ Você pode ter que invalidar o sinal &apos;#&apos;, por exemplo &apos;\#FFF&apos
         <translation type="obsolete">Delete current tool</translation>
     </message>
     <message>
-        <location filename="../../src/config/shortcutswidget.cpp" line="213"/>
-        <location filename="../../src/config/shortcutswidget.cpp" line="222"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="233"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="238"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="244"/>
         <source>Capture screen</source>
-        <translation>Ecrã de captura</translation>
+        <translation>Capturar ecrã</translation>
     </message>
     <message>
         <location filename="../../src/config/shortcutswidget.cpp" line="215"/>

--- a/data/translations/Internationalization_pt_BR.ts
+++ b/data/translations/Internationalization_pt_BR.ts
@@ -1018,6 +1018,16 @@ Por favor, resolva-os manualmente no arquivo de configuração.</translation>
         <translation>Mostrar notificações na área de trabalho</translation>
     </message>
     <message>
+        <location filename="../../src/config/generalconf.cpp" line="341"/>
+        <source>Show mouse cursor in screenshots</source>
+        <translation>Mostrar o cursor do mouse nas capturas de tela</translation>
+    </message>
+    <message>
+        <location filename="../../src/config/generalconf.cpp" line="343"/>
+        <source>Include the current Windows mouse cursor in captured images</source>
+        <translation>Incluir o cursor atual do mouse do Windows nas imagens capturadas</translation>
+    </message>
+    <message>
         <location filename="../../src/config/generalconf.cpp" line="339"/>
         <source>Show tray icon</source>
         <translation>Mostrar ícone na bandeja</translation>
@@ -2633,6 +2643,11 @@ Você pode ter que invalidar o sinal &apos;#&apos;, por exemplo &apos;\#FFF&apos
         <translation>Teclas de atalho</translation>
     </message>
     <message>
+        <location filename="../../src/config/shortcutswidget.cpp" line="51"/>
+        <source>On native Wayland, global shortcuts are controlled by the desktop environment. Configure the same key there to run 'flameshot gui'. Changes here apply immediately on X11/XWayland.</source>
+        <translation>No Wayland nativo, os atalhos globais são controlados pelo ambiente de desktop. Configure nele a mesma tecla para executar “flameshot gui”. As alterações feitas aqui são aplicadas imediatamente no X11/XWayland.</translation>
+    </message>
+    <message>
         <location filename="../../src/config/shortcutswidget.cpp" line="61"/>
         <source>Available shortcuts in the screen capture mode.</source>
         <translation>Atalhos disponíveis no modo de captura de tela.</translation>
@@ -2785,10 +2800,11 @@ Você pode ter que invalidar o sinal &apos;#&apos;, por exemplo &apos;\#FFF&apos
         <translation type="vanished">Excluir ferramenta atual</translation>
     </message>
     <message>
-        <location filename="../../src/config/shortcutswidget.cpp" line="213"/>
-        <location filename="../../src/config/shortcutswidget.cpp" line="222"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="233"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="238"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="244"/>
         <source>Capture screen</source>
-        <translation>Tela de captura</translation>
+        <translation>Capturar tela</translation>
     </message>
     <message>
         <location filename="../../src/config/shortcutswidget.cpp" line="215"/>

--- a/data/translations/Internationalization_ro.ts
+++ b/data/translations/Internationalization_ro.ts
@@ -949,6 +949,16 @@ Please solve them manually in the configuration file.</source>
         <translation type="unfinished">Mostra les notificacions d&apos;escriptori</translation>
     </message>
     <message>
+        <location filename="../../src/config/generalconf.cpp" line="341"/>
+        <source>Show mouse cursor in screenshots</source>
+        <translation>Afișează cursorul mouse-ului în capturile de ecran</translation>
+    </message>
+    <message>
+        <location filename="../../src/config/generalconf.cpp" line="343"/>
+        <source>Include the current Windows mouse cursor in captured images</source>
+        <translation>Include cursorul curent al mouse-ului din Windows în imaginile capturate</translation>
+    </message>
+    <message>
         <location filename="../../src/config/generalconf.cpp" line="339"/>
         <source>Show tray icon</source>
         <translation type="unfinished">Mostra la icona en la barra de tasques</translation>
@@ -2458,6 +2468,11 @@ You may need to escape the &apos;#&apos; sign as in &apos;\#FFF&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../src/config/shortcutswidget.cpp" line="51"/>
+        <source>On native Wayland, global shortcuts are controlled by the desktop environment. Configure the same key there to run 'flameshot gui'. Changes here apply immediately on X11/XWayland.</source>
+        <translation>În Wayland nativ, comenzile rapide globale sunt controlate de mediul desktop. Configurați acolo aceeași tastă pentru a rula „flameshot gui”. Modificările de aici se aplică imediat în X11/XWayland.</translation>
+    </message>
+    <message>
         <location filename="../../src/config/shortcutswidget.cpp" line="61"/>
         <source>Available shortcuts in the screen capture mode.</source>
         <translation type="unfinished">Dreceres disponibles en el mode de captura de pantalla.</translation>
@@ -2610,10 +2625,11 @@ You may need to escape the &apos;#&apos; sign as in &apos;\#FFF&apos;</source>
         <translation type="obsolete">Delete current tool</translation>
     </message>
     <message>
-        <location filename="../../src/config/shortcutswidget.cpp" line="213"/>
-        <location filename="../../src/config/shortcutswidget.cpp" line="222"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="233"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="238"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="244"/>
         <source>Capture screen</source>
-        <translation type="unfinished">Capture screen</translation>
+        <translation>Capturează ecranul</translation>
     </message>
     <message>
         <location filename="../../src/config/shortcutswidget.cpp" line="215"/>

--- a/data/translations/Internationalization_ru.ts
+++ b/data/translations/Internationalization_ru.ts
@@ -1050,6 +1050,16 @@ Please solve them manually in the configuration file.</source>
         <translation>Показывать уведомления</translation>
     </message>
     <message>
+        <location filename="../../src/config/generalconf.cpp" line="341"/>
+        <source>Show mouse cursor in screenshots</source>
+        <translation>Показывать указатель мыши на снимках экрана</translation>
+    </message>
+    <message>
+        <location filename="../../src/config/generalconf.cpp" line="343"/>
+        <source>Include the current Windows mouse cursor in captured images</source>
+        <translation>Добавлять текущий указатель мыши Windows на захваченные изображения</translation>
+    </message>
+    <message>
         <location filename="../../src/config/generalconf.cpp" line="339"/>
         <source>Show tray icon</source>
         <translation>Показывать значок в трее</translation>
@@ -2754,6 +2764,11 @@ You can find me in the system tray.</source>
         <translation>Горячие клавиши</translation>
     </message>
     <message>
+        <location filename="../../src/config/shortcutswidget.cpp" line="51"/>
+        <source>On native Wayland, global shortcuts are controlled by the desktop environment. Configure the same key there to run 'flameshot gui'. Changes here apply immediately on X11/XWayland.</source>
+        <translation>В нативном Wayland глобальные сочетания клавиш управляются окружением рабочего стола. Настройте там ту же клавишу для запуска «flameshot gui». Изменения здесь применяются сразу в X11/XWayland.</translation>
+    </message>
+    <message>
         <location filename="../../src/config/shortcutswidget.cpp" line="61"/>
         <source>Available shortcuts in the screen capture mode.</source>
         <translation>Доступные горячие клавиши в режиме захвата экрана.</translation>
@@ -2906,8 +2921,9 @@ You can find me in the system tray.</source>
         <translation type="vanished">Удалить текущий инструмент</translation>
     </message>
     <message>
-        <location filename="../../src/config/shortcutswidget.cpp" line="213"/>
-        <location filename="../../src/config/shortcutswidget.cpp" line="222"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="233"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="238"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="244"/>
         <source>Capture screen</source>
         <translation>Захватить экран</translation>
     </message>

--- a/data/translations/Internationalization_sk.ts
+++ b/data/translations/Internationalization_sk.ts
@@ -1022,6 +1022,16 @@ Riešte ich ručne v konfiguračnom súbore.</translation>
         <translation>Zobraziť systémové upozornenia</translation>
     </message>
     <message>
+        <location filename="../../src/config/generalconf.cpp" line="341"/>
+        <source>Show mouse cursor in screenshots</source>
+        <translation>Zobraziť kurzor myši na snímkach obrazovky</translation>
+    </message>
+    <message>
+        <location filename="../../src/config/generalconf.cpp" line="343"/>
+        <source>Include the current Windows mouse cursor in captured images</source>
+        <translation>Zahrnúť aktuálny kurzor myši systému Windows do zachytených obrázkov</translation>
+    </message>
+    <message>
         <location filename="../../src/config/generalconf.cpp" line="339"/>
         <source>Show tray icon</source>
         <translation>Zobraziť stavovú ikonu</translation>
@@ -2640,6 +2650,11 @@ Možno budete musieť napísať pred &apos;#&apos; opačnú lomku, teda &apos;\#
         <translation>Klávesové skratky</translation>
     </message>
     <message>
+        <location filename="../../src/config/shortcutswidget.cpp" line="51"/>
+        <source>On native Wayland, global shortcuts are controlled by the desktop environment. Configure the same key there to run 'flameshot gui'. Changes here apply immediately on X11/XWayland.</source>
+        <translation>V natívnom Waylande spravuje globálne klávesové skratky desktopové prostredie. Nastavte v ňom rovnaký kláves na spustenie „flameshot gui“. Zmeny tu sa prejavia okamžite v X11/XWayland.</translation>
+    </message>
+    <message>
         <location filename="../../src/config/shortcutswidget.cpp" line="61"/>
         <source>Available shortcuts in the screen capture mode.</source>
         <translation>Dostupné klávesové skratky v režime zachytávania obrazovky.</translation>
@@ -2792,8 +2807,9 @@ Možno budete musieť napísať pred &apos;#&apos; opačnú lomku, teda &apos;\#
         <translation type="vanished">Vymazať momentálny nástroj</translation>
     </message>
     <message>
-        <location filename="../../src/config/shortcutswidget.cpp" line="213"/>
-        <location filename="../../src/config/shortcutswidget.cpp" line="222"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="233"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="238"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="244"/>
         <source>Capture screen</source>
         <translation>Zachytiť obrazovku</translation>
     </message>

--- a/data/translations/Internationalization_sr_SP.ts
+++ b/data/translations/Internationalization_sr_SP.ts
@@ -966,6 +966,16 @@ Please solve them manually in the configuration file.</translation>
         <translation type="unfinished">Користи системска обавештења</translation>
     </message>
     <message>
+        <location filename="../../src/config/generalconf.cpp" line="341"/>
+        <source>Show mouse cursor in screenshots</source>
+        <translation>Прикажи показивач миша на снимцима екрана</translation>
+    </message>
+    <message>
+        <location filename="../../src/config/generalconf.cpp" line="343"/>
+        <source>Include the current Windows mouse cursor in captured images</source>
+        <translation>Укључи тренутни Windows показивач миша у снимљене слике</translation>
+    </message>
+    <message>
         <location filename="../../src/config/generalconf.cpp" line="339"/>
         <source>Show tray icon</source>
         <translation type="unfinished">Иконица на системској полици</translation>
@@ -2545,6 +2555,11 @@ You may need to escape the &apos;#&apos; sign as in &apos;\#FFF&apos;</translati
         <translation>Hot Keys</translation>
     </message>
     <message>
+        <location filename="../../src/config/shortcutswidget.cpp" line="51"/>
+        <source>On native Wayland, global shortcuts are controlled by the desktop environment. Configure the same key there to run 'flameshot gui'. Changes here apply immediately on X11/XWayland.</source>
+        <translation>На изворном Wayland-у глобалним пречицама управља окружење радне површине. Тамо подесите исти тастер за покретање „flameshot gui“. Промене овде одмах важе на X11/XWayland-у.</translation>
+    </message>
+    <message>
         <location filename="../../src/config/shortcutswidget.cpp" line="61"/>
         <source>Available shortcuts in the screen capture mode.</source>
         <translation type="unfinished">Доступне пречице у моду снимка екрана.</translation>
@@ -2697,10 +2712,11 @@ You may need to escape the &apos;#&apos; sign as in &apos;\#FFF&apos;</translati
         <translation type="obsolete">Delete current tool</translation>
     </message>
     <message>
-        <location filename="../../src/config/shortcutswidget.cpp" line="213"/>
-        <location filename="../../src/config/shortcutswidget.cpp" line="222"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="233"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="238"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="244"/>
         <source>Capture screen</source>
-        <translation type="unfinished">Capture screen</translation>
+        <translation>Сними екран</translation>
     </message>
     <message>
         <location filename="../../src/config/shortcutswidget.cpp" line="215"/>

--- a/data/translations/Internationalization_sv_SE.ts
+++ b/data/translations/Internationalization_sv_SE.ts
@@ -962,6 +962,16 @@ Please solve them manually in the configuration file.</translation>
         <translation>Visa skrivbordsnotifieringar</translation>
     </message>
     <message>
+        <location filename="../../src/config/generalconf.cpp" line="341"/>
+        <source>Show mouse cursor in screenshots</source>
+        <translation>Visa muspekaren i skärmbilder</translation>
+    </message>
+    <message>
+        <location filename="../../src/config/generalconf.cpp" line="343"/>
+        <source>Include the current Windows mouse cursor in captured images</source>
+        <translation>Inkludera den aktuella Windows-muspekaren i tagna bilder</translation>
+    </message>
+    <message>
         <location filename="../../src/config/generalconf.cpp" line="339"/>
         <source>Show tray icon</source>
         <translation>Visa ikon i systemfältet</translation>
@@ -2544,6 +2554,11 @@ You may need to escape the &apos;#&apos; sign as in &apos;\#FFF&apos;</translati
         <translation>Hot Keys</translation>
     </message>
     <message>
+        <location filename="../../src/config/shortcutswidget.cpp" line="51"/>
+        <source>On native Wayland, global shortcuts are controlled by the desktop environment. Configure the same key there to run 'flameshot gui'. Changes here apply immediately on X11/XWayland.</source>
+        <translation>På inbyggt Wayland styrs globala kortkommandon av skrivbordsmiljön. Ställ in samma tangent där för att köra ”flameshot gui”. Ändringar här börjar gälla direkt på X11/XWayland.</translation>
+    </message>
+    <message>
         <location filename="../../src/config/shortcutswidget.cpp" line="61"/>
         <source>Available shortcuts in the screen capture mode.</source>
         <translation>Tillgängliga genvägar i skärmklippningsläget.</translation>
@@ -2696,10 +2711,11 @@ You may need to escape the &apos;#&apos; sign as in &apos;\#FFF&apos;</translati
         <translation type="obsolete">Delete current tool</translation>
     </message>
     <message>
-        <location filename="../../src/config/shortcutswidget.cpp" line="213"/>
-        <location filename="../../src/config/shortcutswidget.cpp" line="222"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="233"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="238"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="244"/>
         <source>Capture screen</source>
-        <translation type="unfinished">Capture screen</translation>
+        <translation>Ta skärmbild</translation>
     </message>
     <message>
         <location filename="../../src/config/shortcutswidget.cpp" line="215"/>

--- a/data/translations/Internationalization_sw.ts
+++ b/data/translations/Internationalization_sw.ts
@@ -953,6 +953,16 @@ Please solve them manually in the configuration file.</source>
         <translation type="unfinished">Mostra les notificacions d&apos;escriptori</translation>
     </message>
     <message>
+        <location filename="../../src/config/generalconf.cpp" line="341"/>
+        <source>Show mouse cursor in screenshots</source>
+        <translation>Onyesha kishale cha kipanya katika picha za skrini</translation>
+    </message>
+    <message>
+        <location filename="../../src/config/generalconf.cpp" line="343"/>
+        <source>Include the current Windows mouse cursor in captured images</source>
+        <translation>Jumuisha kishale cha sasa cha kipanya cha Windows katika picha zilizonaswa</translation>
+    </message>
+    <message>
         <location filename="../../src/config/generalconf.cpp" line="339"/>
         <source>Show tray icon</source>
         <translation type="unfinished">Mostra la icona en la barra de tasques</translation>
@@ -2462,6 +2472,11 @@ You may need to escape the &apos;#&apos; sign as in &apos;\#FFF&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../src/config/shortcutswidget.cpp" line="51"/>
+        <source>On native Wayland, global shortcuts are controlled by the desktop environment. Configure the same key there to run 'flameshot gui'. Changes here apply immediately on X11/XWayland.</source>
+        <translation>Kwenye Wayland asilia, mikato ya kimataifa inadhibitiwa na mazingira ya eneo-kazi. Sanidi kitufe hicho hicho huko ili kuendesha 'flameshot gui'. Mabadiliko hapa yanatumika mara moja kwenye X11/XWayland.</translation>
+    </message>
+    <message>
         <location filename="../../src/config/shortcutswidget.cpp" line="61"/>
         <source>Available shortcuts in the screen capture mode.</source>
         <translation type="unfinished">Dreceres disponibles en el mode de captura de pantalla.</translation>
@@ -2572,10 +2587,11 @@ You may need to escape the &apos;#&apos; sign as in &apos;\#FFF&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/config/shortcutswidget.cpp" line="213"/>
-        <location filename="../../src/config/shortcutswidget.cpp" line="222"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="233"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="238"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="244"/>
         <source>Capture screen</source>
-        <translation type="unfinished"></translation>
+        <translation>Nasa skrini</translation>
     </message>
     <message>
         <location filename="../../src/config/shortcutswidget.cpp" line="215"/>

--- a/data/translations/Internationalization_ta.ts
+++ b/data/translations/Internationalization_ta.ts
@@ -944,6 +944,16 @@ Please solve them manually in the configuration file.</source>
         <translation type="unfinished">Mostra les notificacions d&apos;escriptori</translation>
     </message>
     <message>
+        <location filename="../../src/config/generalconf.cpp" line="341"/>
+        <source>Show mouse cursor in screenshots</source>
+        <translation>திரைப்பிடிப்புகளில் சுட்டிக்காட்டியை காட்டு</translation>
+    </message>
+    <message>
+        <location filename="../../src/config/generalconf.cpp" line="343"/>
+        <source>Include the current Windows mouse cursor in captured images</source>
+        <translation>பிடிக்கப்பட்ட படங்களில் தற்போதைய Windows சுட்டிக்காட்டியைச் சேர்</translation>
+    </message>
+    <message>
         <location filename="../../src/config/generalconf.cpp" line="339"/>
         <source>Show tray icon</source>
         <translation type="unfinished">Mostra la icona en la barra de tasques</translation>
@@ -2453,6 +2463,11 @@ You may need to escape the &apos;#&apos; sign as in &apos;\#FFF&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../src/config/shortcutswidget.cpp" line="51"/>
+        <source>On native Wayland, global shortcuts are controlled by the desktop environment. Configure the same key there to run 'flameshot gui'. Changes here apply immediately on X11/XWayland.</source>
+        <translation>நேட்டிவ் Wayland-இல், உலகளாவிய விசைப்பலகை குறுக்குவழிகளை மேசைத்தள சூழல் கட்டுப்படுத்துகிறது. 'flameshot gui' ஐ இயக்க அதே விசையை அங்கே அமைக்கவும். இங்குள்ள மாற்றங்கள் X11/XWayland-இல் உடனடியாக அமலாகும்.</translation>
+    </message>
+    <message>
         <location filename="../../src/config/shortcutswidget.cpp" line="61"/>
         <source>Available shortcuts in the screen capture mode.</source>
         <translation type="unfinished">Dreceres disponibles en el mode de captura de pantalla.</translation>
@@ -2563,10 +2578,11 @@ You may need to escape the &apos;#&apos; sign as in &apos;\#FFF&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/config/shortcutswidget.cpp" line="213"/>
-        <location filename="../../src/config/shortcutswidget.cpp" line="222"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="233"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="238"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="244"/>
         <source>Capture screen</source>
-        <translation type="unfinished"></translation>
+        <translation>திரையைப் பிடி</translation>
     </message>
     <message>
         <location filename="../../src/config/shortcutswidget.cpp" line="215"/>

--- a/data/translations/Internationalization_th.ts
+++ b/data/translations/Internationalization_th.ts
@@ -963,6 +963,16 @@ Please solve them manually in the configuration file.</source>
         <translation>แสดงแจ้งเตือนบนเดสก์ท็อป</translation>
     </message>
     <message>
+        <location filename="../../src/config/generalconf.cpp" line="341"/>
+        <source>Show mouse cursor in screenshots</source>
+        <translation>แสดงตัวชี้เมาส์ในภาพหน้าจอ</translation>
+    </message>
+    <message>
+        <location filename="../../src/config/generalconf.cpp" line="343"/>
+        <source>Include the current Windows mouse cursor in captured images</source>
+        <translation>รวมตัวชี้เมาส์ Windows ปัจจุบันไว้ในภาพที่จับ</translation>
+    </message>
+    <message>
         <location filename="../../src/config/generalconf.cpp" line="339"/>
         <source>Show tray icon</source>
         <translation>แสดงถาดไอคอน</translation>
@@ -2554,6 +2564,11 @@ You may need to escape the &apos;#&apos; sign as in &apos;\#FFF&apos;</source>
         <translation>คีย์ลัด</translation>
     </message>
     <message>
+        <location filename="../../src/config/shortcutswidget.cpp" line="51"/>
+        <source>On native Wayland, global shortcuts are controlled by the desktop environment. Configure the same key there to run 'flameshot gui'. Changes here apply immediately on X11/XWayland.</source>
+        <translation>บน Wayland แบบเนทีฟ ปุ่มลัดส่วนกลางจะถูกควบคุมโดยสภาพแวดล้อมเดสก์ท็อป โปรดกำหนดปุ่มเดียวกันที่นั่นเพื่อเรียกใช้ 'flameshot gui' การเปลี่ยนแปลงที่นี่มีผลทันทีบน X11/XWayland</translation>
+    </message>
+    <message>
         <location filename="../../src/config/shortcutswidget.cpp" line="61"/>
         <source>Available shortcuts in the screen capture mode.</source>
         <translation>ปุ่มลัดที่สามารถใช้งานได้ในโหมดจับภาพหน้าจอ</translation>
@@ -2706,8 +2721,9 @@ You may need to escape the &apos;#&apos; sign as in &apos;\#FFF&apos;</source>
         <translation type="vanished">ลบเครื่องมือปัจจุบัน</translation>
     </message>
     <message>
-        <location filename="../../src/config/shortcutswidget.cpp" line="213"/>
-        <location filename="../../src/config/shortcutswidget.cpp" line="222"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="233"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="238"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="244"/>
         <source>Capture screen</source>
         <translation>จับภาพหน้าจอ</translation>
     </message>

--- a/data/translations/Internationalization_tr.ts
+++ b/data/translations/Internationalization_tr.ts
@@ -974,6 +974,16 @@ Lütfen bunları yapılandırma dosyasında elle çözün.</translation>
         <translation>Masaüstü bildirimlerini göster</translation>
     </message>
     <message>
+        <location filename="../../src/config/generalconf.cpp" line="341"/>
+        <source>Show mouse cursor in screenshots</source>
+        <translation>Ekran görüntülerinde fare imlecini göster</translation>
+    </message>
+    <message>
+        <location filename="../../src/config/generalconf.cpp" line="343"/>
+        <source>Include the current Windows mouse cursor in captured images</source>
+        <translation>Yakalanan görüntülere geçerli Windows fare imlecini ekle</translation>
+    </message>
+    <message>
         <location filename="../../src/config/generalconf.cpp" line="339"/>
         <source>Show tray icon</source>
         <translation>Tepsi simgesini göster</translation>
@@ -2556,6 +2566,11 @@ You may need to escape the &apos;#&apos; sign as in &apos;\#FFF&apos;</source>
         <translation>Kısayol Tuşları</translation>
     </message>
     <message>
+        <location filename="../../src/config/shortcutswidget.cpp" line="51"/>
+        <source>On native Wayland, global shortcuts are controlled by the desktop environment. Configure the same key there to run 'flameshot gui'. Changes here apply immediately on X11/XWayland.</source>
+        <translation>Yerel Wayland'de genel kısayollar masaüstü ortamı tarafından yönetilir. 'flameshot gui' çalıştırmak için aynı tuşu orada yapılandırın. Buradaki değişiklikler X11/XWayland'de hemen uygulanır.</translation>
+    </message>
+    <message>
         <location filename="../../src/config/shortcutswidget.cpp" line="61"/>
         <source>Available shortcuts in the screen capture mode.</source>
         <translation>Ekran yakalama modunda kullanılabilir kısayollar.</translation>
@@ -2708,8 +2723,9 @@ You may need to escape the &apos;#&apos; sign as in &apos;\#FFF&apos;</source>
         <translation type="vanished">Geçerli aracı sil</translation>
     </message>
     <message>
-        <location filename="../../src/config/shortcutswidget.cpp" line="213"/>
-        <location filename="../../src/config/shortcutswidget.cpp" line="222"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="233"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="238"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="244"/>
         <source>Capture screen</source>
         <translation>Ekran görüntüsü al</translation>
     </message>

--- a/data/translations/Internationalization_uk.ts
+++ b/data/translations/Internationalization_uk.ts
@@ -1050,6 +1050,16 @@ Please solve them manually in the configuration file.</source>
         <translation>Показувати сповіщення</translation>
     </message>
     <message>
+        <location filename="../../src/config/generalconf.cpp" line="341"/>
+        <source>Show mouse cursor in screenshots</source>
+        <translation>Показувати вказівник миші на знімках екрана</translation>
+    </message>
+    <message>
+        <location filename="../../src/config/generalconf.cpp" line="343"/>
+        <source>Include the current Windows mouse cursor in captured images</source>
+        <translation>Додавати поточний вказівник миші Windows до захоплених зображень</translation>
+    </message>
+    <message>
         <location filename="../../src/config/generalconf.cpp" line="339"/>
         <source>Show tray icon</source>
         <translation>Показувати значок у лотку</translation>
@@ -2754,6 +2764,11 @@ You can find me in the system tray.</source>
         <translation>Гарячі клавіші</translation>
     </message>
     <message>
+        <location filename="../../src/config/shortcutswidget.cpp" line="51"/>
+        <source>On native Wayland, global shortcuts are controlled by the desktop environment. Configure the same key there to run 'flameshot gui'. Changes here apply immediately on X11/XWayland.</source>
+        <translation>У нативному Wayland глобальними клавіатурними скороченнями керує стільничне середовище. Налаштуйте там ту саму клавішу для запуску «flameshot gui». Зміни тут застосовуються негайно в X11/XWayland.</translation>
+    </message>
+    <message>
         <location filename="../../src/config/shortcutswidget.cpp" line="61"/>
         <source>Available shortcuts in the screen capture mode.</source>
         <translation>Доступні комбінації клавіш у режимі захоплення екрана.</translation>
@@ -2906,10 +2921,11 @@ You can find me in the system tray.</source>
         <translation type="vanished">Видалити поточний інструмент</translation>
     </message>
     <message>
-        <location filename="../../src/config/shortcutswidget.cpp" line="213"/>
-        <location filename="../../src/config/shortcutswidget.cpp" line="222"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="233"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="238"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="244"/>
         <source>Capture screen</source>
-        <translation>Захоплення екрана</translation>
+        <translation>Захопити екран</translation>
     </message>
     <message>
         <location filename="../../src/config/shortcutswidget.cpp" line="215"/>

--- a/data/translations/Internationalization_vi.ts
+++ b/data/translations/Internationalization_vi.ts
@@ -959,6 +959,16 @@ Vui lòng xử lí chúng thủ công trong tệp cấu hình.</translation>
         <translation>Hiển thị thông báo máy tính</translation>
     </message>
     <message>
+        <location filename="../../src/config/generalconf.cpp" line="341"/>
+        <source>Show mouse cursor in screenshots</source>
+        <translation>Hiển thị con trỏ chuột trong ảnh chụp màn hình</translation>
+    </message>
+    <message>
+        <location filename="../../src/config/generalconf.cpp" line="343"/>
+        <source>Include the current Windows mouse cursor in captured images</source>
+        <translation>Bao gồm con trỏ chuột Windows hiện tại trong ảnh đã chụp</translation>
+    </message>
+    <message>
         <location filename="../../src/config/generalconf.cpp" line="339"/>
         <source>Show tray icon</source>
         <translation>Hiển thị biểu tượng trong khay</translation>
@@ -2557,6 +2567,11 @@ Bạn có thể cần phải thoát khỏi dấu &apos;#&apos; như trong &apos;
         <translation>Phím nóng</translation>
     </message>
     <message>
+        <location filename="../../src/config/shortcutswidget.cpp" line="51"/>
+        <source>On native Wayland, global shortcuts are controlled by the desktop environment. Configure the same key there to run 'flameshot gui'. Changes here apply immediately on X11/XWayland.</source>
+        <translation>Trên Wayland gốc, phím tắt toàn cục do môi trường máy tính để bàn quản lý. Hãy cấu hình cùng phím đó tại đây để chạy “flameshot gui”. Các thay đổi ở đây được áp dụng ngay trên X11/XWayland.</translation>
+    </message>
+    <message>
         <location filename="../../src/config/shortcutswidget.cpp" line="61"/>
         <source>Available shortcuts in the screen capture mode.</source>
         <translation>Các phím tắt có sẵn trong chế độ chụp màn hình.</translation>
@@ -2709,8 +2724,9 @@ Bạn có thể cần phải thoát khỏi dấu &apos;#&apos; như trong &apos;
         <translation type="obsolete">Delete current tool</translation>
     </message>
     <message>
-        <location filename="../../src/config/shortcutswidget.cpp" line="213"/>
-        <location filename="../../src/config/shortcutswidget.cpp" line="222"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="233"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="238"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="244"/>
         <source>Capture screen</source>
         <translation>Chụp màn hình</translation>
     </message>

--- a/data/translations/Internationalization_zh_CN.ts
+++ b/data/translations/Internationalization_zh_CN.ts
@@ -1027,6 +1027,16 @@ Please solve them manually in the configuration file.</source>
         <translation>显示桌面通知</translation>
     </message>
     <message>
+        <location filename="../../src/config/generalconf.cpp" line="341"/>
+        <source>Show mouse cursor in screenshots</source>
+        <translation>在屏幕截图中显示鼠标指针</translation>
+    </message>
+    <message>
+        <location filename="../../src/config/generalconf.cpp" line="343"/>
+        <source>Include the current Windows mouse cursor in captured images</source>
+        <translation>在捕获的图像中包含当前 Windows 鼠标指针</translation>
+    </message>
+    <message>
         <location filename="../../src/config/generalconf.cpp" line="339"/>
         <source>Show tray icon</source>
         <translation>显示托盘图标</translation>
@@ -2637,6 +2647,11 @@ You may need to escape the &apos;#&apos; sign as in &apos;\#FFF&apos;</source>
         <translation>热键</translation>
     </message>
     <message>
+        <location filename="../../src/config/shortcutswidget.cpp" line="51"/>
+        <source>On native Wayland, global shortcuts are controlled by the desktop environment. Configure the same key there to run 'flameshot gui'. Changes here apply immediately on X11/XWayland.</source>
+        <translation>在原生 Wayland 中，全局快捷键由桌面环境管理。请在桌面环境中配置相同的按键以运行“flameshot gui”。此处的更改会在 X11/XWayland 上立即生效。</translation>
+    </message>
+    <message>
         <location filename="../../src/config/shortcutswidget.cpp" line="61"/>
         <source>Available shortcuts in the screen capture mode.</source>
         <translation>屏幕捕捉模式中的可用快捷键。</translation>
@@ -2789,8 +2804,9 @@ You may need to escape the &apos;#&apos; sign as in &apos;\#FFF&apos;</source>
         <translation type="vanished">删除当前工具</translation>
     </message>
     <message>
-        <location filename="../../src/config/shortcutswidget.cpp" line="213"/>
-        <location filename="../../src/config/shortcutswidget.cpp" line="222"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="233"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="238"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="244"/>
         <source>Capture screen</source>
         <translation>捕获屏幕</translation>
     </message>

--- a/data/translations/Internationalization_zh_HK.ts
+++ b/data/translations/Internationalization_zh_HK.ts
@@ -1010,6 +1010,16 @@ Please solve them manually in the configuration file.</translation>
         <translation type="unfinished">顯示桌面通知</translation>
     </message>
     <message>
+        <location filename="../../src/config/generalconf.cpp" line="341"/>
+        <source>Show mouse cursor in screenshots</source>
+        <translation>在螢幕截圖中顯示滑鼠游標</translation>
+    </message>
+    <message>
+        <location filename="../../src/config/generalconf.cpp" line="343"/>
+        <source>Include the current Windows mouse cursor in captured images</source>
+        <translation>在擷取的圖像中包含目前的 Windows 滑鼠游標</translation>
+    </message>
+    <message>
         <location filename="../../src/config/generalconf.cpp" line="339"/>
         <source>Show tray icon</source>
         <translation type="unfinished">顯示託盤圖標</translation>
@@ -2576,6 +2586,11 @@ You may need to escape the &apos;#&apos; sign as in &apos;\#FFF&apos;</translati
         <translation>Hot Keys</translation>
     </message>
     <message>
+        <location filename="../../src/config/shortcutswidget.cpp" line="51"/>
+        <source>On native Wayland, global shortcuts are controlled by the desktop environment. Configure the same key there to run 'flameshot gui'. Changes here apply immediately on X11/XWayland.</source>
+        <translation>在原生 Wayland 中，全域快捷鍵由桌面環境管理。請在桌面環境中設定相同按鍵以執行「flameshot gui」。此處的變更會在 X11/XWayland 上立即生效。</translation>
+    </message>
+    <message>
         <location filename="../../src/config/shortcutswidget.cpp" line="61"/>
         <source>Available shortcuts in the screen capture mode.</source>
         <translation type="unfinished">螢幕捕獲模式中的可用快捷鍵。</translation>
@@ -2728,10 +2743,11 @@ You may need to escape the &apos;#&apos; sign as in &apos;\#FFF&apos;</translati
         <translation type="obsolete">Delete current tool</translation>
     </message>
     <message>
-        <location filename="../../src/config/shortcutswidget.cpp" line="213"/>
-        <location filename="../../src/config/shortcutswidget.cpp" line="222"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="233"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="238"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="244"/>
         <source>Capture screen</source>
-        <translation type="unfinished">Capture screen</translation>
+        <translation>擷取螢幕</translation>
     </message>
     <message>
         <location filename="../../src/config/shortcutswidget.cpp" line="215"/>

--- a/data/translations/Internationalization_zh_TW.ts
+++ b/data/translations/Internationalization_zh_TW.ts
@@ -958,6 +958,16 @@ Please solve them manually in the configuration file.</source>
         <translation>顯示桌面通知</translation>
     </message>
     <message>
+        <location filename="../../src/config/generalconf.cpp" line="341"/>
+        <source>Show mouse cursor in screenshots</source>
+        <translation>在螢幕擷取畫面中顯示滑鼠游標</translation>
+    </message>
+    <message>
+        <location filename="../../src/config/generalconf.cpp" line="343"/>
+        <source>Include the current Windows mouse cursor in captured images</source>
+        <translation>在擷取的影像中包含目前的 Windows 滑鼠游標</translation>
+    </message>
+    <message>
         <location filename="../../src/config/generalconf.cpp" line="339"/>
         <source>Show tray icon</source>
         <translation>顯示工具列圖示</translation>
@@ -2536,6 +2546,11 @@ You may need to escape the &apos;#&apos; sign as in &apos;\#FFF&apos;</source>
         <translation>熱鍵</translation>
     </message>
     <message>
+        <location filename="../../src/config/shortcutswidget.cpp" line="51"/>
+        <source>On native Wayland, global shortcuts are controlled by the desktop environment. Configure the same key there to run 'flameshot gui'. Changes here apply immediately on X11/XWayland.</source>
+        <translation>在原生 Wayland 中，全域快速鍵由桌面環境管理。請在桌面環境中設定相同按鍵以執行「flameshot gui」。此處的變更會在 X11/XWayland 上立即生效。</translation>
+    </message>
+    <message>
         <location filename="../../src/config/shortcutswidget.cpp" line="61"/>
         <source>Available shortcuts in the screen capture mode.</source>
         <translation>螢幕擷取模式中的可用快捷鍵。</translation>
@@ -2688,10 +2703,11 @@ You may need to escape the &apos;#&apos; sign as in &apos;\#FFF&apos;</source>
         <translation type="vanished">刪除目前工具</translation>
     </message>
     <message>
-        <location filename="../../src/config/shortcutswidget.cpp" line="213"/>
-        <location filename="../../src/config/shortcutswidget.cpp" line="222"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="233"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="238"/>
+        <location filename="../../src/config/shortcutswidget.cpp" line="244"/>
         <source>Capture screen</source>
-        <translation>擷取畫面</translation>
+        <translation>擷取螢幕</translation>
     </message>
     <message>
         <location filename="../../src/config/shortcutswidget.cpp" line="215"/>

--- a/flameshot.example.ini
+++ b/flameshot.example.ini
@@ -45,6 +45,9 @@
 ;; Show desktop notifications (bool)
 ;showDesktopNotification=true
 ;
+;; Include the mouse cursor in screenshots (Windows only) (bool)
+;includeMouseCursor=false
+;
 ;; Show abort notifications (bool)
 ;showAbortNotification=true
 ;
@@ -127,6 +130,8 @@
 ;
 ;; Shortcut Settings for all tools
 ;[Shortcuts]
+;; Global capture shortcut (Windows only)
+;TAKE_SCREENSHOT=Print
 ;TYPE_ARROW=A
 ;TYPE_CANCEL=Ctrl+Backspace
 ;TYPE_CIRCLE=C

--- a/packaging/flatpak/org.flameshot.Flameshot.yml
+++ b/packaging/flatpak/org.flameshot.Flameshot.yml
@@ -24,8 +24,9 @@ modules:
   - name: flameshot
     buildsystem: cmake-ninja
     config-opts:
-      - -DCMAKE_BUILD_TYPE=Release 
+      - -DCMAKE_BUILD_TYPE=Release
       - -DUSE_WAYLAND_CLIPBOARD=1
+      - -DFLAMESHOT_QHOTKEY_SOURCE_DIR=/run/build/flameshot/external/QHotkey
     sources:
       - type: git
         url: https://gitlab.com/mattbas/Qt-Color-Widgets.git
@@ -38,6 +39,11 @@ modules:
         commit: 3186a158f8e6565e89f5983b4028c892737844ff
         dest: external/KDSingleApplication
         
+      - type: git
+        url: https://github.com/flameshot-org/QHotkey.git
+        branch: master
+        dest: external/QHotkey
+
       - type: git
         url: https://github.com/flameshot-org/flameshot.git
         branch: master

--- a/packaging/rpm/flameshot.spec
+++ b/packaging/rpm/flameshot.spec
@@ -6,6 +6,7 @@ Summary: Powerful yet simple to use screenshot software
 License: GPL-3.0-or-later
 URL:     https://github.com/flameshot-org/flameshot
 Source0: %{url}/archive/v%{version}/%{name}-%{version}.tar.gz
+Source1: https://github.com/flameshot-org/QHotkey/archive/refs/heads/master.tar.gz
 Vendor:  Flameshot
 
 BuildRequires: git
@@ -75,6 +76,10 @@ Features:
 
 %prep
 %autosetup -p1
+mkdir -p external
+rm -rf external/QHotkey external/QHotkey-master
+%{__tar} -xzf %{SOURCE1} -C external
+mv external/QHotkey-master external/QHotkey
 
 %build
 %if 0%{?suse_version}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -233,6 +233,13 @@ if (APPLE)
     )
 endif ()
 
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    target_link_libraries(
+            flameshot
+            qhotkey
+    )
+endif()
+
 
 set(_src_root_path ${CMAKE_CURRENT_SOURCE_DIR})
 file(GLOB_RECURSE _source_list LIST_DIRECTORIES false

--- a/src/config/generalconf.cpp
+++ b/src/config/generalconf.cpp
@@ -37,6 +37,9 @@ GeneralConf::GeneralConf(QWidget* parent)
     initAutoCloseIdleDaemon();
     initShowTrayIcon();
     initShowDesktopNotification();
+#if defined(Q_OS_WIN)
+    initIncludeMouseCursor();
+#endif
     initShowAbortNotification();
 #if !defined(DISABLE_UPDATE_CHECKER)
     initCheckForUpdates();
@@ -90,6 +93,9 @@ void GeneralConf::_updateComponents(bool allowEmptySavePath)
     m_helpMessage->setChecked(config.showHelp());
     m_sidePanelButton->setChecked(config.showSidePanelButton());
     m_sysNotifications->setChecked(config.showDesktopNotification());
+#if defined(Q_OS_WIN)
+    m_includeMouseCursor->setChecked(config.includeMouseCursor());
+#endif
     m_abortNotifications->setChecked(config.showAbortNotification());
     m_autostart->setChecked(config.startupLaunch());
     m_saveAfterCopy->setChecked(config.saveAfterCopy());
@@ -162,6 +168,13 @@ void GeneralConf::showDesktopNotificationChanged(bool checked)
 {
     ConfigHandler().setShowDesktopNotification(checked);
 }
+
+#if defined(Q_OS_WIN)
+void GeneralConf::includeMouseCursorChanged(bool checked)
+{
+    ConfigHandler().setIncludeMouseCursor(checked);
+}
+#endif
 
 void GeneralConf::showAbortNotificationChanged(bool checked)
 {
@@ -320,6 +333,22 @@ void GeneralConf::initShowDesktopNotification()
             this,
             &GeneralConf::showDesktopNotificationChanged);
 }
+
+#if defined(Q_OS_WIN)
+void GeneralConf::initIncludeMouseCursor()
+{
+    m_includeMouseCursor =
+      new QCheckBox(tr("Show mouse cursor in screenshots"), this);
+    m_includeMouseCursor->setToolTip(
+      tr("Include the current Windows mouse cursor in captured images"));
+    m_scrollAreaLayout->addWidget(m_includeMouseCursor);
+
+    connect(m_includeMouseCursor,
+            &QCheckBox::clicked,
+            this,
+            &GeneralConf::includeMouseCursorChanged);
+}
+#endif
 
 void GeneralConf::initShowAbortNotification()
 {

--- a/src/config/generalconf.h
+++ b/src/config/generalconf.h
@@ -37,6 +37,9 @@ private slots:
     void saveLastRegion(bool checked);
     void showSidePanelButtonChanged(bool checked);
     void showDesktopNotificationChanged(bool checked);
+#if defined(Q_OS_WIN)
+    void includeMouseCursorChanged(bool checked);
+#endif
     void showAbortNotificationChanged(bool checked);
 #if !defined(DISABLE_UPDATE_CHECKER)
     void checkForUpdatesChanged(bool checked);
@@ -90,6 +93,9 @@ private:
     void initSaveAfterCopy();
     void initScrollArea();
     void initShowDesktopNotification();
+#if defined(Q_OS_WIN)
+    void initIncludeMouseCursor();
+#endif
     void initShowAbortNotification();
     void initShowHelp();
     void initShowMagnifier();
@@ -125,6 +131,9 @@ private:
     QVBoxLayout* m_scrollAreaLayout;
     QScrollArea* m_scrollArea;
     QCheckBox* m_sysNotifications;
+#if defined(Q_OS_WIN)
+    QCheckBox* m_includeMouseCursor;
+#endif
     QCheckBox* m_abortNotifications;
     QCheckBox* m_showTray;
     QCheckBox* m_helpMessage;

--- a/src/config/setshortcutwidget.cpp
+++ b/src/config/setshortcutwidget.cpp
@@ -5,14 +5,17 @@
 #include "utils/globalvalues.h"
 
 #include <QIcon>
+#include <QKeyCombination>
 #include <QKeyEvent>
 #include <QLabel>
 #include <QLayout>
 #include <QPixmap>
 #include <QTimer>
+#if defined(Q_OS_WIN)
+#include <qt_windows.h>
+#endif
 
-SetShortcutDialog::SetShortcutDialog(QDialog* parent,
-                                     const QString& shortcutName)
+SetShortcutDialog::SetShortcutDialog(QDialog* parent)
   : QDialog(parent)
 {
     setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
@@ -44,18 +47,6 @@ SetShortcutDialog::SetShortcutDialog(QDialog* parent,
       tr("Press Esc to cancel or Backspace to disable the keyboard shortcut.");
 #endif
 
-    auto restartMessageAdded = false;
-    if (shortcutName == "TAKE_SCREENSHOT" && restartMessageAdded == false) {
-        msg +=
-          "\n" + tr("Flameshot must be restarted for changes to take effect.");
-        restartMessageAdded = true;
-    }
-    if (shortcutName == "SCREENSHOT_HISTORY" && restartMessageAdded == false) {
-        msg +=
-          "\n" + tr("Flameshot must be restarted for changes to take effect.");
-        restartMessageAdded = true;
-    }
-
     auto* infoBottom = new QLabel(msg);
     infoBottom->setMargin(10);
     infoBottom->setAlignment(Qt::AlignCenter);
@@ -65,10 +56,43 @@ SetShortcutDialog::SetShortcutDialog(QDialog* parent,
     QTimer::singleShot(0, this, &SetShortcutDialog::startCapture);
 }
 
+SetShortcutDialog::~SetShortcutDialog()
+{
+    stopCapture();
+}
+
 void SetShortcutDialog::startCapture()
 {
     grabKeyboard(); // Call AFTER show()!
     setFocus();
+#if defined(Q_OS_WIN)
+    // Print Screen can be delivered as WM_HOTKEY or only as a key-release
+    // event on Windows. Register it temporarily while this dialog is active
+    // so it can be selected even after the capture shortcut was changed away
+    // from PrtSc. If registration fails, the key/native event fallbacks below
+    // can still capture it.
+    constexpr int printScreenCaptureHotkeyId = 0x4653; // "FS"
+    m_printScreenHotkeyRegistered =
+      RegisterHotKey(reinterpret_cast<HWND>(winId()),
+                     printScreenCaptureHotkeyId,
+                     0,
+                     VK_SNAPSHOT);
+#endif
+}
+
+void SetShortcutDialog::stopCapture()
+{
+    if (QWidget::keyboardGrabber() == this) {
+        releaseKeyboard();
+    }
+#if defined(Q_OS_WIN)
+    if (m_printScreenHotkeyRegistered) {
+        constexpr int printScreenCaptureHotkeyId = 0x4653;
+        UnregisterHotKey(reinterpret_cast<HWND>(winId()),
+                         printScreenCaptureHotkeyId);
+        m_printScreenHotkeyRegistered = false;
+    }
+#endif
 }
 
 const QKeySequence& SetShortcutDialog::shortcut()
@@ -76,44 +100,115 @@ const QKeySequence& SetShortcutDialog::shortcut()
     return m_ks;
 }
 
-void SetShortcutDialog::keyPressEvent(QKeyEvent* ke)
+void SetShortcutDialog::updateShortcutFromKeyEvent(QKeyEvent* event)
 {
-    Qt::KeyboardModifiers mods = ke->modifiers();
+    int key = event->key();
+#if defined(Q_OS_WIN)
+    // Qt can report Print Screen only through nativeVirtualKey(), especially
+    // when Windows emits no translated key-press event for VK_SNAPSHOT.
+    if (event->nativeVirtualKey() == VK_SNAPSHOT) {
+        key = Qt::Key_Print;
+    }
+#endif
 
-    if (mods & Qt::ShiftModifier) {
-        m_modifier += "Shift+";
-    }
-    if (mods & Qt::ControlModifier) {
-        m_modifier += "Ctrl+";
-    }
-    if (mods & Qt::AltModifier) {
-        m_modifier += "Alt+";
-    }
-    // ke->key() == Qt::Key_Meta required on Windows to grab Win key
-    if (ke->modifiers() & Qt::MetaModifier || ke->key() == Qt::Key_Meta) {
-        m_modifier += "Meta+";
+    if (key == 0 || key == Qt::Key_unknown || key == Qt::Key_Shift ||
+        key == Qt::Key_Control || key == Qt::Key_Alt || key == Qt::Key_Meta) {
+        return;
     }
 
-    QString key = QKeySequence(ke->key()).toString();
-    m_ks = QKeySequence(m_modifier + key);
+    const Qt::KeyboardModifiers modifiers =
+      event->modifiers() & (Qt::ShiftModifier | Qt::ControlModifier |
+                            Qt::AltModifier | Qt::MetaModifier);
+    m_ks = QKeySequence(QKeyCombination(modifiers, static_cast<Qt::Key>(key)));
+}
+
+void SetShortcutDialog::keyPressEvent(QKeyEvent* event)
+{
+    updateShortcutFromKeyEvent(event);
+    event->accept();
 }
 
 void SetShortcutDialog::keyReleaseEvent(QKeyEvent* event)
 {
+    // Print Screen commonly arrives as a release-only event on Windows.
+    if (m_ks.isEmpty()) {
+        updateShortcutFromKeyEvent(event);
+    }
+
     if (m_ks == QKeySequence(Qt::Key_Escape)) {
         reject();
+        return;
     }
-    accept();
+
+    if (!m_ks.isEmpty()) {
+        accept();
+    }
 }
+
+#if defined(Q_OS_WIN)
+bool SetShortcutDialog::nativeEvent(const QByteArray& eventType,
+                                    void* message,
+                                    qintptr* result)
+{
+    Q_UNUSED(eventType)
+
+    auto* msg = static_cast<MSG*>(message);
+    if (msg == nullptr) {
+        return QDialog::nativeEvent(eventType, message, result);
+    }
+
+    constexpr int printScreenCaptureHotkeyId = 0x4653;
+    if (msg->message == WM_HOTKEY &&
+        static_cast<int>(msg->wParam) == printScreenCaptureHotkeyId) {
+        m_ks = QKeySequence(Qt::Key_Print);
+        if (result != nullptr) {
+            *result = 0;
+        }
+        QTimer::singleShot(0, this, &SetShortcutDialog::accept);
+        return true;
+    }
+
+    const bool isKeyMessage =
+      msg->message == WM_KEYDOWN || msg->message == WM_SYSKEYDOWN ||
+      msg->message == WM_KEYUP || msg->message == WM_SYSKEYUP;
+    if (isKeyMessage && msg->wParam == VK_SNAPSHOT) {
+        Qt::KeyboardModifiers modifiers = Qt::NoModifier;
+        if (GetKeyState(VK_SHIFT) & 0x8000) {
+            modifiers |= Qt::ShiftModifier;
+        }
+        if (GetKeyState(VK_CONTROL) & 0x8000) {
+            modifiers |= Qt::ControlModifier;
+        }
+        if (GetKeyState(VK_MENU) & 0x8000) {
+            modifiers |= Qt::AltModifier;
+        }
+        if ((GetKeyState(VK_LWIN) & 0x8000) ||
+            (GetKeyState(VK_RWIN) & 0x8000)) {
+            modifiers |= Qt::MetaModifier;
+        }
+
+        m_ks = QKeySequence(QKeyCombination(modifiers, Qt::Key_Print));
+        if (result != nullptr) {
+            *result = 0;
+        }
+        if (msg->message == WM_KEYUP || msg->message == WM_SYSKEYUP) {
+            QTimer::singleShot(0, this, &SetShortcutDialog::accept);
+        }
+        return true;
+    }
+
+    return QDialog::nativeEvent(eventType, message, result);
+}
+#endif
 
 void SetShortcutDialog::accept()
 {
-    releaseKeyboard();
+    stopCapture();
     QDialog::accept();
 }
 
 void SetShortcutDialog::reject()
 {
-    releaseKeyboard();
+    stopCapture();
     QDialog::reject();
 }

--- a/src/config/setshortcutwidget.h
+++ b/src/config/setshortcutwidget.h
@@ -7,19 +7,25 @@
 #include <QKeySequence>
 #include <QObject>
 
+class QKeyEvent;
 class QVBoxLayout;
 
 class SetShortcutDialog : public QDialog
 {
     Q_OBJECT
 public:
-    explicit SetShortcutDialog(QDialog* parent = nullptr,
-                               const QString& shortcutName = "");
+    explicit SetShortcutDialog(QDialog* parent = nullptr);
+    ~SetShortcutDialog() override;
     const QKeySequence& shortcut();
 
 public:
     void keyPressEvent(QKeyEvent*) override;
     void keyReleaseEvent(QKeyEvent* event) override;
+#if defined(Q_OS_WIN)
+    bool nativeEvent(const QByteArray& eventType,
+                     void* message,
+                     qintptr* result) override;
+#endif
 
 private slots:
     void accept() override;
@@ -27,8 +33,12 @@ private slots:
 
 private:
     void startCapture();
+    void stopCapture();
+    void updateShortcutFromKeyEvent(QKeyEvent* event);
 
     QVBoxLayout* m_layout;
-    QString m_modifier;
     QKeySequence m_ks;
+#if defined(Q_OS_WIN)
+    bool m_printScreenHotkeyRegistered = false;
+#endif
 };

--- a/src/config/shortcutswidget.cpp
+++ b/src/config/shortcutswidget.cpp
@@ -11,6 +11,7 @@
 #include <QCheckBox>
 #include <QCursor>
 #include <QDir>
+#include <QGuiApplication>
 #include <QHeaderView>
 #include <QIcon>
 #include <QKeyEvent>
@@ -43,6 +44,19 @@ ShortcutsWidget::ShortcutsWidget(QWidget* parent)
 #endif
 
     initInfoTable();
+#if defined(Q_OS_LINUX)
+    if (!QGuiApplication::platformName().contains(QStringLiteral("xcb"),
+                                                  Qt::CaseInsensitive)) {
+        auto* waylandNotice = new QLabel(
+          tr("On native Wayland, global shortcuts are controlled by the "
+             "desktop environment. Configure the same key there to run "
+             "'flameshot gui'. Changes here apply immediately on "
+             "X11/XWayland."),
+          this);
+        waylandNotice->setWordWrap(true);
+        m_layout->addWidget(waylandNotice);
+    }
+#endif
     connect(ConfigHandler::getInstance(),
             &ConfigHandler::fileChanged,
             this,
@@ -137,7 +151,7 @@ void ShortcutsWidget::onShortcutCellClicked(int row, int col)
         }
 
         QString shortcutName = m_shortcuts.at(row).at(0);
-        auto* setShortcutDialog = new SetShortcutDialog(nullptr, shortcutName);
+        auto* setShortcutDialog = new SetShortcutDialog(nullptr);
         if (0 != setShortcutDialog->exec()) {
             QKeySequence shortcutValue = setShortcutDialog->shortcut();
 
@@ -152,6 +166,12 @@ void ShortcutsWidget::onShortcutCellClicked(int row, int col)
             }
 #endif
             if (m_config.setShortcut(shortcutName, shortcutValue.toString())) {
+#if defined(Q_OS_WIN)
+                if (shortcutName == "TAKE_SCREENSHOT" &&
+                    shortcutValue == QKeySequence(Qt::Key_Print)) {
+                    checkPrintScreenForcesSnipping();
+                }
+#endif
                 populateInfoTable();
             }
         }
@@ -215,19 +235,13 @@ void ShortcutsWidget::loadShortcuts()
     appendShortcut("SCREENSHOT_HISTORY", tr("Screenshot history"));
 #endif
 #elif defined(Q_OS_WIN)
-    if (this->isPrintScreenKeyForSnippingDisabled()) {
-        m_shortcuts << (QStringList() << "" << QObject::tr("Capture screen")
-                                      << "Print Screen");
-    }
     appendShortcut("TAKE_SCREENSHOT", tr("Capture screen"));
 #ifdef ENABLE_IMGUR
     m_shortcuts << (QStringList() << "" << QObject::tr("Screenshot history")
                                   << "Shift+Print Screen");
 #endif
-#else
-    // TODO - Linux doesn't support global shortcuts for (XServer and Wayland),
-    // possibly it will be solved in the QHotKey library later. So it is
-    // disabled for now.
+#elif defined(Q_OS_LINUX)
+    appendShortcut("TAKE_SCREENSHOT", tr("Capture screen"));
 #endif
     m_shortcuts << (QStringList()
                     << "" << QObject::tr("Show color picker") << "Right Click");
@@ -260,6 +274,12 @@ const QString& ShortcutsWidget::nativeOSHotKeyText(const QString& text)
 #if defined(Q_OS_WIN)
 void ShortcutsWidget::checkPrintScreenForcesSnipping()
 {
+    const QKeySequence captureShortcut(
+      ConfigHandler().shortcut("TAKE_SCREENSHOT"));
+    if (captureShortcut != QKeySequence(Qt::Key_Print)) {
+        return;
+    }
+
     if (!isPrintScreenKeyForSnippingDisabled() &&
         !ConfigHandler().ignorePrntScrForcesSnipping()) {
         QMessageBox msgBox;

--- a/src/core/flameshot.cpp
+++ b/src/core/flameshot.cpp
@@ -3,7 +3,7 @@
 
 #include "flameshot.h"
 #include "core/flameshotdaemon.h"
-#if defined(Q_OS_MACOS) || defined(Q_OS_WIN)
+#if defined(Q_OS_MACOS) || defined(Q_OS_WIN) || defined(Q_OS_LINUX)
 #include "qhotkey.h"
 #endif
 
@@ -65,6 +65,7 @@ constexpr const char* visibleInDockProperty = "_visibleInDock";
 #include <QDebug>
 #include <QDesktopServices>
 #include <QFile>
+#include <QGuiApplication>
 #include <QMessageBox>
 #include <QThread>
 #include <QTimer>
@@ -78,10 +79,10 @@ constexpr const char* visibleInDockProperty = "_visibleInDock";
 Flameshot::Flameshot()
   : m_haveExternalWidget(false)
   , m_captureWindow(nullptr)
-#if (defined(Q_OS_MACOS) || defined(Q_OS_WIN))
+#if defined(Q_OS_MACOS) || defined(Q_OS_WIN) || defined(Q_OS_LINUX)
   , m_HotkeyScreenshotCapture(nullptr)
 #endif
-#if (defined(Q_OS_MACOS) && ENABLE_IMGUR)
+#if defined(Q_OS_MACOS) && defined(ENABLE_IMGUR)
   , m_HotkeyScreenshotHistory(nullptr)
 #endif
 {
@@ -94,24 +95,103 @@ Flameshot::Flameshot()
         CGRequestScreenCaptureAccess();
     }
 #endif
-#if (defined(Q_OS_MACOS) || defined(Q_OS_WIN))
-    // Set global shortcuts for MacOS or Windows
-    m_HotkeyScreenshotCapture = new QHotkey(
-      QKeySequence(ConfigHandler().shortcut("TAKE_SCREENSHOT")), true, this);
-    QObject::connect(m_HotkeyScreenshotCapture,
-                     &QHotkey::activated,
-                     qApp,
-                     [this]() { gui(); });
+#if defined(Q_OS_MACOS) || defined(Q_OS_WIN) || defined(Q_OS_LINUX)
+    QObject::connect(
+      ConfigHandler::getInstance(),
+      &ConfigHandler::shortcutChanged,
+      this,
+      [this](const QString& actionName, const QString& shortcut) {
+          if (actionName == QStringLiteral("TAKE_SCREENSHOT")) {
+              reloadCaptureShortcut(shortcut);
+          }
+#if defined(Q_OS_MACOS) && defined(ENABLE_IMGUR)
+          else if (actionName == QStringLiteral("SCREENSHOT_HISTORY")) {
+              reloadHistoryShortcut(shortcut);
+          }
 #endif
-#if (defined(Q_OS_MACOS) && ENABLE_IMGUR)
-    m_HotkeyScreenshotHistory = new QHotkey(
-      QKeySequence(ConfigHandler().shortcut("SCREENSHOT_HISTORY")), true, this);
-    QObject::connect(m_HotkeyScreenshotHistory,
-                     &QHotkey::activated,
-                     qApp,
-                     [this]() { history(); });
+      });
+
+    // Also reload shortcuts changed by editing flameshot.ini externally.
+    QObject::connect(
+      ConfigHandler::getInstance(),
+      &ConfigHandler::fileChanged,
+      this,
+      [this]() {
+          reloadCaptureShortcut(ConfigHandler().shortcut("TAKE_SCREENSHOT"));
+#if defined(Q_OS_MACOS) && defined(ENABLE_IMGUR)
+          reloadHistoryShortcut(ConfigHandler().shortcut("SCREENSHOT_HISTORY"));
+#endif
+      });
+
+    reloadCaptureShortcut(ConfigHandler().shortcut("TAKE_SCREENSHOT"));
+#endif
+#if defined(Q_OS_MACOS) && defined(ENABLE_IMGUR)
+    reloadHistoryShortcut(ConfigHandler().shortcut("SCREENSHOT_HISTORY"));
 #endif
 }
+
+#if defined(Q_OS_MACOS) || defined(Q_OS_WIN) || defined(Q_OS_LINUX)
+void Flameshot::reloadCaptureShortcut(const QString& shortcut)
+{
+    if (shortcut == m_captureShortcut) {
+        return;
+    }
+
+    delete m_HotkeyScreenshotCapture;
+    m_HotkeyScreenshotCapture = nullptr;
+    m_captureShortcut = shortcut;
+
+    const QKeySequence captureShortcut(shortcut);
+    if (captureShortcut.isEmpty()) {
+        return;
+    }
+
+#if defined(Q_OS_WIN)
+    // Plain Print Screen is managed by GlobalShortcutFilter through the native
+    // Windows API. QHotkey handles every other configured shortcut.
+    if (captureShortcut == QKeySequence(Qt::Key_Print)) {
+        return;
+    }
+#elif defined(Q_OS_LINUX)
+    // QHotkey's Linux backend uses X11. It works on X11 and XWayland, while
+    // native Wayland requires the compositor/desktop to own the shortcut.
+    if (!QGuiApplication::platformName().contains(QStringLiteral("xcb"),
+                                                  Qt::CaseInsensitive)) {
+        return;
+    }
+#endif
+
+    m_HotkeyScreenshotCapture = new QHotkey(captureShortcut, true, this);
+    QObject::connect(m_HotkeyScreenshotCapture,
+                     &QHotkey::activated,
+                     this,
+                     [this]() { gui(); });
+}
+#endif
+
+#if defined(Q_OS_MACOS) && defined(ENABLE_IMGUR)
+void Flameshot::reloadHistoryShortcut(const QString& shortcut)
+{
+    if (shortcut == m_historyShortcut) {
+        return;
+    }
+
+    delete m_HotkeyScreenshotHistory;
+    m_HotkeyScreenshotHistory = nullptr;
+    m_historyShortcut = shortcut;
+
+    const QKeySequence historyShortcut(shortcut);
+    if (historyShortcut.isEmpty()) {
+        return;
+    }
+
+    m_HotkeyScreenshotHistory = new QHotkey(historyShortcut, true, this);
+    QObject::connect(m_HotkeyScreenshotHistory,
+                     &QHotkey::activated,
+                     this,
+                     [this]() { history(); });
+}
+#endif
 
 Flameshot* Flameshot::instance()
 {

--- a/src/core/flameshot.h
+++ b/src/core/flameshot.h
@@ -8,6 +8,7 @@
 
 #include <QObject>
 #include <QPointer>
+#include <QString>
 #include <QVersionNumber>
 #include <QWindow>
 
@@ -18,7 +19,7 @@ class QWidget;
 #ifdef ENABLE_IMGUR
 class UploadHistory;
 #endif
-#if (defined(Q_OS_MACOS) || defined(Q_OS_WIN))
+#if defined(Q_OS_MACOS) || defined(Q_OS_WIN) || defined(Q_OS_LINUX)
 class QHotkey;
 #endif
 
@@ -83,6 +84,12 @@ public slots:
 private:
     Flameshot();
     bool resolveAnyConfigErrors();
+#if defined(Q_OS_MACOS) || defined(Q_OS_WIN) || defined(Q_OS_LINUX)
+    void reloadCaptureShortcut(const QString& shortcut);
+#endif
+#if defined(Q_OS_MACOS) && defined(ENABLE_IMGUR)
+    void reloadHistoryShortcut(const QString& shortcut);
+#endif
 
     // class members
     static Origin m_origin;
@@ -102,10 +109,12 @@ private:
     int m_dockIconVisibleCount = 0;
 #endif
 
-#if (defined(Q_OS_MACOS) || defined(Q_OS_WIN))
+#if defined(Q_OS_MACOS) || defined(Q_OS_WIN) || defined(Q_OS_LINUX)
     QHotkey* m_HotkeyScreenshotCapture;
+    QString m_captureShortcut;
 #endif
-#if (defined(Q_OS_MACOS) && ENABLE_IMGUR)
+#if defined(Q_OS_MACOS) && defined(ENABLE_IMGUR)
     QHotkey* m_HotkeyScreenshotHistory;
+    QString m_historyShortcut;
 #endif
 };

--- a/src/core/flameshotdaemon.h
+++ b/src/core/flameshotdaemon.h
@@ -3,6 +3,10 @@
 #include <QByteArray>
 #include <QObject>
 
+#if defined(Q_OS_MACOS) || defined(Q_OS_WIN) || defined(Q_OS_LINUX)
+#include "qhotkey.h"
+#endif
+
 #if !(defined(Q_OS_MACOS) || defined(Q_OS_WIN))
 #include <QtDBus/QDBusAbstractAdaptor>
 #endif

--- a/src/core/globalshortcutfilter.cpp
+++ b/src/core/globalshortcutfilter.cpp
@@ -3,19 +3,68 @@
 
 #include "globalshortcutfilter.h"
 #include "core/flameshot.h"
+#include "utils/confighandler.h"
+
+#include <QKeySequence>
 
 #include <qt_windows.h>
 
 GlobalShortcutFilter::GlobalShortcutFilter(QObject* parent)
   : QObject(parent)
 {
-    // Forced Print Screen
-    if (RegisterHotKey(NULL, 1, 0, VK_SNAPSHOT)) {
-        // ok - capture screen
+    QObject::connect(
+      ConfigHandler::getInstance(),
+      &ConfigHandler::shortcutChanged,
+      this,
+      [this](const QString& actionName, const QString& shortcut) {
+          if (actionName == QStringLiteral("TAKE_SCREENSHOT")) {
+              reloadPrintScreenShortcut(shortcut);
+          }
+      });
+    QObject::connect(ConfigHandler::getInstance(),
+                     &ConfigHandler::fileChanged,
+                     this,
+                     [this]() {
+                         reloadPrintScreenShortcut(
+                           ConfigHandler().shortcut("TAKE_SCREENSHOT"));
+                     });
+
+    reloadPrintScreenShortcut(ConfigHandler().shortcut("TAKE_SCREENSHOT"));
+
+#ifdef ENABLE_IMGUR
+    m_historyShortcutRegistered =
+      RegisterHotKey(NULL, 2, MOD_SHIFT, VK_SNAPSHOT) != FALSE;
+#endif
+}
+
+GlobalShortcutFilter::~GlobalShortcutFilter()
+{
+    if (m_printScreenRegistered) {
+        UnregisterHotKey(NULL, 1);
+    }
+#ifdef ENABLE_IMGUR
+    if (m_historyShortcutRegistered) {
+        UnregisterHotKey(NULL, 2);
+    }
+#endif
+}
+
+void GlobalShortcutFilter::reloadPrintScreenShortcut(const QString& shortcut)
+{
+    const bool shouldRegister =
+      QKeySequence(shortcut) == QKeySequence(Qt::Key_Print);
+
+    if (!shouldRegister) {
+        if (m_printScreenRegistered) {
+            UnregisterHotKey(NULL, 1);
+            m_printScreenRegistered = false;
+        }
+        return;
     }
 
-    if (RegisterHotKey(NULL, 2, MOD_SHIFT, VK_SNAPSHOT)) {
-        // ok - show screenshots history
+    if (!m_printScreenRegistered) {
+        m_printScreenRegistered =
+          RegisterHotKey(NULL, 1, 0, VK_SNAPSHOT) != FALSE;
     }
 }
 
@@ -28,8 +77,6 @@ bool GlobalShortcutFilter::nativeEventFilter(const QByteArray& eventType,
 
     MSG* msg = static_cast<MSG*>(message);
     if (msg->message == WM_HOTKEY) {
-        // TODO: this is just a temporary workaround; proper global
-        // support would need custom shortcuts defined by the user.
         const quint32 keycode = HIWORD(msg->lParam);
         const quint32 modifiers = LOWORD(msg->lParam);
 #ifdef ENABLE_IMGUR
@@ -39,8 +86,10 @@ bool GlobalShortcutFilter::nativeEventFilter(const QByteArray& eventType,
             return true;
         }
 #endif
-        // Capture screen
-        if (VK_SNAPSHOT == keycode && 0 == modifiers) {
+        // Capture screen only when plain Print Screen is the configured
+        // TAKE_SCREENSHOT shortcut and native registration succeeded.
+        if (m_printScreenRegistered && VK_SNAPSHOT == keycode &&
+            0 == modifiers) {
             Flameshot::instance()->requestCapture(
               CaptureRequest(CaptureRequest::GRAPHICAL_MODE));
             return true;

--- a/src/core/globalshortcutfilter.h
+++ b/src/core/globalshortcutfilter.h
@@ -13,12 +13,18 @@ class GlobalShortcutFilter
     Q_OBJECT
 public:
     explicit GlobalShortcutFilter(QObject* parent = nullptr);
+    ~GlobalShortcutFilter() override;
 
     bool nativeEventFilter(const QByteArray& eventType,
                            void* message,
                            qintptr* result);
 
 private:
+    void reloadPrintScreenShortcut(const QString& shortcut);
+
+    bool m_printScreenRegistered = false;
+    bool m_historyShortcutRegistered = false;
+
     quint32 getNativeModifier(Qt::KeyboardModifiers modifiers);
     quint32 nativeKeycode(Qt::Key key);
     bool registerShortcut(quint32 nativeKey, quint32 nativeMods);

--- a/src/utils/confighandler.cpp
+++ b/src/utils/confighandler.cpp
@@ -77,6 +77,9 @@ static QMap<class QString, QSharedPointer<ValueHandler>>
     OPTION("showHelp"                    ,Bool               ( true          )),
     OPTION("showSidePanelButton"         ,Bool               ( true          )),
     OPTION("showDesktopNotification"     ,Bool               ( true          )),
+#if defined(Q_OS_WIN)
+    OPTION("includeMouseCursor"          ,Bool               ( false         )),
+#endif
     OPTION("showAbortNotification"       ,Bool               ( true          )),
     OPTION("disabledTrayIcon"            ,Bool               ( false         )),
     OPTION("historyConfirmationToDelete" ,Bool               ( true          )),
@@ -196,8 +199,8 @@ static QMap<QString, QSharedPointer<KeySequence>> recognizedShortcuts = {
     SHORTCUT("TYPE_MOVE_UP"             ,   "Up"                    ),
     SHORTCUT("TYPE_MOVE_DOWN"           ,   "Down"                  ),
     SHORTCUT("TYPE_COMMIT_CURRENT_TOOL" ,   "Ctrl+Return"           ),
-#if defined(Q_OS_WIN)
-    SHORTCUT("TAKE_SCREENSHOT"          ,   "Meta+Shift+x"          ),
+#if defined(Q_OS_WIN) || defined(Q_OS_LINUX)
+    SHORTCUT("TAKE_SCREENSHOT"          ,   "Print"                 ),
 #endif
 #if defined(Q_OS_MACOS)
     SHORTCUT("TYPE_DELETE_CURRENT_TOOL" ,   "Backspace"             ),
@@ -444,6 +447,7 @@ bool ConfigHandler::setShortcut(const QString& actionName,
         return false;
     }
 
+    const QString previousShortcut = this->shortcut(actionName);
     bool errorFlag = false;
 
     m_settings.beginGroup(CONFIG_GROUP_SHORTCUTS);
@@ -453,7 +457,6 @@ bool ConfigHandler::setShortcut(const QString& actionName,
         // do not allow to set reserved shortcuts
         errorFlag = true;
     } else {
-        errorFlag = false;
         // Make no difference for Return and Enter keys
         QString newShortcut = KeySequence().value(shortcut).toString();
         for (auto& otherAction : m_settings.allKeys()) {
@@ -471,6 +474,14 @@ bool ConfigHandler::setShortcut(const QString& actionName,
     }
 done:
     m_settings.endGroup();
+
+    if (!errorFlag) {
+        m_settings.sync();
+        const QString updatedShortcut = this->shortcut(actionName);
+        if (updatedShortcut != previousShortcut) {
+            emit getInstance()->shortcutChanged(actionName, updatedShortcut);
+        }
+    }
     return !errorFlag;
 }
 

--- a/src/utils/confighandler.h
+++ b/src/utils/confighandler.h
@@ -88,6 +88,9 @@ public:
     CONFIG_GETTER_SETTER(showDesktopNotification,
                          setShowDesktopNotification,
                          bool)
+#if defined(Q_OS_WIN)
+    CONFIG_GETTER_SETTER(includeMouseCursor, setIncludeMouseCursor, bool)
+#endif
     CONFIG_GETTER_SETTER(showAbortNotification, setShowAbortNotification, bool)
     CONFIG_GETTER_SETTER(filenamePattern, setFilenamePattern, QString)
     CONFIG_GETTER_SETTER(disabledTrayIcon, setDisabledTrayIcon, bool)
@@ -199,6 +202,8 @@ signals:
     void error() const;
     void errorResolved() const;
     void fileChanged() const;
+    void shortcutChanged(const QString& actionName,
+                         const QString& shortcut) const;
 
 private:
     mutable QSettings m_settings;

--- a/src/utils/screengrabber.cpp
+++ b/src/utils/screengrabber.cpp
@@ -741,6 +741,7 @@ QPixmap ScreenGrabber::cropToMonitor(const QPixmap& fullScreenshot,
     return cropped;
 }
 
+#if defined(Q_OS_WIN)
 QPixmap ScreenGrabber::windowsScreenshot(int wid)
 {
     const QList<QScreen*> screens = QGuiApplication::screens();
@@ -820,6 +821,7 @@ QPixmap ScreenGrabber::windowsScreenshot(int wid)
 
     return desktop;
 }
+#endif
 
 QPixmap ScreenGrabber::x11LegacyScreenshot()
 {

--- a/src/utils/screengrabber.cpp
+++ b/src/utils/screengrabber.cpp
@@ -20,6 +20,11 @@
 #include <QScreen>
 #include <QTimer>
 #include <QWidget>
+#if defined(Q_OS_WIN)
+#include <QCursor>
+#include <QImage>
+#include <qt_windows.h>
+#endif
 #include <algorithm>
 
 #ifdef FLAMESHOT_DEBUG_CAPTURE
@@ -33,6 +38,113 @@
 #include <QDir>
 #include <QUrl>
 #include <QUuid>
+#endif
+
+#if defined(Q_OS_WIN)
+namespace {
+void deleteIconInfoBitmaps(ICONINFO& iconInfo)
+{
+    if (iconInfo.hbmColor != nullptr) {
+        DeleteObject(iconInfo.hbmColor);
+        iconInfo.hbmColor = nullptr;
+    }
+    if (iconInfo.hbmMask != nullptr) {
+        DeleteObject(iconInfo.hbmMask);
+        iconInfo.hbmMask = nullptr;
+    }
+}
+
+void drawMouseCursor(QPixmap& screenshot, const QRect& logicalScreenGeometry)
+{
+    if (!ConfigHandler().includeMouseCursor() || screenshot.isNull() ||
+        logicalScreenGeometry.isEmpty()) {
+        return;
+    }
+
+    CURSORINFO cursorInfo{};
+    cursorInfo.cbSize = sizeof(CURSORINFO);
+    if (!GetCursorInfo(&cursorInfo) || !(cursorInfo.flags & CURSOR_SHOWING) ||
+        cursorInfo.hCursor == nullptr) {
+        return;
+    }
+
+    // QCursor and QScreen use the same device-independent virtual desktop
+    // coordinate system. Converting the position using the actual captured
+    // pixel dimensions is more reliable than assuming the reported DPR maps
+    // exactly to the pixmap dimensions.
+    const QPoint logicalCursorPosition = QCursor::pos();
+    if (!logicalScreenGeometry.contains(logicalCursorPosition)) {
+        return;
+    }
+
+    ICONINFO iconInfo{};
+    if (!GetIconInfo(cursorInfo.hCursor, &iconInfo)) {
+        return;
+    }
+
+    const qreal scaleX =
+      static_cast<qreal>(screenshot.width()) / logicalScreenGeometry.width();
+    const qreal scaleY =
+      static_cast<qreal>(screenshot.height()) / logicalScreenGeometry.height();
+    const QPoint logicalOffset =
+      logicalCursorPosition - logicalScreenGeometry.topLeft();
+    const int cursorX =
+      qRound(logicalOffset.x() * scaleX) - static_cast<int>(iconInfo.xHotspot);
+    const int cursorY =
+      qRound(logicalOffset.y() * scaleY) - static_cast<int>(iconInfo.yHotspot);
+    deleteIconInfoBitmaps(iconInfo);
+
+    // DrawIconEx applies the native cursor's alpha/mask/XOR data directly to
+    // the captured pixels. This works for color, monochrome, inverted, custom,
+    // and animated Windows cursors, where converting HCURSOR to a Qt image can
+    // produce a fully transparent or incorrectly masked result.
+    QImage image = screenshot.toImage().convertToFormat(QImage::Format_RGB32);
+    HBITMAP bitmap = image.toHBITMAP();
+    if (bitmap == nullptr) {
+        return;
+    }
+
+    HDC screenDc = GetDC(nullptr);
+    HDC memoryDc = CreateCompatibleDC(screenDc);
+    if (memoryDc == nullptr) {
+        if (screenDc != nullptr) {
+            ReleaseDC(nullptr, screenDc);
+        }
+        DeleteObject(bitmap);
+        return;
+    }
+
+    HGDIOBJ previousBitmap = SelectObject(memoryDc, bitmap);
+    const bool bitmapSelected =
+      previousBitmap != nullptr && previousBitmap != HGDI_ERROR;
+    const BOOL cursorDrawn = bitmapSelected ? DrawIconEx(memoryDc,
+                                                         cursorX,
+                                                         cursorY,
+                                                         cursorInfo.hCursor,
+                                                         0,
+                                                         0,
+                                                         0,
+                                                         nullptr,
+                                                         DI_NORMAL)
+                                            : FALSE;
+
+    if (bitmapSelected) {
+        SelectObject(memoryDc, previousBitmap);
+    }
+    DeleteDC(memoryDc);
+    if (screenDc != nullptr) {
+        ReleaseDC(nullptr, screenDc);
+    }
+
+    if (cursorDrawn) {
+        QImage result = QImage::fromHBITMAP(bitmap);
+        if (!result.isNull()) {
+            screenshot = QPixmap::fromImage(result);
+        }
+    }
+    DeleteObject(bitmap);
+}
+} // namespace
 #endif
 
 bool ScreenGrabber::m_monitorSelectionActive = false;
@@ -357,8 +469,16 @@ QPixmap ScreenGrabber::grabScreen(QScreen* screen, bool& ok)
     p = grabEntireDesktop(ok, screenIndex);
 #else
     ok = true;
-    return screen->grabWindow(
+    QPixmap screenshot = screen->grabWindow(
       0, geometry.x(), geometry.y(), geometry.width(), geometry.height());
+#if defined(Q_OS_WIN)
+    const qreal screenshotDpr = screenshot.devicePixelRatio();
+    screenshot.setDevicePixelRatio(1.0);
+    drawMouseCursor(screenshot, screen->geometry());
+    screenshot.setDevicePixelRatio(
+      screenshotDpr > 0.0 ? screenshotDpr : screen->devicePixelRatio());
+#endif
+    return screenshot;
 #endif
     return p;
 }
@@ -646,7 +766,10 @@ QPixmap ScreenGrabber::windowsScreenshot(int wid)
         qreal screenDpr = screen->devicePixelRatio();
 
         QPixmap screenPixmap = screen->grabWindow(wid);
+        // The Windows desktop compositor below operates in physical pixels.
+        // Normalize the pixmap before drawing the native cursor with GDI.
         screenPixmap.setDevicePixelRatio(1.0);
+        drawMouseCursor(screenPixmap, screenGeom);
 
         int logicalX = screenGeom.x() - minLogicalX;
         int logicalY = screenGeom.y() - minLogicalY;

--- a/src/utils/screengrabber.h
+++ b/src/utils/screengrabber.h
@@ -37,7 +37,9 @@ private:
     void adjustDevicePixelRatio(QPixmap& pixmap);
     QWidget* createMonitorPreviews(const QPixmap& fullScreenshot);
     QPixmap cropToMonitor(const QPixmap& fullScreenshot, int monitorIndex);
+#if defined(Q_OS_WIN)
     QPixmap windowsScreenshot(int wid);
+#endif
     QPixmap x11LegacyScreenshot();
 
     DesktopInfo m_info;


### PR DESCRIPTION
This adds a configurable Capture screen shortcut and applies shortcut changes immediately without restarting Flameshot.

It also adds a Show mouse cursor in screenshots option, with native cursor capture support on Windows.

Global shortcut handling is supported on Windows, macOS, and Linux X11/XWayland. Native Wayland continues to rely on desktop-environment shortcuts.