### PR TITLE
packaging: drop the copied build directory in prepare()

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -19,6 +19,12 @@ source=()
 
 prepare() {
     cp -R "${startdir}/" "${srcdir}/${_pkgname}/"
+
+    # A build directory left over from working on the source tree is copied
+    # along with it, and its CMakeCache.txt still points at the original paths,
+    # which makes the cmake call in build() fail. The .git directory has to stay
+    # because pkgver() reads it.
+    rm -rf "${srcdir}/${_pkgname}/build"
 }
 
 pkgver() {


### PR DESCRIPTION
### The problem

`prepare()` copies the whole source tree into `$srcdir`, so a `build` directory
left over from working on that tree comes along with it. Its `CMakeCache.txt`
still records the original absolute paths, and the `cmake` call in `build()`
refuses to reuse a cache that was created elsewhere:

```
CMake Error: The current CMakeCache.txt directory
/home/user/.cache/makepkg/flameshot-git/src/flameshot/build/CMakeCache.txt is
different than the directory /home/user/sources/flameshot/build where
CMakeCache.txt was created.
CMake Error: The source ".../src/flameshot/CMakeLists.txt" does not match the
source "/home/user/sources/flameshot/CMakeLists.txt" used to generate cache.
==> ERROR: A failure occurred in build().
```

This hits anyone who builds the project normally and then runs `makepkg` in the
same checkout, which is the usual way to try out a local change as a package.

### The fix

Remove the copied `build` directory after the copy. The `.git` directory has to
stay, since `pkgver()` reads the revision from it.

### Testing

On Arch Linux (aarch64): with a `build` directory present, `makepkg` fails as
above before the change and completes after it.
