### PR TITLE
Fix GNOME Wayland mixed-DPI capture scaling

### DIFF
--- a/src/utils/screengrabber.cpp
+++ b/src/utils/screengrabber.cpp
@@ -758,7 +758,16 @@ QPixmap ScreenGrabber::cropToMonitor(const QPixmap& fullScreenshot,
 
 #if defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)
     // Linux: May need rescaling if scale factors don't match
-    if (qAbs(screenshotScaleX - targetDpr) > 0.01) {
+    // GNOME Wayland's portal image uses the same native-coordinate canvas as
+    // QScreen::geometry() on Qt 6.2. In that case the cropped pixels are
+    // already native resolution; upscaling them by DPR creates a 4x-area
+    // image and limits interaction to the visible top-left quarter.
+    const bool nativeWaylandCanvas =
+      m_info.waylandDetected() &&
+      m_info.windowManager() == DesktopInfo::GNOME &&
+      qAbs(screenshotScaleX - 1.0) < 0.01 &&
+      qAbs(screenshotScaleY - 1.0) < 0.01;
+    if (!nativeWaylandCanvas && qAbs(screenshotScaleX - targetDpr) > 0.01) {
         int targetPhysicalWidth = qRound(targetGeometry.width() * targetDpr);
         int targetPhysicalHeight = qRound(targetGeometry.height() * targetDpr);
         cropped = cropped.scaled(targetPhysicalWidth,

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -194,6 +194,13 @@ CaptureWidget::CaptureWidget(const CaptureRequest& req,
             selectedScreen = QGuiApplication::primaryScreen();
         }
         QRect screenGeom = selectedScreen->geometry();
+        if (DesktopInfo().waylandDetected() &&
+            selectedScreen->devicePixelRatio() > 1.0 &&
+            screenGeom.size() == m_context.screenshot.size()) {
+            const qreal dpr = selectedScreen->devicePixelRatio();
+            screenGeom.setSize(QSize(qRound(screenGeom.width() / dpr),
+                                     qRound(screenGeom.height() / dpr)));
+        }
         move(screenGeom.topLeft());
         resize(screenGeom.size());
 
@@ -214,6 +221,12 @@ CaptureWidget::CaptureWidget(const CaptureRequest& req,
             screenForAreas = QGuiApplication::primaryScreen();
         }
         QRect r = screenForAreas ? screenForAreas->geometry() : QRect();
+        if (screenForAreas && DesktopInfo().waylandDetected() &&
+            screenForAreas->devicePixelRatio() > 1.0 &&
+            r.size() == m_context.screenshot.size()) {
+            const qreal dpr = screenForAreas->devicePixelRatio();
+            r.setSize(QSize(qRound(r.width() / dpr), qRound(r.height() / dpr)));
+        }
         r.moveTo(0, 0);
         areas.append(r);
     } else {


### PR DESCRIPTION
Fixes #4871.

## Summary

- keep GNOME Wayland portal crops at native resolution when the portal canvas already matches Qt's native screen coordinates
- size the Wayland capture surface and selection area in device-independent coordinates when raw screen geometry matches the screenshot pixel size
- retain the existing scaling path for X11 and for Wayland portal images whose scale differs from 1

## Why

With a mixed-DPI GNOME Wayland layout, Qt 6.2 can report the DPR 2 monitor's geometry in native pixels while the GNOME portal returns a DPR 1 composite using the same native-coordinate canvas. The existing code crops the native-resolution monitor correctly, then scales it by DPR a second time. The result is a blurred preview with selection limited to the top-left quarter.

The guards in this change are based on the observed relationship between portal scale, screen geometry, screenshot pixel size, and DPR so that compositors which already expose logical geometry keep their current behavior.

## Testing

- `git diff --check`
- `cmake --build build --parallel 8`
- `ctest --test-dir build --output-on-failure` (the build defines no tests)
- manually tested on Ubuntu 22.04.5, GNOME 42.9, Wayland, Qt 6.2.4 with:
  - 2560x1440 external monitor at DPR 1
  - 3840x2400 internal monitor at DPR 2
  - 4858x3840 portal composite at DPR 1

The patched build restores native sharpness and allows selection across the complete HiDPI monitor.
