### PR TITLE
perf: insert button list in sorted order instead of re-sorting

### DIFF
--- a/src/config/buttonlistview.cpp
+++ b/src/config/buttonlistview.cpp
@@ -52,13 +52,14 @@ void ButtonListView::updateActiveButtons(QListWidgetItem* item)
 {
     CaptureTool::Type bType = m_buttonTypeByName[item->text()];
     if (item->checkState() == Qt::Checked) {
-        m_listButtons.append(bType);
-        // TODO refactor so we don't need external sorts
+        // Refactored to avoid external sort: insert into the correct position
         using bt = CaptureTool::Type;
-        std::sort(m_listButtons.begin(), m_listButtons.end(), [](bt a, bt b) {
-            return CaptureToolButton::getPriorityByButton(a) <
-                   CaptureToolButton::getPriorityByButton(b);
-        });
+        auto it = std::lower_bound(
+          m_listButtons.begin(), m_listButtons.end(), bType, [](bt a, bt b) {
+              return CaptureToolButton::getPriorityByButton(a) <
+                     CaptureToolButton::getPriorityByButton(b);
+          });
+        m_listButtons.insert(it, bType);
     } else {
         m_listButtons.removeOne(bType);
     }


### PR DESCRIPTION
This PR optimizes button list ordering in `ButtonListView::updateActiveButtons` by inserting newly checked buttons directly at the correct priority position instead of appending and re-sorting the entire list.

Replaced:
  - `append` + `std::sort(...)`
With:
  - `std::lower_bound(...)` + `insert(...)`

What does the change do?

- Avoids re-sorting the full list on every insert.
- Keeps button order stable by `CaptureToolButton::getPriorityByButton(...)`.
- Completes the existing TODO about removing external sorts.