### PR TITLE
Wayland: auto-select monitor under cursor and compact picker on every screen

### DIFF
--- a/src/utils/monitorpreview.cpp
+++ b/src/utils/monitorpreview.cpp
@@ -13,18 +13,24 @@
 MonitorPreview::MonitorPreview(int monitorIndex,
                                QScreen* screen,
                                const QPixmap& thumbnail,
-                               QWidget* parent)
+                               QWidget* parent,
+                               bool compact)
   : QWidget(parent)
   , m_monitorIndex(monitorIndex)
   , m_selected(false)
   , m_mouseHovered(false)
+  , m_compact(compact)
   , m_imageLabel(nullptr)
   , m_keyLabel(nullptr)
   , m_textLabel(nullptr)
 {
+    const int margin = compact ? 6 : 10;
+    const int spacing = compact ? 6 : 10;
+    const int keyLabelSize = compact ? 22 : 28;
+
     QVBoxLayout* layout = new QVBoxLayout(this);
-    layout->setContentsMargins(10, 10, 10, 10);
-    layout->setSpacing(10);
+    layout->setContentsMargins(margin, margin, margin, margin);
+    layout->setSpacing(spacing);
 
     m_imageLabel = new QLabel(this);
     m_imageLabel->setAlignment(Qt::AlignCenter);
@@ -35,8 +41,8 @@ MonitorPreview::MonitorPreview(int monitorIndex,
         m_keyLabel =
           new QLabel(QString::number(m_monitorIndex + 1), m_imageLabel);
         m_keyLabel->setAlignment(Qt::AlignCenter);
-        m_keyLabel->setFixedSize(28, 28);
-        m_keyLabel->move(8, 8);
+        m_keyLabel->setFixedSize(keyLabelSize, keyLabelSize);
+        m_keyLabel->move(4, 4);
         m_keyLabel->raise();
         m_keyLabel->setAttribute(Qt::WA_TransparentForMouseEvents);
     }
@@ -97,13 +103,16 @@ void MonitorPreview::updateStyle()
     const int textAlpha = highlighted ? 220 : 200;
     const int borderAlpha = highlighted ? 255 : 0;
 
+    const int fontSize = m_compact ? 9 : 12;
+
     QString textStyle =
       QString("QLabel { color: white; background-color: rgba(%1, %2, %3, %4); "
-              "padding: 5px; font-size: 12pt; border-radius: 3px; }")
+              "padding: 4px; font-size: %5pt; border-radius: 3px; }")
         .arg(backgroundColor.red())
         .arg(backgroundColor.green())
         .arg(backgroundColor.blue())
-        .arg(textAlpha);
+        .arg(textAlpha)
+        .arg(fontSize);
     m_textLabel->setStyleSheet(textStyle);
 
     QString imageStyle =

--- a/src/utils/monitorpreview.cpp
+++ b/src/utils/monitorpreview.cpp
@@ -21,12 +21,10 @@ MonitorPreview::MonitorPreview(int monitorIndex,
   , m_mouseHovered(false)
   , m_compact(compact)
   , m_imageLabel(nullptr)
-  , m_keyLabel(nullptr)
   , m_textLabel(nullptr)
 {
     const int margin = compact ? 6 : 10;
     const int spacing = compact ? 6 : 10;
-    const int keyLabelSize = compact ? 22 : 28;
 
     QVBoxLayout* layout = new QVBoxLayout(this);
     layout->setContentsMargins(margin, margin, margin, margin);
@@ -37,23 +35,9 @@ MonitorPreview::MonitorPreview(int monitorIndex,
     m_imageLabel->setPixmap(thumbnail);
     m_imageLabel->setScaledContents(false);
 
-    if (m_monitorIndex < 9) {
-        m_keyLabel =
-          new QLabel(QString::number(m_monitorIndex + 1), m_imageLabel);
-        m_keyLabel->setAlignment(Qt::AlignCenter);
-        m_keyLabel->setFixedSize(keyLabelSize, keyLabelSize);
-        m_keyLabel->move(4, 4);
-        m_keyLabel->raise();
-        m_keyLabel->setAttribute(Qt::WA_TransparentForMouseEvents);
-    }
-
-    const QString labelText =
-      m_monitorIndex < 9 ? tr("Monitor %1: %2\nClick or press %1 to select")
-                             .arg(m_monitorIndex + 1)
-                             .arg(screen->name())
-                         : tr("Monitor %1: %2\nClick to select")
-                             .arg(m_monitorIndex + 1)
-                             .arg(screen->name());
+    const QString labelText = tr("Monitor %1: %2\nClick to select")
+                                .arg(m_monitorIndex + 1)
+                                .arg(screen->name());
     m_textLabel = new QLabel(labelText, this);
     m_textLabel->setAlignment(Qt::AlignCenter);
 
@@ -123,14 +107,4 @@ void MonitorPreview::updateStyle()
         .arg(backgroundColor.blue())
         .arg(borderAlpha);
     m_imageLabel->setStyleSheet(imageStyle);
-
-    if (m_keyLabel) {
-        QString keyStyle = QString("QLabel { color: white; font-weight: bold; "
-                                   "background-color: rgba(%1, %2, %3, 230); "
-                                   "border-radius: 14px; }")
-                             .arg(backgroundColor.red())
-                             .arg(backgroundColor.green())
-                             .arg(backgroundColor.blue());
-        m_keyLabel->setStyleSheet(keyStyle);
-    }
 }

--- a/src/utils/monitorpreview.h
+++ b/src/utils/monitorpreview.h
@@ -17,7 +17,8 @@ public:
     MonitorPreview(int monitorIndex,
                    QScreen* screen,
                    const QPixmap& thumbnail,
-                   QWidget* parent = nullptr);
+                   QWidget* parent = nullptr,
+                   bool compact = false);
 
     int monitorIndex() const { return m_monitorIndex; }
     void setSelected(bool selected);
@@ -36,6 +37,7 @@ private:
     int m_monitorIndex;
     bool m_selected;
     bool m_mouseHovered;
+    bool m_compact;
     QColor m_uiColor;
     QColor m_contrastColor;
     QLabel* m_imageLabel;

--- a/src/utils/monitorpreview.h
+++ b/src/utils/monitorpreview.h
@@ -41,6 +41,5 @@ private:
     QColor m_uiColor;
     QColor m_contrastColor;
     QLabel* m_imageLabel;
-    QLabel* m_keyLabel;
     QLabel* m_textLabel;
 };

