### PR TITLE
Fix monitor selector stuck after closing via window manager

### DIFF
--- a/src/utils/screengrabber.cpp
+++ b/src/utils/screengrabber.cpp
@@ -590,6 +590,10 @@ void ScreenGrabber::setHighlightedMonitorPreview(int previewIndex)
 
 bool ScreenGrabber::eventFilter(QObject* obj, QEvent* event)
 {
+    if (event->type() == QEvent::Close) {
+        cancelMonitorSelection();
+        return true;
+    }
     if (event->type() == QEvent::KeyPress) {
         QKeyEvent* keyEvent = static_cast<QKeyEvent*>(event);
         switch (keyEvent->key()) {


### PR DESCRIPTION
Fixes #4838

Handle QEvent::Close in the event filter so that closing the monitor selector window (e.g. via i3 kill) properly quits the blocking event loop and resets the selection state, preventing the 'Screenshot already in progress' error on subsequent screenshot attempts.