### PR TITLE
Add AVIF and JPEG XL plugins on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,6 +166,14 @@ if(WIN32)
   # Include all dynamically linked runtime libraries such as MSVCRxxx.dll
   include(InstallRequiredSystemLibraries)
 
+  option(DOWNLOAD_EXTERNAL_QT_PLUGINS "Download DLL plugins for AVIF and JPEG XL" ON)
+  if(DOWNLOAD_EXTERNAL_QT_PLUGINS)
+    file(DOWNLOAD https://github.com/novomesk/qt-avif-image-plugin/releases/download/v0.10.3/qavif6.dll ${CMAKE_BINARY_DIR}/imageformats/qavif6.dll)
+    file(DOWNLOAD https://github.com/novomesk/qt-jpegxl-image-plugin/releases/download/v0.8.3/qjpegxl6.dll ${CMAKE_BINARY_DIR}/imageformats/qjpegxl6.dll)
+    install(PROGRAMS ${CMAKE_BINARY_DIR}/imageformats/qavif6.dll ${CMAKE_BINARY_DIR}/imageformats/qjpegxl6.dll
+            DESTINATION ${CMAKE_INSTALL_BINDIR}/imageformats/)
+  endif()
+
   if(USE_PORTABLE_CONFIG)
     set(CPACK_PACKAGE_FILE_NAME "${PROJECT_NAME}-${PROJECT_VERSION}-win64")
     set(CPACK_GENERATOR ZIP)


### PR DESCRIPTION
This is enough to enable AVIF and JXL on Windows ( https://github.com/flameshot-org/flameshot/issues/3062 ).

The MIME types are already included in Qt.

The `qavif6.dll` and `qjpegxl6.dll` were also built on AppVeyor (image Visual Studio 2022 using the same Qt version `C:\Qt\6.9.3\msvc2022_64` as current version of Flameshot on Windows), they work together.

I think the downloading binary DLLs is the most realistic solution, because AppVeyor has 1 hour timeout and it is not enough to built all dependencies in a single run.

If you start building Flameshot using Qt 6.11.1 (for example) in the future, the plugins should continue to work. But of course I can re-compile/update at any time.