### PR TITLE
Copy text to the clipboard through KSystemClipboard on Wayland

### DIFF
--- a/src/core/flameshotdaemon.cpp
+++ b/src/core/flameshotdaemon.cpp
@@ -11,8 +11,13 @@
 #include <QApplication>
 #include <QClipboard>
 #include <QIODevice>
+#include <QMimeData>
 #include <QPixmap>
 #include <QRect>
+
+#if defined(USE_WAYLAND_CLIPBOARD)
+#include <KSystemClipboard>
+#endif
 
 #if !(defined(Q_OS_MACOS) || defined(Q_OS_WIN))
 #include <QDBusConnection>
@@ -354,6 +359,21 @@ void FlameshotDaemon::attachTextToClipboard(const QString& text,
     }
 
     m_hostingClipboard = true;
+
+#if defined(USE_WAYLAND_CLIPBOARD)
+    if (QGuiApplication::platformName() == "wayland") {
+        // The daemon has no focused surface, so a plain QClipboard write is
+        // silently dropped by the compositor. KSystemClipboard goes through
+        // the data-control protocol, which does not need focus. This is the
+        // same reason saveToClipboard() uses it for images.
+        auto* mimeData = new QMimeData();
+        mimeData->setText(text);
+        KSystemClipboard::instance()->setMimeData(mimeData,
+                                                  QClipboard::Clipboard);
+        return;
+    }
+#endif
+
     QClipboard* clipboard = QApplication::clipboard();
 
     clipboard->blockSignals(true);


### PR DESCRIPTION
### The problem

On Wayland a compositor only accepts a clipboard write from a client that owns
a focused surface. The daemon has none, so the `QClipboard::setText()` call in
`FlameshotDaemon::attachTextToClipboard()` is silently dropped and the text
never reaches the clipboard. Nothing reports an error — the daemon even logs
"Text copied to clipboard." while the clipboard keeps its previous contents.

This affects every text-to-clipboard path, most visibly the URL copied after an
upload (`copyURLAfterUpload`).

### Why images are not affected

`saveToClipboard()` already handles this: when built with
`USE_WAYLAND_CLIPBOARD` it writes through `KSystemClipboard`, which uses the
data-control protocol and needs no focus. Only the text path was left on plain
`QClipboard`.

### The fix

Give text the same route, guarded by the same build option and the same
`platformName() == "wayland"` check that the image path uses. On X11, macOS and
Windows nothing changes.

### Testing

Reproduced and verified on Arch Linux (aarch64), Qt 6, wlroots-based compositor
with `xdg-desktop-portal-wlr`, built with `-DUSE_WAYLAND_CLIPBOARD=1`:

- before: the daemon logs the notification, `wl-paste` still returns the
  previous clipboard contents;
- after: `wl-paste` returns the text.

Builds cleanly with and without `USE_WAYLAND_CLIPBOARD`.
