### PR TITLE
packaging: link against the system KDSingleApplication

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -6,7 +6,7 @@ pkgdesc="Powerful yet simple to use screenshot software"
 arch=('i686' 'x86_64' 'aarch64' 'armv7h')
 url="https://github.com/flameshot-org/flameshot"
 license=('GPL-3.0-or-later')
-depends=('qt6-base' 'qt6-svg' 'hicolor-icon-theme' 'kguiaddons')
+depends=('qt6-base' 'qt6-svg' 'hicolor-icon-theme' 'kguiaddons' 'kdsingleapplication')
 makedepends=('qt6-tools' 'cmake' 'ninja')
 optdepends=(
     'gnome-shell-extension-appindicator: for system tray icon if you are using Gnome'
@@ -35,6 +35,7 @@ build() {
         -DCMAKE_INSTALL_PREFIX=/usr \
         -DUSE_WAYLAND_CLIPBOARD=1 \
         -DDISABLE_UPDATE_CHECKER=1 \
+        -DUSE_BUNDLED_KDSINGLEAPPLICATION=OFF \
 
     cmake --build build
 }


### PR DESCRIPTION
### The problem

`USE_BUNDLED_KDSINGLEAPPLICATION` defaults to `ON`, and the bundled build
installs the library's development files along with flameshot. The resulting
package therefore ships:

```
usr/include/kdsingleapplication-qt6/kdsingleapplication.h
usr/include/kdsingleapplication-qt6/kdsingleapplication_lib.h
usr/include/kdsingleapplication-qt6/kdsingleapplication_version.h
usr/lib/cmake/KDSingleApplication-qt6/KDSingleApplication-qt6Targets.cmake
usr/lib/cmake/KDSingleApplication-qt6/KDSingleApplication-qt6Targets-none.cmake
usr/lib/libkdsingleapplication-qt6.a
```

On a system that already has the `kdsingleapplication` package — it is in
Arch's `extra` — pacman refuses to install:

```
error: failed to commit transaction (conflicting files)
flameshot-git: /usr/include/kdsingleapplication-qt6/kdsingleapplication.h
exists in filesystem (owned by kdsingleapplication)
...
```

The library is linked statically, so those headers, cmake targets and the
static archive serve no purpose inside the flameshot package.

### The fix

Build against the system copy and declare the dependency. Arch ships 1.2.1,
the same version the bundled build fetches, so this is not a version downgrade.

### Testing

On Arch Linux (aarch64), with `kdsingleapplication 1.2.1-1` installed: the
package fails to install before the change and installs cleanly after it.
Checked every file of the resulting package with `pacman -Qo` — none is owned
by another package now.
