### PR TITLE
Add option to disable the Circle Counter outline

### DIFF
--- a/flameshot.example.ini
+++ b/flameshot.example.ini
@@ -73,6 +73,9 @@
 ;; Last used Circle Counter size (int)
 ;drawCircleCounterSize=1
 ;
+;; Draw a contrasting outline ring around the Circle Counter bubble (bool)
+;drawCircleCounterOutline=true
+;
 ;; Last used Pixelate pixel size (int)
 ;drawPixelateSize=2
 ;

--- a/src/config/generalconf.cpp
+++ b/src/config/generalconf.cpp
@@ -79,6 +79,7 @@ GeneralConf::GeneralConf(QWidget* parent)
     initSquareMagnifier();
     initJpegQuality();
     initReverseArrow();
+    initDrawCircleCounterOutline();
     // this has to be at the end
     initConfigButtons();
     updateComponents();
@@ -113,6 +114,7 @@ void GeneralConf::_updateComponents(bool allowEmptySavePath)
     m_squareMagnifier->setChecked(config.squareMagnifier());
     m_saveLastRegion->setChecked(config.saveLastRegion());
     m_reverseArrow->setChecked(config.reverseArrow());
+    m_drawCircleCounterOutline->setChecked(config.drawCircleCounterOutline());
     m_autoCloseIdleDaemon->setChecked(config.autoCloseIdleDaemon());
     m_predefinedColorPaletteLarge->setChecked(
       config.predefinedColorPaletteLarge());
@@ -863,6 +865,20 @@ void GeneralConf::initReverseArrow()
 
     connect(
       m_reverseArrow, &QCheckBox::clicked, this, &GeneralConf::setReverseArrow);
+}
+
+void GeneralConf::initDrawCircleCounterOutline()
+{
+    m_drawCircleCounterOutline =
+      new QCheckBox(tr("Draw outline around circle counter"), this);
+    m_drawCircleCounterOutline->setToolTip(
+      tr("Draw a contrasting ring around the counter bubble so it stays "
+         "visible on any background"));
+    m_scrollAreaLayout->addWidget(m_drawCircleCounterOutline);
+
+    connect(m_drawCircleCounterOutline, &QCheckBox::clicked, [](bool checked) {
+        ConfigHandler().setDrawCircleCounterOutline(checked);
+    });
 }
 
 void GeneralConf::initInsecurePixelate()

--- a/src/config/generalconf.h
+++ b/src/config/generalconf.h
@@ -107,6 +107,7 @@ private:
     void initShowSelectionGeometry();
     void initJpegQuality();
     void initReverseArrow();
+    void initDrawCircleCounterOutline();
     void initInsecurePixelate();
 #if !defined(Q_OS_MACOS)
     void initCaptureActiveMonitor();
@@ -164,6 +165,7 @@ private:
     QSpinBox* m_xywhTimeout;
     QSpinBox* m_jpegQuality;
     QCheckBox* m_reverseArrow;
+    QCheckBox* m_drawCircleCounterOutline;
     QCheckBox* m_insecurePixelate;
 #if !defined(Q_OS_MACOS)
     QCheckBox* m_captureActiveMonitor;

--- a/src/tools/circlecount/circlecounttool.cpp
+++ b/src/tools/circlecount/circlecounttool.cpp
@@ -3,6 +3,7 @@
 
 #include "circlecounttool.h"
 #include "utils/colorutils.h"
+#include "utils/confighandler.h"
 
 #include <QPainter>
 #include <QPainterPath>
@@ -134,10 +135,15 @@ void CircleCountTool::process(QPainter& painter, const QPixmap& pixmap)
         painter.drawPath(path);
     }
 
-    painter.setPen(contrastColor);
-    painter.setBrush(antiContrastColor);
-    painter.drawEllipse(
-      points().first, bubble_size + PADDING_VALUE, bubble_size + PADDING_VALUE);
+    if (ConfigHandler().drawCircleCounterOutline()) {
+        painter.setPen(contrastColor);
+        painter.setBrush(antiContrastColor);
+        painter.drawEllipse(points().first,
+                            bubble_size + PADDING_VALUE,
+                            bubble_size + PADDING_VALUE);
+    } else {
+        painter.setPen(Qt::NoPen);
+    }
     painter.setBrush(color());
     painter.drawEllipse(points().first, bubble_size, bubble_size);
     QRect textRect = QRect(points().first.x() - bubble_size / 2,

--- a/src/utils/confighandler.cpp
+++ b/src/utils/confighandler.cpp
@@ -118,6 +118,7 @@ static QMap<class QString, QSharedPointer<ValueHandler>>
     OPTION("drawThickness"               ,LowerBoundedInt    ( 1, 3          )),
     OPTION("drawFontSize"                ,LowerBoundedInt    ( 1, 8          )),
     OPTION("drawCircleCounterSize"       ,LowerBoundedInt    ( 1, 1          )),
+    OPTION("drawCircleCounterOutline"    ,Bool               ( true          )),
     OPTION("drawPixelateSize"            ,LowerBoundedInt    ( 1, 2          )),
     OPTION("drawRectangleSize"           ,LowerBoundedInt    ( 1, 1          )),
     OPTION("drawMarkerSize"              ,LowerBoundedInt    ( 1, 5          )),

--- a/src/utils/confighandler.h
+++ b/src/utils/confighandler.h
@@ -94,6 +94,9 @@ public:
     CONFIG_GETTER_SETTER(drawThickness, setDrawThickness, int)
     CONFIG_GETTER_SETTER(drawFontSize, setDrawFontSize, int)
     CONFIG_GETTER_SETTER(drawCircleCounterSize, setDrawCircleCounterSize, int)
+    CONFIG_GETTER_SETTER(drawCircleCounterOutline,
+                         setDrawCircleCounterOutline,
+                         bool)
     CONFIG_GETTER_SETTER(drawPixelateSize, setDrawPixelateSize, int)
     CONFIG_GETTER_SETTER(drawRectangleSize, setDrawRectangleSize, int)
     CONFIG_GETTER_SETTER(drawMarkerSize, setDrawMarkerSize, int)


### PR DESCRIPTION
Closes #3580

### Problem

The Circle Counter bubble is always drawn with a contrasting ring around it, and there is currently no way to turn it off.

The ring appears black for both light and dark draw colors, but by two different mechanisms in `CircleCountTool::process()`:

- an outer ellipse is **filled** with `antiContrastColor` — this is what shows on *dark* draw colors (e.g. red)
- the pen is set to `contrastColor` and **strokes both** ellipses — this is what shows on *light* draw colors (e.g. green)

So disabling only one of the two would still leave a dark border for half the palette.

### Change

Adds a `drawCircleCounterOutline` option plus a matching checkbox in *Configuration > General*, and documents it in `flameshot.example.ini`.

When the option is off, the outer ellipse is skipped and the pen is set to `Qt::NoPen` before the bubble is drawn, which removes both sources of the ring. The text pen is unaffected — it is reassigned to `contrastColor` before `drawText()` — so the number keeps its automatic contrast color.

### Default behaviour

The option defaults to `true`, so the rendering is byte-for-byte unchanged for existing users, and nothing is written to the config file unless the option is actually toggled.

### Notes

This was previously raised in #3008, where the response was that the ring is intended design and could be made customizable via a feature request. #3580 is that request; this PR implements it.

### Testing

Built and run on Windows 11 (MSVC 19.44, Qt 6.9.3, CMake 4.4). Verified that the checkbox is checked by default, that toggling it persists to `flameshot.ini`, and that counter bubbles render without the ring for both dark and light draw colors. `clang-format` reports no changes to the modified regions.