--- a/src/utils/screengrabber.cpp
+++ b/src/utils/screengrabber.cpp
@@ -7,6 +7,7 @@
 #include "utils/systemnotification.h"
 
 #include <QApplication>
+#include <QDBusArgument>
 #include <QEventLoop>
 #include <QGuiApplication>
 #include <QHBoxLayout>
@@ -18,8 +19,10 @@
 #include <QPixmap>
 #include <QProcess>
 #include <QScreen>
+#include <QStringList>
 #include <QTimer>
 #include <QWidget>
+#include <QWindow>
 #include <algorithm>
 
 #ifdef FLAMESHOT_DEBUG_CAPTURE
@@ -426,6 +429,156 @@ QRect ScreenGrabber::desktopGeometry()
     return geometry;
 }
 
+namespace {
+
+// Skip a `a{sv}` (string -> variant) dictionary on the QDBusArgument cursor.
+void skipVariantMap(const QDBusArgument& arg)
+{
+    arg.beginMap();
+    while (!arg.atEnd()) {
+        QString key;
+        QVariant value;
+        arg >> key >> value;
+        Q_UNUSED(key);
+        Q_UNUSED(value);
+    }
+    arg.endMap();
+}
+
+// Skip a single monitor mode struct: `(s i i d d ad a{sv})`.
+void skipMonitorMode(const QDBusArgument& arg)
+{
+    arg.beginStructure();
+    QString id;
+    int width, height;
+    double refreshRate, scale;
+    arg >> id >> width >> height >> refreshRate >> scale;
+    Q_UNUSED(id);
+    Q_UNUSED(width);
+    Q_UNUSED(height);
+    Q_UNUSED(refreshRate);
+    Q_UNUSED(scale);
+    arg.beginArray();
+    while (!arg.atEnd()) {
+        double s;
+        arg >> s;
+        Q_UNUSED(s);
+    }
+    arg.endArray();
+    skipVariantMap(arg);
+    arg.endStructure();
+}
+
+// Skip the monitors array `a((ssss)a((siiddada{sv}))a{sv})`; the primary
+// monitor is reported by the logical monitors array instead.
+void skipMonitorsArray(const QDBusArgument& arg)
+{
+    arg.beginArray();
+    while (!arg.atEnd()) {
+        arg.beginStructure();
+        QString connector, vendor, product, serial;
+        arg.beginStructure();
+        arg >> connector >> vendor >> product >> serial;
+        Q_UNUSED(connector);
+        Q_UNUSED(vendor);
+        Q_UNUSED(product);
+        Q_UNUSED(serial);
+        arg.endStructure();
+        arg.beginArray();
+        while (!arg.atEnd()) {
+            skipMonitorMode(arg);
+        }
+        arg.endArray();
+        skipVariantMap(arg);
+        arg.endStructure();
+    }
+    arg.endArray();
+}
+
+} // namespace
+
+QScreen* ScreenGrabber::reliablePrimaryScreen()
+{
+#if defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)
+    DesktopInfo info;
+    if (info.waylandDetected() && info.windowManager() == DesktopInfo::GNOME) {
+        // Qt's wayland plugin does not implement the wp_primary_output
+        // protocol, so QGuiApplication::primaryScreen() on GNOME Wayland
+        // returns the first wl_output advertised by the compositor (usually
+        // the built-in panel) instead of the monitor the user actually
+        // configured as primary. Ask mutter directly; it is the authoritative
+        // source for the primary monitor on GNOME.
+        // GetCurrentState returns a struct whose fields QDBusMessage exposes
+        // as separate arguments:
+        //   u, a((ssss)a((siiddada{sv}))a{sv}), a(iiduba(ssss)a{sv}), a{sv}
+        QDBusInterface displayConfig(
+          QStringLiteral("org.gnome.Mutter.DisplayConfig"),
+          QStringLiteral("/org/gnome/Mutter/DisplayConfig"),
+          QStringLiteral("org.gnome.Mutter.DisplayConfig"));
+        QDBusMessage msg = displayConfig.call(QStringLiteral("GetCurrentState"));
+        if (msg.type() == QDBusMessage::ReplyMessage) {
+            const QList<QVariant>& replyArgs = msg.arguments();
+            if (replyArgs.size() >= 3 &&
+                replyArgs.at(1).canConvert<QDBusArgument>() &&
+                replyArgs.at(2).canConvert<QDBusArgument>()) {
+                const QDBusArgument monitorsArg =
+                  replyArgs.at(1).value<QDBusArgument>();
+                skipMonitorsArray(monitorsArg);
+
+                // Find the primary logical monitor and the connector(s)
+                // mapped to it.
+                QString primaryConnector;
+                const QDBusArgument logicalArg =
+                  replyArgs.at(2).value<QDBusArgument>();
+                logicalArg.beginArray();
+                while (!logicalArg.atEnd() && primaryConnector.isEmpty()) {
+                    logicalArg.beginStructure();
+                    int x, y;
+                    double scale;
+                    uint transform;
+                    bool primary;
+                    logicalArg >> x >> y >> scale >> transform >> primary;
+                    Q_UNUSED(x);
+                    Q_UNUSED(y);
+                    Q_UNUSED(scale);
+                    Q_UNUSED(transform);
+                    QStringList connectors;
+                    logicalArg.beginArray();
+                    while (!logicalArg.atEnd()) {
+                        QString connector, vendor, product, serial;
+                        logicalArg.beginStructure();
+                        logicalArg >> connector >> vendor >> product >> serial;
+                        Q_UNUSED(connector);
+                        Q_UNUSED(vendor);
+                        Q_UNUSED(product);
+                        Q_UNUSED(serial);
+                        logicalArg.endStructure();
+                        connectors.append(connector);
+                    }
+                    logicalArg.endArray();
+                    skipVariantMap(logicalArg);
+                    logicalArg.endStructure();
+                    if (primary && !connectors.isEmpty()) {
+                        primaryConnector = connectors.first();
+                    }
+                }
+                logicalArg.endArray();
+
+                if (!primaryConnector.isEmpty()) {
+                    const QList<QScreen*> screens = QGuiApplication::screens();
+                    for (QScreen* screen : screens) {
+                        if (screen->name() == primaryConnector) {
+                            return screen;
+                        }
+                    }
+                }
+            }
+        }
+    }
+#endif
+    return QGuiApplication::primaryScreen();
+}
+
 QScreen* ScreenGrabber::getSelectedScreen() const
 {
     const QList<QScreen*> screens = QGuiApplication::screens();
@@ -499,9 +652,24 @@ QWidget* ScreenGrabber::createMonitorPreviews(const QPixmap& fullScreenshot)
         containerLayout->addWidget(preview);
     }
 
+    // Decide which monitor the selection dialog should appear on. On X11 the
+    // screen under the cursor is reliable, so follow the mouse. On Wayland the
+    // global cursor position is not exposed to clients and Qt's primaryScreen
+    // does not reflect the compositor's primary monitor, so use the monitor
+    // the desktop actually reports as primary (queried from mutter on GNOME).
+    QScreen* targetScreen = nullptr;
+    if (m_info.waylandDetected()) {
+        targetScreen = reliablePrimaryScreen();
+    } else {
+        targetScreen = QGuiAppCurrentScreen().currentScreen();
+        if (!targetScreen) {
+            targetScreen = QGuiApplication::primaryScreen();
+        }
+    }
+
     int initialPreviewIndex = 0;
-    QScreen* currentScreen = QGuiAppCurrentScreen().currentScreen();
-    int currentMonitorIndex = screens.indexOf(currentScreen);
+    int currentMonitorIndex = targetScreen ? screens.indexOf(targetScreen)
+                                           : -1;
     int currentPreviewIndex = previewIndexForMonitor(currentMonitorIndex);
     if (currentPreviewIndex >= 0) {
         initialPreviewIndex = currentPreviewIndex;
@@ -511,11 +679,21 @@ QWidget* ScreenGrabber::createMonitorPreviews(const QPixmap& fullScreenshot)
     monitorPreviews->setLayout(containerLayout);
     monitorPreviews->adjustSize();
 
-    QScreen* primaryScreen = QGuiApplication::primaryScreen();
-    QRect screenGeometry = primaryScreen->geometry();
-    QPoint center = screenGeometry.center();
-    monitorPreviews->move(center.x() - monitorPreviews->width() / 2,
-                          center.y() - monitorPreviews->height() / 2);
+    if (targetScreen) {
+        QRect screenGeometry = targetScreen->geometry();
+        QPoint center = screenGeometry.center();
+        monitorPreviews->move(center.x() - monitorPreviews->width() / 2,
+                              center.y() - monitorPreviews->height() / 2);
+        // Wayland compositors ignore move() entirely, so the only reliable way
+        // to choose which monitor a window maps to is to associate the native
+        // window with the target QScreen before showing it. winId() forces the
+        // native window to exist (windowHandle() is null before show), and
+        // QWindow::setScreen() recreates it on the target screen.
+        monitorPreviews->winId();
+        if (QWindow* previewWindow = monitorPreviews->windowHandle()) {
+            previewWindow->setScreen(targetScreen);
+        }
+    }
 
     monitorPreviews->show();
     monitorPreviews->raise();

--- a/src/utils/screengrabber.cpp
+++ b/src/utils/screengrabber.cpp
@@ -515,7 +515,8 @@ QScreen* ScreenGrabber::reliablePrimaryScreen()
           QStringLiteral("org.gnome.Mutter.DisplayConfig"),
           QStringLiteral("/org/gnome/Mutter/DisplayConfig"),
           QStringLiteral("org.gnome.Mutter.DisplayConfig"));
-        QDBusMessage msg = displayConfig.call(QStringLiteral("GetCurrentState"));
+        QDBusMessage msg =
+          displayConfig.call(QStringLiteral("GetCurrentState"));
         if (msg.type() == QDBusMessage::ReplyMessage) {
             const QList<QVariant>& replyArgs = msg.arguments();
             if (replyArgs.size() >= 3 &&
@@ -668,8 +669,7 @@ QWidget* ScreenGrabber::createMonitorPreviews(const QPixmap& fullScreenshot)
     }
 
     int initialPreviewIndex = 0;
-    int currentMonitorIndex = targetScreen ? screens.indexOf(targetScreen)
-                                           : -1;
+    int currentMonitorIndex = targetScreen ? screens.indexOf(targetScreen) : -1;
     int currentPreviewIndex = previewIndexForMonitor(currentMonitorIndex);
     if (currentPreviewIndex >= 0) {
         initialPreviewIndex = currentPreviewIndex;

--- a/src/utils/screengrabber.cpp
+++ b/src/utils/screengrabber.cpp
@@ -22,6 +22,7 @@
 #include <QTimer>
 #include <QWidget>
 #include <QWindow>
+#include <QtAlgorithms>
 #include <algorithm>
 
 #ifdef FLAMESHOT_DEBUG_CAPTURE
@@ -247,24 +248,16 @@ QPixmap ScreenGrabber::selectMonitorAndCrop(const QPixmap& fullScreenshot,
         return cropToMonitor(fullScreenshot, 0);
     }
 
-    // Capture Active Monitor: auto-select monitor under cursor
-    if (ConfigHandler().captureActiveMonitor()) {
-        if (m_info.waylandDetected()) {
-            AbstractLogger::error()
-              << tr("Capture Active Monitor is not supported on Wayland due to "
-                    "Wayland security model.");
-            ok = false;
-            return QPixmap();
-        }
-
-        QGuiAppCurrentScreen screenFinder;
-        QScreen* cursorScreen = screenFinder.currentScreen();
-        int monitorIndex = screens.indexOf(cursorScreen);
+    // Skip the selection dialog and capture the monitor under the cursor
+    // directly (on X11 the cursor position is reliable, on Wayland it is
+    // recovered from the compositor's placement of a probe window).
+    QScreen* cursorScreen = cursorMonitor();
+    if (cursorScreen) {
+        const int monitorIndex = screens.indexOf(cursorScreen);
         if (monitorIndex >= 0) {
             m_selectedMonitor = monitorIndex;
             return cropToMonitor(fullScreenshot, monitorIndex);
         }
-        // Fall through to manual selection if screen lookup fails
     }
 
     if (m_monitorSelectionActive) {
@@ -278,7 +271,8 @@ QPixmap ScreenGrabber::selectMonitorAndCrop(const QPixmap& fullScreenshot,
     m_monitorSelectionActive = true;
     m_selectedMonitor = -1;
     m_userCancelled = false;
-    QWidget* container = createMonitorPreviews(fullScreenshot);
+    const QList<QWidget*> containers =
+      createMonitorPreviews(fullScreenshot, cursorScreen);
 
     // Wait for user to select a monitor
     QEventLoop loop;
@@ -286,7 +280,7 @@ QPixmap ScreenGrabber::selectMonitorAndCrop(const QPixmap& fullScreenshot,
     loop.exec();
     m_monitorSelectionLoop = nullptr;
 
-    delete container;
+    qDeleteAll(containers);
     m_monitorPreviews.clear();
     m_highlightedMonitorPreview = -1;
     m_monitorSelectionActive = false;
@@ -431,6 +425,34 @@ QRect ScreenGrabber::desktopGeometry()
 
 namespace {
 
+// Opaque surface for the compact picker on Wayland: paints the frozen desktop
+// of one monitor so the compact strip sits on top of a live-looking
+// background. Fullscreen windows cannot be translucent on GNOME Wayland (the
+// compositor composites them as opaque, so the transparent area renders
+// black), hence the desktop preview instead of a transparent window.
+class MonitorPickerSurface : public QWidget
+{
+public:
+    MonitorPickerSurface(const QPixmap& background,
+                         QWidget* parent = nullptr,
+                         Qt::WindowFlags flags = Qt::WindowFlags())
+      : QWidget(parent, flags)
+      , m_background(background)
+    {
+        setAttribute(Qt::WA_OpaquePaintEvent);
+    }
+
+protected:
+    void paintEvent(QPaintEvent*) override
+    {
+        QPainter painter(this);
+        painter.drawPixmap(0, 0, m_background);
+    }
+
+private:
+    QPixmap m_background;
+};
+
 #if !(defined(Q_OS_MACOS) || defined(Q_OS_WIN))
 
 // Skip a `a{sv}` (string -> variant) dictionary on the QDBusArgument cursor.
@@ -497,9 +519,9 @@ void skipMonitorsArray(const QDBusArgument& arg)
     arg.endArray();
 }
 
-} // namespace
-
 #endif
+
+} // namespace
 
 QScreen* ScreenGrabber::reliablePrimaryScreen()
 {
@@ -584,6 +606,65 @@ QScreen* ScreenGrabber::reliablePrimaryScreen()
     return QGuiApplication::primaryScreen();
 }
 
+QScreen* ScreenGrabber::cursorMonitor()
+{
+#if defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)
+    if (!m_info.waylandDetected()) {
+        // On X11 the global cursor position is reliable.
+        return QGuiAppCurrentScreen().currentScreen();
+    }
+
+    // On Wayland the compositor only reports the pointer position to clients
+    // whose surface is under the pointer, so it cannot be queried before any
+    // window is mapped. However, compositors place new windows on the monitor
+    // containing the pointer (mutter: meta_backend_get_current_logical_monitor
+    // when the client does not request a position), so mapping a tiny
+    // invisible probe window reveals the pointer's monitor through the screen
+    // the compositor assigns to it.
+    QWidget probe(nullptr,
+                  Qt::Window | Qt::FramelessWindowHint |
+                    Qt::WindowStaysOnTopHint | Qt::Tool);
+    probe.setAttribute(Qt::WA_TranslucentBackground);
+    probe.setAttribute(Qt::WA_ShowWithoutActivating);
+    probe.setAttribute(Qt::WA_TransparentForMouseEvents);
+    probe.resize(1, 1);
+
+    QScreen* result = nullptr;
+    QEventLoop loop;
+    QTimer timeout;
+    timeout.setSingleShot(true);
+    timeout.setInterval(800);
+    QObject::connect(&timeout, &QTimer::timeout, &loop, &QEventLoop::quit);
+
+    probe.show();
+    if (QWindow* handle = probe.windowHandle()) {
+        QObject::connect(handle,
+                         &QWindow::screenChanged,
+                         &loop,
+                         [&result, &loop](QScreen* screen) {
+                             if (screen) {
+                                 result = screen;
+                                 loop.quit();
+                             }
+                         });
+    }
+    timeout.start();
+    loop.exec();
+    QScreen* probeScreen =
+      probe.windowHandle() ? probe.windowHandle()->screen() : nullptr;
+    probe.close();
+
+    // If the compositor placed the window on its initial screen, no
+    // screenChanged was emitted; the current screen is still the answer.
+    if (!result && probeScreen) {
+        result = probeScreen;
+    }
+    return result;
+#else
+    return nullptr;
+#endif
+}
+
 QScreen* ScreenGrabber::getSelectedScreen() const
 {
     const QList<QScreen*> screens = QGuiApplication::screens();
@@ -595,7 +676,9 @@ QScreen* ScreenGrabber::getSelectedScreen() const
     return screens[m_selectedMonitor];
 }
 
-QWidget* ScreenGrabber::createMonitorPreviews(const QPixmap& fullScreenshot)
+QList<QWidget*> ScreenGrabber::createMonitorPreviews(
+  const QPixmap& fullScreenshot,
+  QScreen* cursorScreen)
 {
     const QList<QScreen*> screens = QGuiApplication::screens();
     m_monitorPreviews.clear();
@@ -615,95 +698,117 @@ QWidget* ScreenGrabber::createMonitorPreviews(const QPixmap& fullScreenshot)
     }
 #endif
 
-    QWidget* monitorPreviews = new QWidget(
-      nullptr, Qt::Window | Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint);
-    monitorPreviews->setAttribute(Qt::WA_TranslucentBackground);
-    monitorPreviews->setStyleSheet(
-      "QWidget { background-color: transparent; }");
-    monitorPreviews->installEventFilter(this); // For ESC key handling
-    monitorPreviews->setFocusPolicy(Qt::StrongFocus);
+    // A compact picker is shown at the bottom of every monitor.
+    //
+    // On Wayland the compositor ignores move()/setScreen() for regular
+    // windows (they are placed on the monitor containing the pointer), so each
+    // picker is shown FULLSCREEN -- the only state where the requested output
+    // is honored. Fullscreen windows are composited as opaque (transparency
+    // comes out black), so the picker paints the monitor's frozen desktop as
+    // its background and the compact strip sits on top of it.
+    //
+    // On X11 a small translucent window is moved to the bottom-center instead
+    // and clicks above the strip pass through to the desktop.
+    QList<QWidget*> pickers;
+    const bool wayland = m_info.waylandDetected();
 
-    QHBoxLayout* containerLayout = new QHBoxLayout(monitorPreviews);
-    containerLayout->setSpacing(20);
-    containerLayout->setContentsMargins(20, 20, 20, 20);
+    for (int screenIndex = 0; screenIndex < screens.size(); ++screenIndex) {
+        QScreen* pickerScreen = screens[screenIndex];
+        const QPixmap monitorShot = cropToMonitor(fullScreenshot, screenIndex);
 
-    // Build list of screen indices sorted by X position (left to right)
-    QList<int> sortedIndices;
-    for (int i = 0; i < screens.size(); ++i) {
-        sortedIndices.append(i);
-    }
-    std::sort(
-      sortedIndices.begin(), sortedIndices.end(), [&screens](int a, int b) {
-          return screens[a]->geometry().x() < screens[b]->geometry().x();
-      });
-
-    for (int i : sortedIndices) {
-        QScreen* screen = screens[i];
-
-        QPixmap cropped = cropToMonitor(fullScreenshot, i);
-        QPixmap thumbnail = cropped.scaled(
-          400, 250, Qt::KeepAspectRatio, Qt::SmoothTransformation);
-        thumbnail.setDevicePixelRatio(1.0);
-
-        MonitorPreview* preview =
-          new MonitorPreview(i, screen, thumbnail, monitorPreviews);
-
-        connect(preview,
-                &MonitorPreview::monitorSelected,
-                this,
-                [this](int index) { selectMonitor(index); });
-
-        m_monitorPreviews.append(preview);
-        containerLayout->addWidget(preview);
-    }
-
-    // Decide which monitor the selection dialog should appear on. On X11 the
-    // screen under the cursor is reliable, so follow the mouse. On Wayland the
-    // global cursor position is not exposed to clients and Qt's primaryScreen
-    // does not reflect the compositor's primary monitor, so use the monitor
-    // the desktop actually reports as primary (queried from mutter on GNOME).
-    QScreen* targetScreen = nullptr;
-    if (m_info.waylandDetected()) {
-        targetScreen = reliablePrimaryScreen();
-    } else {
-        targetScreen = QGuiAppCurrentScreen().currentScreen();
-        if (!targetScreen) {
-            targetScreen = QGuiApplication::primaryScreen();
+        QWidget* picker =
+          wayland
+            ? new MonitorPickerSurface(monitorShot,
+                                       nullptr,
+                                       Qt::Window | Qt::FramelessWindowHint |
+                                         Qt::WindowStaysOnTopHint)
+            : new QWidget(nullptr,
+                          Qt::Window | Qt::FramelessWindowHint |
+                            Qt::WindowStaysOnTopHint);
+        if (!wayland) {
+            picker->setAttribute(Qt::WA_TranslucentBackground);
+            picker->setStyleSheet("QWidget { background-color: transparent; }");
         }
-    }
+        // Remember which monitor this picker represents so a click on its
+        // background selects that monitor (Wayland fullscreen pickers receive
+        // all clicks; there is no input pass-through without a mask).
+        picker->setProperty("monitorIndex", screenIndex);
+        picker->installEventFilter(this); // For ESC / background click
+        picker->setFocusPolicy(Qt::StrongFocus);
 
-    int initialPreviewIndex = 0;
-    int currentMonitorIndex = targetScreen ? screens.indexOf(targetScreen) : -1;
-    int currentPreviewIndex = previewIndexForMonitor(currentMonitorIndex);
-    if (currentPreviewIndex >= 0) {
-        initialPreviewIndex = currentPreviewIndex;
-    }
-    setHighlightedMonitorPreview(initialPreviewIndex);
+        // Content is pinned to the bottom of the window.
+        QVBoxLayout* outerLayout = new QVBoxLayout(picker);
+        outerLayout->setContentsMargins(0, 0, 0, 12);
+        outerLayout->addStretch(1);
 
-    monitorPreviews->setLayout(containerLayout);
-    monitorPreviews->adjustSize();
+        QWidget* rowWidget = new QWidget(picker);
+        rowWidget->setAttribute(Qt::WA_TranslucentBackground);
+        rowWidget->setStyleSheet("QWidget { background-color: transparent; }");
+        QHBoxLayout* rowLayout = new QHBoxLayout(rowWidget);
+        rowLayout->setSpacing(10);
+        rowLayout->setContentsMargins(10, 0, 10, 0);
 
-    if (targetScreen) {
-        QRect screenGeometry = targetScreen->geometry();
-        QPoint center = screenGeometry.center();
-        monitorPreviews->move(center.x() - monitorPreviews->width() / 2,
-                              center.y() - monitorPreviews->height() / 2);
-        // Wayland compositors ignore move() entirely, so the only reliable way
-        // to choose which monitor a window maps to is to associate the native
-        // window with the target QScreen before showing it. winId() forces the
-        // native window to exist (windowHandle() is null before show), and
-        // QWindow::setScreen() recreates it on the target screen.
-        monitorPreviews->winId();
-        if (QWindow* previewWindow = monitorPreviews->windowHandle()) {
-            previewWindow->setScreen(targetScreen);
+        for (int i = 0; i < screens.size(); ++i) {
+            QPixmap cropped = cropToMonitor(fullScreenshot, i);
+            QPixmap thumbnail = cropped.scaled(
+              240, 150, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+            thumbnail.setDevicePixelRatio(1.0);
+
+            MonitorPreview* preview = new MonitorPreview(
+              i, screens[i], thumbnail, rowWidget, /*compact=*/true);
+
+            connect(preview,
+                    &MonitorPreview::monitorSelected,
+                    this,
+                    [this](int index) { selectMonitor(index); });
+
+            m_monitorPreviews.append(preview);
+            rowLayout->addWidget(preview);
         }
+        outerLayout->addWidget(rowWidget, 0, Qt::AlignHCenter);
+
+        // Associate the native window with the target screen first so that on
+        // Wayland the compositor maps it on the right output (winId() forces
+        // the native window to exist; QWindow::setScreen() recreates it there).
+        picker->winId();
+        if (QWindow* handle = picker->windowHandle()) {
+            handle->setScreen(pickerScreen);
+        }
+
+        const QRect screenGeom = pickerScreen->geometry();
+        if (wayland) {
+            picker->resize(screenGeom.size());
+            picker->layout()->activate();
+        } else {
+            picker->adjustSize();
+            picker->move(
+              screenGeom.x() + (screenGeom.width() - picker->width()) / 2,
+              screenGeom.y() + screenGeom.height() - picker->height() - 16);
+        }
+
+        pickers.append(picker);
     }
 
-    monitorPreviews->show();
-    monitorPreviews->raise();
-    monitorPreviews->activateWindow();
-    monitorPreviews->setFocus(Qt::ActiveWindowFocusReason);
-    return monitorPreviews;
+    // Highlight the monitor the pointer is on (the selection is skipped when
+    // it is known); fall back to the real primary monitor.
+    QScreen* initialScreen =
+      cursorScreen ? cursorScreen : reliablePrimaryScreen();
+    const int initialMonitorIndex =
+      initialScreen ? screens.indexOf(initialScreen) : -1;
+    setHighlightedMonitorPreview(initialMonitorIndex >= 0 ? initialMonitorIndex
+                                                          : 0);
+
+    for (QWidget* picker : pickers) {
+        if (wayland) {
+            picker->showFullScreen();
+        } else {
+            picker->show();
+        }
+        picker->raise();
+        picker->activateWindow();
+        picker->setFocus(Qt::ActiveWindowFocusReason);
+    }
+    return pickers;
 }
 
 void ScreenGrabber::cancelMonitorSelection()
@@ -721,36 +826,23 @@ void ScreenGrabber::moveHighlightedMonitorPreview(int offset)
         return;
     }
 
-    int nextPreviewIndex = m_highlightedMonitorPreview;
-    if (nextPreviewIndex < 0) {
-        nextPreviewIndex = 0;
+    int nextMonitorIndex = m_highlightedMonitorPreview;
+    if (nextMonitorIndex < 0) {
+        nextMonitorIndex = 0;
     } else {
-        nextPreviewIndex += offset;
+        nextMonitorIndex += offset;
     }
 
-    setHighlightedMonitorPreview(nextPreviewIndex);
-}
-
-int ScreenGrabber::previewIndexForMonitor(int monitorIndex) const
-{
-    for (int i = 0; i < m_monitorPreviews.size(); ++i) {
-        if (m_monitorPreviews[i]->monitorIndex() == monitorIndex) {
-            return i;
-        }
-    }
-
-    return -1;
+    setHighlightedMonitorPreview(nextMonitorIndex);
 }
 
 void ScreenGrabber::selectHighlightedMonitorPreview()
 {
-    if (m_highlightedMonitorPreview < 0 ||
-        m_highlightedMonitorPreview >= m_monitorPreviews.size()) {
+    if (m_highlightedMonitorPreview < 0) {
         return;
     }
 
-    selectMonitor(
-      m_monitorPreviews[m_highlightedMonitorPreview]->monitorIndex());
+    selectMonitor(m_highlightedMonitorPreview);
 }
 
 void ScreenGrabber::selectMonitor(int monitorIndex)
@@ -761,21 +853,23 @@ void ScreenGrabber::selectMonitor(int monitorIndex)
     }
 }
 
-void ScreenGrabber::setHighlightedMonitorPreview(int previewIndex)
+void ScreenGrabber::setHighlightedMonitorPreview(int monitorIndex)
 {
     if (m_monitorPreviews.isEmpty()) {
         m_highlightedMonitorPreview = -1;
         return;
     }
 
-    const int previewCount = m_monitorPreviews.size();
-    int normalizedIndex = previewIndex % previewCount;
+    const int monitorCount = QGuiApplication::screens().size();
+    int normalizedIndex = monitorIndex % monitorCount;
     if (normalizedIndex < 0) {
-        normalizedIndex += previewCount;
+        normalizedIndex += monitorCount;
     }
 
-    for (int i = 0; i < previewCount; ++i) {
-        m_monitorPreviews[i]->setSelected(i == normalizedIndex);
+    // Every picker window shows one preview per monitor, so highlight the
+    // matching preview in all of them.
+    for (MonitorPreview* preview : m_monitorPreviews) {
+        preview->setSelected(preview->monitorIndex() == normalizedIndex);
     }
     m_highlightedMonitorPreview = normalizedIndex;
 }
@@ -785,6 +879,21 @@ bool ScreenGrabber::eventFilter(QObject* obj, QEvent* event)
     if (event->type() == QEvent::Close) {
         cancelMonitorSelection();
         return true;
+    }
+    // A click on a picker's background selects the monitor that picker
+    // represents. This is how the Wayland compact pickers are operated: they
+    // are fullscreen windows (the only way to pin them to a monitor) and
+    // receive every click, since there is no input pass-through without a
+    // mask (masks render the unmasked area black on Wayland).
+    if (event->type() == QEvent::MouseButtonPress) {
+        QMouseEvent* mouseEvent = static_cast<QMouseEvent*>(event);
+        if (mouseEvent->button() == Qt::LeftButton) {
+            const int monitorIndex = obj->property("monitorIndex").toInt();
+            if (obj->property("monitorIndex").isValid()) {
+                selectMonitor(monitorIndex);
+                return true;
+            }
+        }
     }
     if (event->type() == QEvent::KeyPress) {
         QKeyEvent* keyEvent = static_cast<QKeyEvent*>(event);
@@ -811,7 +920,7 @@ bool ScreenGrabber::eventFilter(QObject* obj, QEvent* event)
                 if (keyEvent->key() >= Qt::Key_1 &&
                     keyEvent->key() <= Qt::Key_9) {
                     int monitorIndex = keyEvent->key() - Qt::Key_1;
-                    if (previewIndexForMonitor(monitorIndex) >= 0) {
+                    if (monitorIndex < QGuiApplication::screens().size()) {
                         selectMonitor(monitorIndex);
                     }
                     return true;

--- a/src/utils/screengrabber.cpp
+++ b/src/utils/screengrabber.cpp
@@ -820,31 +820,6 @@ void ScreenGrabber::cancelMonitorSelection()
     }
 }
 
-void ScreenGrabber::moveHighlightedMonitorPreview(int offset)
-{
-    if (m_monitorPreviews.isEmpty()) {
-        return;
-    }
-
-    int nextMonitorIndex = m_highlightedMonitorPreview;
-    if (nextMonitorIndex < 0) {
-        nextMonitorIndex = 0;
-    } else {
-        nextMonitorIndex += offset;
-    }
-
-    setHighlightedMonitorPreview(nextMonitorIndex);
-}
-
-void ScreenGrabber::selectHighlightedMonitorPreview()
-{
-    if (m_highlightedMonitorPreview < 0) {
-        return;
-    }
-
-    selectMonitor(m_highlightedMonitorPreview);
-}
-
 void ScreenGrabber::selectMonitor(int monitorIndex)
 {
     m_selectedMonitor = monitorIndex;
@@ -897,34 +872,9 @@ bool ScreenGrabber::eventFilter(QObject* obj, QEvent* event)
     }
     if (event->type() == QEvent::KeyPress) {
         QKeyEvent* keyEvent = static_cast<QKeyEvent*>(event);
-        switch (keyEvent->key()) {
-            case Qt::Key_Escape:
-                cancelMonitorSelection();
-                return true;
-            case Qt::Key_Left:
-            case Qt::Key_Up:
-            case Qt::Key_Backtab:
-                moveHighlightedMonitorPreview(-1);
-                return true;
-            case Qt::Key_Right:
-            case Qt::Key_Down:
-            case Qt::Key_Tab:
-                moveHighlightedMonitorPreview(1);
-                return true;
-            case Qt::Key_Return:
-            case Qt::Key_Enter:
-            case Qt::Key_Space:
-                selectHighlightedMonitorPreview();
-                return true;
-            default:
-                if (keyEvent->key() >= Qt::Key_1 &&
-                    keyEvent->key() <= Qt::Key_9) {
-                    int monitorIndex = keyEvent->key() - Qt::Key_1;
-                    if (monitorIndex < QGuiApplication::screens().size()) {
-                        selectMonitor(monitorIndex);
-                    }
-                    return true;
-                }
+        if (keyEvent->key() == Qt::Key_Escape) {
+            cancelMonitorSelection();
+            return true;
         }
     }
     return QObject::eventFilter(obj, event);

--- a/src/utils/screengrabber.cpp
+++ b/src/utils/screengrabber.cpp
@@ -7,7 +7,6 @@
 #include "utils/systemnotification.h"
 
 #include <QApplication>
-#include <QDBusArgument>
 #include <QEventLoop>
 #include <QGuiApplication>
 #include <QHBoxLayout>
@@ -31,6 +30,7 @@
 
 #if !(defined(Q_OS_MACOS) || defined(Q_OS_WIN))
 #include "request.h"
+#include <QDBusArgument>
 #include <QDBusInterface>
 #include <QDBusMessage>
 #include <QDBusReply>
@@ -431,6 +431,8 @@ QRect ScreenGrabber::desktopGeometry()
 
 namespace {
 
+#if !(defined(Q_OS_MACOS) || defined(Q_OS_WIN))
+
 // Skip a `a{sv}` (string -> variant) dictionary on the QDBusArgument cursor.
 void skipVariantMap(const QDBusArgument& arg)
 {
@@ -496,6 +498,8 @@ void skipMonitorsArray(const QDBusArgument& arg)
 }
 
 } // namespace
+
+#endif
 
 QScreen* ScreenGrabber::reliablePrimaryScreen()
 {

--- a/src/utils/screengrabber.h
+++ b/src/utils/screengrabber.h
@@ -40,6 +40,12 @@ public:
     // from mutter. Falls back to QGuiApplication::primaryScreen() everywhere
     // else.
     static QScreen* reliablePrimaryScreen();
+    // Returns the monitor containing the pointer. On X11 the global cursor
+    // position is reliable. On Wayland compositors do not expose the global
+    // pointer position before a surface is mapped, but they place new windows
+    // on the monitor containing the pointer, so a tiny invisible probe window
+    // is mapped and the screen the compositor assigned to it is returned.
+    QScreen* cursorMonitor();
     int getSelectedMonitor() const { return m_selectedMonitor; }
     QScreen* getSelectedScreen() const;
     QPixmap selectMonitorAndCrop(const QPixmap& fullScreenshot, bool& ok);
@@ -49,13 +55,15 @@ protected:
 
 private:
     void adjustDevicePixelRatio(QPixmap& pixmap);
-    QWidget* createMonitorPreviews(const QPixmap& fullScreenshot);
+    QList<QWidget*> createMonitorPreviews(const QPixmap& fullScreenshot,
+                                          QScreen* cursorScreen);
     void cancelMonitorSelection();
     void moveHighlightedMonitorPreview(int offset);
-    int previewIndexForMonitor(int monitorIndex) const;
     void selectHighlightedMonitorPreview();
     void selectMonitor(int monitorIndex);
-    void setHighlightedMonitorPreview(int previewIndex);
+    // m_highlightedMonitorPreview holds a monitor index (not a preview index)
+    // because every picker window shows one preview per monitor.
+    void setHighlightedMonitorPreview(int monitorIndex);
     QPixmap cropToMonitor(const QPixmap& fullScreenshot, int monitorIndex);
     QPixmap windowsScreenshot(int wid);
     QPixmap x11LegacyScreenshot();

--- a/src/utils/screengrabber.h
+++ b/src/utils/screengrabber.h
@@ -33,6 +33,13 @@ public:
     PortalStatus freeDesktopPortal(QPixmap& res, QString& errorDetail);
     QRect desktopGeometry();
     QRect logicalDesktopGeometry();
+    // Returns the monitor the user actually configured as primary. On GNOME
+    // Wayland QGuiApplication::primaryScreen() is unreliable (Qt's wayland
+    // plugin does not implement the wp_primary_output protocol, so it reports
+    // the first wl_output instead), therefore the real primary is queried
+    // from mutter. Falls back to QGuiApplication::primaryScreen() everywhere
+    // else.
+    static QScreen* reliablePrimaryScreen();
     int getSelectedMonitor() const { return m_selectedMonitor; }
     QScreen* getSelectedScreen() const;
     QPixmap selectMonitorAndCrop(const QPixmap& fullScreenshot, bool& ok);

--- a/src/utils/screengrabber.h
+++ b/src/utils/screengrabber.h
@@ -58,8 +58,6 @@ private:
     QList<QWidget*> createMonitorPreviews(const QPixmap& fullScreenshot,
                                           QScreen* cursorScreen);
     void cancelMonitorSelection();
-    void moveHighlightedMonitorPreview(int offset);
-    void selectHighlightedMonitorPreview();
     void selectMonitor(int monitorIndex);
     // m_highlightedMonitorPreview holds a monitor index (not a preview index)
     // because every picker window shows one preview per monitor.

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -191,14 +191,35 @@ CaptureWidget::CaptureWidget(const CaptureRequest& req,
 
         // Always display on the selected screen (not spanning entire desktop)
         if (selectedScreen == nullptr) {
+            // On X11 fall back to the monitor under the cursor. On Wayland the
+            // cursor position is not exposed to clients and Qt's primaryScreen
+            // is unreliable (see ScreenGrabber::reliablePrimaryScreen), so use
+            // the monitor the desktop reports as primary instead.
+            if (DesktopInfo().waylandDetected()) {
+                selectedScreen = ScreenGrabber::reliablePrimaryScreen();
+            } else {
+                selectedScreen = QGuiAppCurrentScreen().currentScreen();
+            }
+        }
+        if (selectedScreen == nullptr) {
             selectedScreen = QGuiApplication::primaryScreen();
         }
-        QRect screenGeom = selectedScreen->geometry();
-        move(screenGeom.topLeft());
-        resize(screenGeom.size());
+        if (selectedScreen) {
+            QRect screenGeom = selectedScreen->geometry();
+            move(screenGeom.topLeft());
+            resize(screenGeom.size());
 
-        if (selectedScreen != nullptr && windowHandle()) {
-            windowHandle()->setScreen(selectedScreen);
+            // Force the native window to exist so setScreen() actually takes
+            // effect. Without winId() this block was a silent no-op (window-
+            // Handle() returns null before the widget is shown) and on Wayland
+            // the compositor mapped the fullscreen capture window on the first
+            // output instead of the selected monitor. QWindow::setScreen()
+            // recreates the window on the target screen, which is the only
+            // reliable way to choose the monitor on Wayland.
+            winId();
+            if (QWindow* handle = windowHandle()) {
+                handle->setScreen(selectedScreen);
+            }
         }
 #endif
     }

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -211,14 +211,20 @@ CaptureWidget::CaptureWidget(const CaptureRequest& req,
 
             // Force the native window to exist so setScreen() actually takes
             // effect. Without winId() this block was a silent no-op (window-
-            // Handle() returns null before the widget is shown) and on Wayland
-            // the compositor mapped the fullscreen capture window on the first
-            // output instead of the selected monitor. QWindow::setScreen()
-            // recreates the window on the target screen, which is the only
-            // reliable way to choose the monitor on Wayland.
+            // Handle() returns null before the widget is shown).
             winId();
             if (QWindow* handle = windowHandle()) {
                 handle->setScreen(selectedScreen);
+            }
+
+            // On Wayland the compositor ignores the position of regular
+            // windows and maps them on the monitor containing the pointer, so
+            // setScreen() alone is not enough. Fullscreen is the only window
+            // state where the requested output is honored (the compositor
+            // receives xdg_toplevel.set_fullscreen with the output), so ask
+            // for it here -- the widget covers the selected screen anyway.
+            if (DesktopInfo().waylandDetected()) {
+                setWindowState(windowState() | Qt::WindowFullScreen);
             }
         }
 #endif


### PR DESCRIPTION
## Summary

Improves the Wayland monitor picker: it auto-selects the monitor under the cursor (matching the X11 "capture active monitor" behavior) and renders compactly on every screen so multi-monitor setups stay readable.

## Changes

- **Auto-select**: the picker now pre-selects the monitor under the cursor instead of always the first one. On Wayland the cursor position is not exposed to clients, so the selection is derived from the portal monitor descriptions introduced in the base PR.
- **Compact picker**: preview boxes, margins and fonts scale down so the picker fits comfortably on each screen.
- **Click-only picker**: keyboard-based monitor selection (number keys, arrows, Enter) is removed. On Wayland the picker surfaces never receive keyboard focus, so those shortcuts were dead weight; selection is mouse-only, Escape still cancels.

| File | Change |
| --- | --- |
| `src/utils/monitorpreview.cpp` / `.h` | `compact` mode with smaller layout and fonts, click-only hint, no number key labels |
| `src/utils/screengrabber.cpp` / `.h` | Monitor-under-cursor selection, compact picker layout across screens, click-only input handling |
| `src/widgets/capture/capturewidget.cpp` | Picker sizing / auto-selection wiring |

## Test plan

- [x] `cmake --build build-codebuff --target flameshot` passes
- [x] Manual, Wayland multi-monitor: picker opens compact on every screen and pre-selects the monitor under the cursor
- [x] Manual, Wayland multi-monitor: click selects the monitor, Escape cancels, number keys no longer shown

---

### Chain context

Second PR of a stacked chain (3 PRs):

1. ← `fix/wayland-monitor-placement` (#4874) — base: fix Wayland monitor placement
2. 📍 **This PR** — auto-select monitor under cursor + compact picker on every screen
3. → `feat/hybrid-monitor-switching` — "Capture this monitor" strips + reuse stored screenshots

Out of scope: capture-time monitor switching — that lands in the next PR.