### PR TITLE
Add per-location save hotkeys, Imgur uploader, and reskin support

### DIFF
--- a/contrib/flameshot-theme/assets/check.svg
+++ b/contrib/flameshot-theme/assets/check.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <path d="M3 8.5 L6.5 12 L13 4" fill="none" stroke="#ffffff" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/contrib/flameshot-theme/crazy-mechanics.conf
+++ b/contrib/flameshot-theme/crazy-mechanics.conf
@@ -1,0 +1,7 @@
+# crazy-mechanics :: default theme (active outside Halloween/New Year windows)
+# Source: nicitaacom/14_portfolio app/styles/theme-crazy-mechanics.css
+#   cta 277deg 100% 68% | brass 40deg 45% 55% | primary 0deg 0% 13%
+MAIN=#c05cff
+CONTRAST=#c09d59
+DRAW=#c05cff
+USER_COLORS="picker, #c05cff, #c09d59, #212121, #7c6892, #5f8c74"

--- a/contrib/flameshot-theme/crazy-mechanics.qss
+++ b/contrib/flameshot-theme/crazy-mechanics.qss
@@ -1,0 +1,210 @@
+/* flameshot-theme :: crazy-mechanics
+ * Structure borrowed from the github-desktop-accent box-in-box panel
+ * language (surface/border/hover/selected), colors from the Crazy
+ * Mechanics design system (nicitaacom/14_portfolio).
+ *   room #1b1b1b | surface #242424 | raised #3a3542 | border #7d6f92
+ *   accent #c05cff | accent-bright #d68bff | on-accent #210633
+ *   text #e8e8e8 | secondary #8f8698
+ */
+
+QWidget {
+    background-color: #1b1b1b;
+    color: #e8e8e8;
+    selection-background-color: #c05cff;
+    selection-color: #210633;
+}
+
+QDialog, QMainWindow {
+    background-color: #1b1b1b;
+}
+
+QScrollArea, QAbstractScrollArea::viewport {
+    background-color: #1b1b1b;
+    border: none;
+}
+
+QGroupBox {
+    background-color: #242424;
+    border: 1px solid #7d6f92;
+    border-radius: 6px;
+    margin-top: 14px;
+    padding: 14px 10px 12px 10px;
+    font-weight: 600;
+}
+QGroupBox::title {
+    subcontrol-origin: margin;
+    left: 10px;
+    top: -2px;
+    padding: 1px 6px;
+    color: #e8e8e8;
+    font-weight: 700;
+}
+
+QTabWidget::pane {
+    background-color: #242424;
+    border: 1px solid #7d6f92;
+    border-radius: 6px;
+    top: -1px;
+}
+QTabBar::tab {
+    background-color: #1b1b1b;
+    color: #8f8698;
+    border: 1px solid #7d6f92;
+    border-bottom: none;
+    border-top-left-radius: 6px;
+    border-top-right-radius: 6px;
+    padding: 6px 14px;
+    margin-right: 2px;
+}
+QTabBar::tab:selected {
+    background-color: #242424;
+    color: #e8e8e8;
+    border-bottom: 2px solid #c05cff;
+}
+QTabBar::tab:hover:!selected {
+    background-color: #3a3542;
+    color: #e8e8e8;
+}
+
+QPushButton {
+    background-color: #3a3542;
+    color: #e8e8e8;
+    border: 1px solid #7d6f92;
+    border-radius: 5px;
+    padding: 5px 14px;
+}
+QPushButton:hover {
+    background-color: #7d6f92;
+    border-color: #c05cff;
+}
+QPushButton:pressed {
+    background-color: #c05cff;
+    color: #210633;
+}
+QPushButton:disabled {
+    color: #8f8698;
+    background-color: #1b1b1b;
+    border: 1px solid #1b1b1b;
+}
+QPushButton:default {
+    border: 1px solid #c05cff;
+}
+
+QLineEdit, QSpinBox, QComboBox, QAbstractSpinBox {
+    background-color: #1b1b1b;
+    color: #e8e8e8;
+    border: 1px solid #7d6f92;
+    border-radius: 4px;
+    padding: 3px 6px;
+}
+QLineEdit:focus, QSpinBox:focus, QComboBox:focus {
+    border: 1px solid #c05cff;
+}
+QLineEdit:disabled {
+    color: #8f8698;
+}
+QComboBox::drop-down {
+    border: none;
+    width: 18px;
+}
+QComboBox QAbstractItemView {
+    background-color: #242424;
+    color: #e8e8e8;
+    border: 1px solid #7d6f92;
+    selection-background-color: #c05cff;
+    selection-color: #210633;
+}
+
+QCheckBox {
+    color: #e8e8e8;
+    spacing: 8px;
+}
+QCheckBox::indicator {
+    width: 14px;
+    height: 14px;
+    border: 1px solid #7d6f92;
+    border-radius: 3px;
+    background-color: #1b1b1b;
+}
+QCheckBox::indicator:checked {
+    background-color: #c05cff;
+    border-color: #d68bff;
+    image: url(/home/kali/.local/share/flameshot-theme/assets/check.svg);
+}
+QCheckBox::indicator:hover {
+    border-color: #c05cff;
+}
+
+QLabel {
+    color: #e8e8e8;
+    background: transparent;
+}
+
+QMenu {
+    background-color: #242424;
+    color: #e8e8e8;
+    border: 1px solid #7d6f92;
+}
+QMenu::item:selected {
+    background-color: #c05cff;
+    color: #210633;
+}
+
+QToolTip {
+    background-color: #3a3542;
+    color: #e8e8e8;
+    border: 1px solid #c05cff;
+    padding: 4px;
+}
+
+QScrollBar:vertical {
+    background: #1b1b1b;
+    width: 10px;
+    margin: 0;
+}
+QScrollBar::handle:vertical {
+    background: #7d6f92;
+    border-radius: 5px;
+    min-height: 24px;
+}
+QScrollBar::handle:vertical:hover {
+    background: #c05cff;
+}
+QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical {
+    height: 0;
+}
+
+QListView, QTreeView, QTableView, QTableWidget {
+    background-color: #1b1b1b;
+    color: #e8e8e8;
+    border: 1px solid #7d6f92;
+    alternate-background-color: #242424;
+    gridline-color: #7d6f92;
+}
+QListView::item:selected, QTreeView::item:selected,
+QTableView::item:selected, QTableWidget::item:selected {
+    background-color: #c05cff;
+    color: #210633;
+}
+QListView::item:hover, QTreeView::item:hover,
+QTableView::item:hover, QTableWidget::item:hover {
+    background-color: #3a3542;
+}
+QHeaderView::section {
+    background-color: #242424;
+    color: #e8e8e8;
+    border: 1px solid #7d6f92;
+    padding: 4px 6px;
+}
+
+QSlider::groove:horizontal {
+    background: #7d6f92;
+    height: 4px;
+    border-radius: 2px;
+}
+QSlider::handle:horizontal {
+    background: #c05cff;
+    width: 14px;
+    margin: -6px 0;
+    border-radius: 7px;
+}

--- a/contrib/flameshot-theme/flameshot-seasonal-theme
+++ b/contrib/flameshot-theme/flameshot-seasonal-theme
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Auto-applies the seasonal Flameshot theme for the current month, mirroring
+# nicitaacom/14_portfolio's THEME_MONTHS schedule:
+#   11        -> halloween
+#   12, 1     -> new-year
+#   otherwise -> green (default)
+set -euo pipefail
+
+MONTH=$(date +%-m)
+
+case "$MONTH" in
+    11) THEME="halloween" ;;
+    12|1) THEME="new-year" ;;
+    *) THEME="green" ;;
+esac
+
+CURRENT_MARKER="$HOME/.local/share/flameshot-theme/.current"
+if [ -f "$CURRENT_MARKER" ] && [ "$(cat "$CURRENT_MARKER")" = "$THEME" ]; then
+    exit 0
+fi
+
+"$HOME/.local/bin/flameshot-theme" "$THEME"
+echo "$THEME" > "$CURRENT_MARKER"

--- a/contrib/flameshot-theme/flameshot-theme
+++ b/contrib/flameshot-theme/flameshot-theme
@@ -1,0 +1,69 @@
+#!/bin/bash
+# Swaps Flameshot's accent colors using palette files derived from the
+# "Crazy Mechanics" design system (nicitaacom/14_portfolio), same swap
+# mechanism as github-desktop-accent: a marked config file per theme,
+# applied by patching known keys in place.
+#
+#   flameshot-theme <name>      apply a theme (see --list)
+#   flameshot-theme --list      show available themes
+#   flameshot-theme --revert    back to the default (crazy-mechanics)
+set -euo pipefail
+
+THEME_DIR="$HOME/.local/share/flameshot-theme"
+INI="$HOME/.config/flameshot/flameshot.ini"
+
+if [ "${1:-}" = "--list" ]; then
+    ls "$THEME_DIR"/*.conf 2>/dev/null | xargs -n1 basename | sed 's/\.conf$//'
+    exit 0
+fi
+
+if [ "${1:-}" = "--revert" ]; then
+    NAME="crazy-mechanics"
+else
+    NAME="${1:?usage: flameshot-theme <name>|--list|--revert}"
+fi
+
+CONF="$THEME_DIR/$NAME.conf"
+[ -f "$CONF" ] || { echo "no such theme: $NAME (see: flameshot-theme --list)" >&2; exit 1; }
+
+# shellcheck disable=SC1090
+source "$CONF"
+
+QSS="$THEME_DIR/$NAME.qss"
+if [ -f "$QSS" ]; then
+    cp "$QSS" "$THEME_DIR/current.qss"
+else
+    rm -f "$THEME_DIR/current.qss"
+fi
+
+python3 - "$INI" "$MAIN" "$CONTRAST" "$DRAW" "$USER_COLORS" <<'PY'
+import sys
+ini, main, contrast, draw, user_colors = sys.argv[1:6]
+keys = {"uiColor": main, "contrastUiColor": contrast, "drawColor": draw, "userColors": user_colors}
+
+lines = open(ini, encoding="utf-8").read().splitlines()
+seen = set()
+out = []
+for line in lines:
+    k = line.split("=", 1)[0]
+    if k in keys:
+        out.append(f"{k}={keys[k]}")
+        seen.add(k)
+    else:
+        out.append(line)
+idx = out.index("[General]") + 1
+for k, v in keys.items():
+    if k not in seen:
+        out.insert(idx, f"{k}={v}")
+open(ini, "w", encoding="utf-8").write("\n".join(out) + "\n")
+PY
+
+pkill flameshot 2>/dev/null || true
+sleep 0.3
+setsid /usr/local/bin/flameshot >/dev/null 2>&1 &
+disown
+# Give the daemon a moment to finish starting before this script (and its
+# process group) exits - otherwise it can get reaped mid-startup.
+sleep 1.5
+
+echo "applied theme: $NAME (main=$MAIN contrast=$CONTRAST)"

--- a/contrib/flameshot-theme/green.conf
+++ b/contrib/flameshot-theme/green.conf
@@ -1,0 +1,6 @@
+# green :: same dark bg/surface language as ~/.local/bin/github-desktop-accent's
+# dark-green.css, accent set to the requested #60ff00.
+MAIN=#60ff00
+CONTRAST=#ffc107
+DRAW=#60ff00
+USER_COLORS="picker, #60ff00, #ffc107, #101210, #8fff4d, #7fae95"

--- a/contrib/flameshot-theme/green.qss
+++ b/contrib/flameshot-theme/green.qss
@@ -1,0 +1,210 @@
+/* flameshot-theme :: green
+ * Structure borrowed from the github-desktop-accent box-in-box panel
+ * language (surface/border/hover/selected), colors from the Crazy
+ * Mechanics design system (nicitaacom/14_portfolio).
+ *   room #101210 | surface #171a17 | raised #202620 | border #4a6b47
+ *   accent #60ff00 | accent-bright #8fff4d | on-accent #0a1a05
+ *   text #e8f5e0 | secondary #8fae95
+ */
+
+QWidget {
+    background-color: #101210;
+    color: #e8f5e0;
+    selection-background-color: #60ff00;
+    selection-color: #0a1a05;
+}
+
+QDialog, QMainWindow {
+    background-color: #101210;
+}
+
+QScrollArea, QAbstractScrollArea::viewport {
+    background-color: #101210;
+    border: none;
+}
+
+QGroupBox {
+    background-color: #171a17;
+    border: 1px solid #4a6b47;
+    border-radius: 6px;
+    margin-top: 14px;
+    padding: 14px 10px 12px 10px;
+    font-weight: 600;
+}
+QGroupBox::title {
+    subcontrol-origin: margin;
+    left: 10px;
+    top: -2px;
+    padding: 1px 6px;
+    color: #e8f5e0;
+    font-weight: 700;
+}
+
+QTabWidget::pane {
+    background-color: #171a17;
+    border: 1px solid #4a6b47;
+    border-radius: 6px;
+    top: -1px;
+}
+QTabBar::tab {
+    background-color: #101210;
+    color: #8fae95;
+    border: 1px solid #4a6b47;
+    border-bottom: none;
+    border-top-left-radius: 6px;
+    border-top-right-radius: 6px;
+    padding: 6px 14px;
+    margin-right: 2px;
+}
+QTabBar::tab:selected {
+    background-color: #171a17;
+    color: #e8f5e0;
+    border-bottom: 2px solid #60ff00;
+}
+QTabBar::tab:hover:!selected {
+    background-color: #202620;
+    color: #e8f5e0;
+}
+
+QPushButton {
+    background-color: #202620;
+    color: #e8f5e0;
+    border: 1px solid #4a6b47;
+    border-radius: 5px;
+    padding: 5px 14px;
+}
+QPushButton:hover {
+    background-color: #4a6b47;
+    border-color: #60ff00;
+}
+QPushButton:pressed {
+    background-color: #60ff00;
+    color: #0a1a05;
+}
+QPushButton:disabled {
+    color: #8fae95;
+    background-color: #101210;
+    border: 1px solid #101210;
+}
+QPushButton:default {
+    border: 1px solid #60ff00;
+}
+
+QLineEdit, QSpinBox, QComboBox, QAbstractSpinBox {
+    background-color: #101210;
+    color: #e8f5e0;
+    border: 1px solid #4a6b47;
+    border-radius: 4px;
+    padding: 3px 6px;
+}
+QLineEdit:focus, QSpinBox:focus, QComboBox:focus {
+    border: 1px solid #60ff00;
+}
+QLineEdit:disabled {
+    color: #8fae95;
+}
+QComboBox::drop-down {
+    border: none;
+    width: 18px;
+}
+QComboBox QAbstractItemView {
+    background-color: #171a17;
+    color: #e8f5e0;
+    border: 1px solid #4a6b47;
+    selection-background-color: #60ff00;
+    selection-color: #0a1a05;
+}
+
+QCheckBox {
+    color: #e8f5e0;
+    spacing: 8px;
+}
+QCheckBox::indicator {
+    width: 14px;
+    height: 14px;
+    border: 1px solid #4a6b47;
+    border-radius: 3px;
+    background-color: #101210;
+}
+QCheckBox::indicator:checked {
+    background-color: #60ff00;
+    border-color: #8fff4d;
+    image: url(/home/kali/.local/share/flameshot-theme/assets/check.svg);
+}
+QCheckBox::indicator:hover {
+    border-color: #60ff00;
+}
+
+QLabel {
+    color: #e8f5e0;
+    background: transparent;
+}
+
+QMenu {
+    background-color: #171a17;
+    color: #e8f5e0;
+    border: 1px solid #4a6b47;
+}
+QMenu::item:selected {
+    background-color: #60ff00;
+    color: #0a1a05;
+}
+
+QToolTip {
+    background-color: #202620;
+    color: #e8f5e0;
+    border: 1px solid #60ff00;
+    padding: 4px;
+}
+
+QScrollBar:vertical {
+    background: #101210;
+    width: 10px;
+    margin: 0;
+}
+QScrollBar::handle:vertical {
+    background: #4a6b47;
+    border-radius: 5px;
+    min-height: 24px;
+}
+QScrollBar::handle:vertical:hover {
+    background: #60ff00;
+}
+QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical {
+    height: 0;
+}
+
+QListView, QTreeView, QTableView, QTableWidget {
+    background-color: #101210;
+    color: #e8f5e0;
+    border: 1px solid #4a6b47;
+    alternate-background-color: #171a17;
+    gridline-color: #4a6b47;
+}
+QListView::item:selected, QTreeView::item:selected,
+QTableView::item:selected, QTableWidget::item:selected {
+    background-color: #60ff00;
+    color: #0a1a05;
+}
+QListView::item:hover, QTreeView::item:hover,
+QTableView::item:hover, QTableWidget::item:hover {
+    background-color: #202620;
+}
+QHeaderView::section {
+    background-color: #171a17;
+    color: #e8f5e0;
+    border: 1px solid #4a6b47;
+    padding: 4px 6px;
+}
+
+QSlider::groove:horizontal {
+    background: #4a6b47;
+    height: 4px;
+    border-radius: 2px;
+}
+QSlider::handle:horizontal {
+    background: #60ff00;
+    width: 14px;
+    margin: -6px 0;
+    border-radius: 7px;
+}

--- a/contrib/flameshot-theme/halloween.conf
+++ b/contrib/flameshot-theme/halloween.conf
@@ -1,0 +1,6 @@
+# halloween :: active November (month 11)
+# Source: nicitaacom/14_portfolio app/styles/theme-halloween.css
+MAIN=#ff7819
+CONTRAST=#7c6892
+DRAW=#ff7819
+USER_COLORS="picker, #ff7819, #4d3b69, #7c6892, #3f6847, #e7e1d1"

--- a/contrib/flameshot-theme/halloween.qss
+++ b/contrib/flameshot-theme/halloween.qss
@@ -1,0 +1,210 @@
+/* flameshot-theme :: halloween
+ * Structure borrowed from the github-desktop-accent box-in-box panel
+ * language (surface/border/hover/selected), colors from the Crazy
+ * Mechanics design system (nicitaacom/14_portfolio).
+ *   room #070509 | surface #120e18 | raised #2a2135 | border #8e72c2
+ *   accent #ff7819 | accent-bright #ff9a4d | on-accent #2a0f00
+ *   text #f1ebe0 | secondary #7d6d94
+ */
+
+QWidget {
+    background-color: #070509;
+    color: #f1ebe0;
+    selection-background-color: #ff7819;
+    selection-color: #2a0f00;
+}
+
+QDialog, QMainWindow {
+    background-color: #070509;
+}
+
+QScrollArea, QAbstractScrollArea::viewport {
+    background-color: #070509;
+    border: none;
+}
+
+QGroupBox {
+    background-color: #120e18;
+    border: 1px solid #8e72c2;
+    border-radius: 6px;
+    margin-top: 14px;
+    padding: 14px 10px 12px 10px;
+    font-weight: 600;
+}
+QGroupBox::title {
+    subcontrol-origin: margin;
+    left: 10px;
+    top: -2px;
+    padding: 1px 6px;
+    color: #f1ebe0;
+    font-weight: 700;
+}
+
+QTabWidget::pane {
+    background-color: #120e18;
+    border: 1px solid #8e72c2;
+    border-radius: 6px;
+    top: -1px;
+}
+QTabBar::tab {
+    background-color: #070509;
+    color: #7d6d94;
+    border: 1px solid #8e72c2;
+    border-bottom: none;
+    border-top-left-radius: 6px;
+    border-top-right-radius: 6px;
+    padding: 6px 14px;
+    margin-right: 2px;
+}
+QTabBar::tab:selected {
+    background-color: #120e18;
+    color: #f1ebe0;
+    border-bottom: 2px solid #ff7819;
+}
+QTabBar::tab:hover:!selected {
+    background-color: #2a2135;
+    color: #f1ebe0;
+}
+
+QPushButton {
+    background-color: #2a2135;
+    color: #f1ebe0;
+    border: 1px solid #8e72c2;
+    border-radius: 5px;
+    padding: 5px 14px;
+}
+QPushButton:hover {
+    background-color: #8e72c2;
+    border-color: #ff7819;
+}
+QPushButton:pressed {
+    background-color: #ff7819;
+    color: #2a0f00;
+}
+QPushButton:disabled {
+    color: #7d6d94;
+    background-color: #070509;
+    border: 1px solid #070509;
+}
+QPushButton:default {
+    border: 1px solid #ff7819;
+}
+
+QLineEdit, QSpinBox, QComboBox, QAbstractSpinBox {
+    background-color: #070509;
+    color: #f1ebe0;
+    border: 1px solid #8e72c2;
+    border-radius: 4px;
+    padding: 3px 6px;
+}
+QLineEdit:focus, QSpinBox:focus, QComboBox:focus {
+    border: 1px solid #ff7819;
+}
+QLineEdit:disabled {
+    color: #7d6d94;
+}
+QComboBox::drop-down {
+    border: none;
+    width: 18px;
+}
+QComboBox QAbstractItemView {
+    background-color: #120e18;
+    color: #f1ebe0;
+    border: 1px solid #8e72c2;
+    selection-background-color: #ff7819;
+    selection-color: #2a0f00;
+}
+
+QCheckBox {
+    color: #f1ebe0;
+    spacing: 8px;
+}
+QCheckBox::indicator {
+    width: 14px;
+    height: 14px;
+    border: 1px solid #8e72c2;
+    border-radius: 3px;
+    background-color: #070509;
+}
+QCheckBox::indicator:checked {
+    background-color: #ff7819;
+    border-color: #ff9a4d;
+    image: url(/home/kali/.local/share/flameshot-theme/assets/check.svg);
+}
+QCheckBox::indicator:hover {
+    border-color: #ff7819;
+}
+
+QLabel {
+    color: #f1ebe0;
+    background: transparent;
+}
+
+QMenu {
+    background-color: #120e18;
+    color: #f1ebe0;
+    border: 1px solid #8e72c2;
+}
+QMenu::item:selected {
+    background-color: #ff7819;
+    color: #2a0f00;
+}
+
+QToolTip {
+    background-color: #2a2135;
+    color: #f1ebe0;
+    border: 1px solid #ff7819;
+    padding: 4px;
+}
+
+QScrollBar:vertical {
+    background: #070509;
+    width: 10px;
+    margin: 0;
+}
+QScrollBar::handle:vertical {
+    background: #8e72c2;
+    border-radius: 5px;
+    min-height: 24px;
+}
+QScrollBar::handle:vertical:hover {
+    background: #ff7819;
+}
+QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical {
+    height: 0;
+}
+
+QListView, QTreeView, QTableView, QTableWidget {
+    background-color: #070509;
+    color: #f1ebe0;
+    border: 1px solid #8e72c2;
+    alternate-background-color: #120e18;
+    gridline-color: #8e72c2;
+}
+QListView::item:selected, QTreeView::item:selected,
+QTableView::item:selected, QTableWidget::item:selected {
+    background-color: #ff7819;
+    color: #2a0f00;
+}
+QListView::item:hover, QTreeView::item:hover,
+QTableView::item:hover, QTableWidget::item:hover {
+    background-color: #2a2135;
+}
+QHeaderView::section {
+    background-color: #120e18;
+    color: #f1ebe0;
+    border: 1px solid #8e72c2;
+    padding: 4px 6px;
+}
+
+QSlider::groove:horizontal {
+    background: #8e72c2;
+    height: 4px;
+    border-radius: 2px;
+}
+QSlider::handle:horizontal {
+    background: #ff7819;
+    width: 14px;
+    margin: -6px 0;
+    border-radius: 7px;
+}

--- a/contrib/flameshot-theme/new-year.conf
+++ b/contrib/flameshot-theme/new-year.conf
@@ -1,0 +1,6 @@
+# new-year :: active December-January (months 12, 1)
+# Source: nicitaacom/14_portfolio app/styles/theme-new-year.css
+MAIN=#c81a30
+CONTRAST=#f7b23b
+DRAW=#c81a30
+USER_COLORS="picker, #c81a30, #f7b23b, #1d5c40, #d9c397, #f8f6f2"

--- a/contrib/flameshot-theme/new-year.qss
+++ b/contrib/flameshot-theme/new-year.qss
@@ -1,0 +1,210 @@
+/* flameshot-theme :: new-year
+ * Structure borrowed from the github-desktop-accent box-in-box panel
+ * language (surface/border/hover/selected), colors from the Crazy
+ * Mechanics design system (nicitaacom/14_portfolio).
+ *   room #0a1622 | surface #102439 | raised #1c5b44 | border #4a9d74
+ *   accent #c81a30 | accent-bright #e84257 | on-accent #fdf3f0
+ *   text #f8f6f2 | secondary #6f8f81
+ */
+
+QWidget {
+    background-color: #0a1622;
+    color: #f8f6f2;
+    selection-background-color: #c81a30;
+    selection-color: #fdf3f0;
+}
+
+QDialog, QMainWindow {
+    background-color: #0a1622;
+}
+
+QScrollArea, QAbstractScrollArea::viewport {
+    background-color: #0a1622;
+    border: none;
+}
+
+QGroupBox {
+    background-color: #102439;
+    border: 1px solid #4a9d74;
+    border-radius: 6px;
+    margin-top: 14px;
+    padding: 14px 10px 12px 10px;
+    font-weight: 600;
+}
+QGroupBox::title {
+    subcontrol-origin: margin;
+    left: 10px;
+    top: -2px;
+    padding: 1px 6px;
+    color: #f8f6f2;
+    font-weight: 700;
+}
+
+QTabWidget::pane {
+    background-color: #102439;
+    border: 1px solid #4a9d74;
+    border-radius: 6px;
+    top: -1px;
+}
+QTabBar::tab {
+    background-color: #0a1622;
+    color: #6f8f81;
+    border: 1px solid #4a9d74;
+    border-bottom: none;
+    border-top-left-radius: 6px;
+    border-top-right-radius: 6px;
+    padding: 6px 14px;
+    margin-right: 2px;
+}
+QTabBar::tab:selected {
+    background-color: #102439;
+    color: #f8f6f2;
+    border-bottom: 2px solid #c81a30;
+}
+QTabBar::tab:hover:!selected {
+    background-color: #1c5b44;
+    color: #f8f6f2;
+}
+
+QPushButton {
+    background-color: #1c5b44;
+    color: #f8f6f2;
+    border: 1px solid #4a9d74;
+    border-radius: 5px;
+    padding: 5px 14px;
+}
+QPushButton:hover {
+    background-color: #4a9d74;
+    border-color: #c81a30;
+}
+QPushButton:pressed {
+    background-color: #c81a30;
+    color: #fdf3f0;
+}
+QPushButton:disabled {
+    color: #6f8f81;
+    background-color: #0a1622;
+    border: 1px solid #0a1622;
+}
+QPushButton:default {
+    border: 1px solid #c81a30;
+}
+
+QLineEdit, QSpinBox, QComboBox, QAbstractSpinBox {
+    background-color: #0a1622;
+    color: #f8f6f2;
+    border: 1px solid #4a9d74;
+    border-radius: 4px;
+    padding: 3px 6px;
+}
+QLineEdit:focus, QSpinBox:focus, QComboBox:focus {
+    border: 1px solid #c81a30;
+}
+QLineEdit:disabled {
+    color: #6f8f81;
+}
+QComboBox::drop-down {
+    border: none;
+    width: 18px;
+}
+QComboBox QAbstractItemView {
+    background-color: #102439;
+    color: #f8f6f2;
+    border: 1px solid #4a9d74;
+    selection-background-color: #c81a30;
+    selection-color: #fdf3f0;
+}
+
+QCheckBox {
+    color: #f8f6f2;
+    spacing: 8px;
+}
+QCheckBox::indicator {
+    width: 14px;
+    height: 14px;
+    border: 1px solid #4a9d74;
+    border-radius: 3px;
+    background-color: #0a1622;
+}
+QCheckBox::indicator:checked {
+    background-color: #c81a30;
+    border-color: #e84257;
+    image: url(/home/kali/.local/share/flameshot-theme/assets/check.svg);
+}
+QCheckBox::indicator:hover {
+    border-color: #c81a30;
+}
+
+QLabel {
+    color: #f8f6f2;
+    background: transparent;
+}
+
+QMenu {
+    background-color: #102439;
+    color: #f8f6f2;
+    border: 1px solid #4a9d74;
+}
+QMenu::item:selected {
+    background-color: #c81a30;
+    color: #fdf3f0;
+}
+
+QToolTip {
+    background-color: #1c5b44;
+    color: #f8f6f2;
+    border: 1px solid #c81a30;
+    padding: 4px;
+}
+
+QScrollBar:vertical {
+    background: #0a1622;
+    width: 10px;
+    margin: 0;
+}
+QScrollBar::handle:vertical {
+    background: #4a9d74;
+    border-radius: 5px;
+    min-height: 24px;
+}
+QScrollBar::handle:vertical:hover {
+    background: #c81a30;
+}
+QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical {
+    height: 0;
+}
+
+QListView, QTreeView, QTableView, QTableWidget {
+    background-color: #0a1622;
+    color: #f8f6f2;
+    border: 1px solid #4a9d74;
+    alternate-background-color: #102439;
+    gridline-color: #4a9d74;
+}
+QListView::item:selected, QTreeView::item:selected,
+QTableView::item:selected, QTableWidget::item:selected {
+    background-color: #c81a30;
+    color: #fdf3f0;
+}
+QListView::item:hover, QTreeView::item:hover,
+QTableView::item:hover, QTableWidget::item:hover {
+    background-color: #1c5b44;
+}
+QHeaderView::section {
+    background-color: #102439;
+    color: #f8f6f2;
+    border: 1px solid #4a9d74;
+    padding: 4px 6px;
+}
+
+QSlider::groove:horizontal {
+    background: #4a9d74;
+    height: 4px;
+    border-radius: 2px;
+}
+QSlider::handle:horizontal {
+    background: #c81a30;
+    width: 14px;
+    margin: -6px 0;
+    border-radius: 7px;
+}

--- a/dev_readme-hotkeys-shortcuts.md
+++ b/dev_readme-hotkeys-shortcuts.md
@@ -1,0 +1,176 @@
+# Hotkeys & Shortcuts
+
+## Incident: Ctrl+E (and shortcuts in general) randomly not firing
+
+**Symptom:** after opening a capture (Print), keyboard shortcuts like
+Ctrl+E (toggle side panel) would work sometimes and silently do nothing
+other times. Also present: a "Flameshot Error / The configuration
+contains an error" notification flashing on almost every single launch,
+immediately followed by "successfully resolved."
+
+**What it looked like it was:** a window manager focus problem. Under
+xfwm4, a newly-opened capture window doesn't always become the genuine
+X11-focused window even after `activateWindow()`/`raise()` - confirmed
+directly by comparing `xdotool getactivewindow` against the window
+Flameshot had just opened. Since Qt's `QShortcut` only fires when its
+window is the active one, this looked like a completely sufficient
+explanation, and several fixes were built around it:
+
+1. A delayed re-activation retry after opening
+2. Swapping the window's `Qt::Tool` flag for `Qt::Window` (this genuinely
+   *did* fix real X11 focus, confirmed via `xdotool getwindowfocus`) -
+   but it made window stacking/rendering intermittently unstable
+   (occasional crash, occasional render-behind-other-windows), a worse
+   problem than the one it solved. Reverted.
+3. Changing the `QShortcut` context from `Qt::WindowShortcut` to
+   `Qt::ApplicationShortcut`
+4. A raw `XSetInputFocus` call bypassing the window manager entirely,
+   isolated into its own translation unit to avoid Xlib/Qt macro
+   collisions (`Bool`, `True`, `None`, etc. from `<X11/Xlib.h>` break Qt
+   headers if they ever share a compile unit) - this also caused crashes
+   (likely from opening ad-hoc Xlib connections alongside Qt's own xcb
+   connection to the same X server)
+5. Firing the toggle over D-Bus from an OS-level global hotkey instead of
+   a Qt shortcut at all (sidesteps window focus completely) - the D-Bus
+   call itself worked, but exposed that a *separate* `flameshot gui` CLI
+   process's capture window is not the same object as the daemon's
+   `m_captureWindow`, so the daemon-side D-Bus call had nothing to act on
+
+None of these fully fixed it, and #2 and #4 actively made things worse.
+All were reverted.
+
+**What it actually was:** `TYPE_SAVE_LOCATION_1/2/3` (added for the
+per-location save hotkeys) had no entry in `confighandler.cpp`'s
+`SHORTCUT(...)` table (see the SOP below - this is step 4, and it's the
+step that's easy to forget). The moment a key got bound to one of those
+actions, `~/.config/flameshot/flameshot.ini` gained a line like
+`TYPE_SAVE_LOCATION_1=Ctrl+D` that the config validator didn't recognize.
+`resolveAnyConfigErrors()` is called at the *start* of every single
+`Flameshot::gui()` invocation and, on failure, calls
+`ConfigResolver::exec()` - a **blocking modal dialog** - before the
+capture window is shown. That dialog opening and auto-resolving on every
+single launch was disrupting Qt's focus/activation state at exactly the
+moment the capture window needed to establish itself as active, which is
+what made keyboard shortcuts fire inconsistently afterward.
+
+**The actual fix:** add the three missing entries to the `SHORTCUT(...)`
+table in `confighandler.cpp` (see step 4 below). One line each. Once the
+config stopped being flagged as invalid, the blocking resolver dialog
+stopped firing on every launch, and shortcuts (including Ctrl+E) started
+working reliably.
+
+**Lesson:** a flaky, hard-to-reproduce input/focus bug is worth checking
+against "is something *else* stealing the event loop or focus at the
+same moment" before assuming it's a deep window-manager limitation. Five
+targeted fixes for the assumed root cause (WM focus) were built, tested,
+and mostly reverted before the actual cause (a blocking dialog from an
+unrelated validation gap) was found. The retry/timer-based
+`activateWindow()` calls from attempts #1 and #3's era were left in
+place since they're harmless and can only help; the code for #2, #4, and
+#5 was fully reverted.
+
+---
+
+## SOP: Adding a new capture-tool hotkey
+
+How to add a new action to Flameshot's capture editor that shows up in
+the Shortcuts tab (Configuration > Shortcuts) with a user-rebindable key,
+using `SaveLocationTool` (`src/tools/savelocation/`) as the worked
+example.
+
+There are **5 required steps**. Missing step 4 is the exact trap
+described in the incident above: the app still builds and runs fine, but
+the moment a user binds a key to your new action (or Flameshot itself
+persists the entry), it gets written to
+`~/.config/flameshot/flameshot.ini` under `[Shortcuts]`, and on the next
+launch the config validator doesn't recognize the key and throws up a
+blocking "Configuration file has errors" dialog - which, per the incident
+above, can also make keyboard shortcuts flaky app-wide, not just show an
+error. It doesn't show up until someone actually binds the key, so it's
+easy to miss in your own testing if you don't try binding it yourself.
+
+### 1. Add the enum value
+
+`src/tools/capturetool.h`, inside `CaptureTool::Type`. Append at the
+**bottom** - the comment there is not decorative, existing users'
+persisted ini files reference these by their integer value:
+
+```cpp
+TYPE_SAVE_LOCATION_1 = 25,
+TYPE_SAVE_LOCATION_2 = 26,
+TYPE_SAVE_LOCATION_3 = 27,
+```
+
+### 2. Implement the tool
+
+A `CaptureTool` subclass (see `src/tools/savelocation/savelocationtool.h/.cpp`
+for a full example, or copy `src/tools/save/savetool.*` for the simplest
+possible one). Minimum required overrides: `type()`, `name()`,
+`description()` (this is the text shown in the Shortcuts tab's
+Description column - keep it short, it's a table cell, not a sentence),
+`icon()`, `copy()`, `closeOnButtonPressed()`, and `pressed()` (the actual
+behavior).
+
+Register the new .cpp/.h in the relevant `CMakeLists.txt`
+(`src/tools/CMakeLists.txt` for tools) via `target_sources(flameshot
+PRIVATE ...)`. New files aren't picked up automatically - if you add a
+file without this, you'll get a linker error ("undefined reference") on
+the *next* full reconfigure+build, but a *plain* rebuild will silently
+skip it, which is confusing if you don't know to expect it. Always run
+`cmake -S . -B build ...` again after adding a new source file, before
+`cmake --build build`.
+
+### 3. Register it in ToolFactory
+
+`src/tools/toolfactory.cpp` - add a case to `ToolFactory::CreateTool()`.
+If your constructor takes extra args beyond `parent` (like
+`SaveLocationTool(int location, QObject* parent)` does), you can't use
+the `if_TYPE_return_TOOL` macro; write the `case` by hand.
+
+### 4. Register the default shortcut - THE STEP THAT'S EASY TO FORGET
+
+`src/utils/confighandler.cpp`, in the `SHORTCUT(...)` table (search for
+`SHORTCUT("TYPE_PIN"` to find it). Add an entry even if the default key
+is empty:
+
+```cpp
+SHORTCUT("TYPE_SAVE_LOCATION_1"     ,                           ),
+```
+
+This is what makes `checkUnrecognizedSettings()` accept the key once it's
+persisted to the ini. Without it, the config validator treats any ini
+line like `TYPE_SAVE_LOCATION_1=Ctrl+D` as garbage and blocks the app on
+every launch with "Configuration file has errors" until the user manually
+removes the offending line via the resolver dialog - see the incident
+above for how disruptive this actually is.
+
+If you want the action pre-bound to a specific key out of the box (not
+just present-but-unbound), that's also done here:
+
+```cpp
+SHORTCUT("TYPE_IMAGEUPLOADER"       ,   "Ctrl+D"                ),
+```
+
+### 5. Add it to the Shortcuts-tab / toolbar list
+
+`src/widgets/capture/capturetoolbutton.cpp`,
+`CaptureToolButton::iterableButtonTypes` - this exact array (in this exact
+order) is what the Shortcuts tab iterates to build its row list, so
+position in this array = row position in that table. Add to
+`buttonTypeOrder` too if you also want a specific position among the
+capture-editor's on-screen toolbar icons (a separate, cosmetic concern -
+`iterableButtonTypes` alone is enough for the Shortcuts tab to work).
+
+### After all 5 steps
+
+```bash
+cmake -S . -B build -DCMAKE_INSTALL_PREFIX=/opt/flameshot -DCMAKE_BUILD_TYPE=Release -DENABLE_IMGUR=ON
+cmake --build build --parallel "$(nproc)"
+sudo cmake --install build
+```
+
+Then restart the daemon (`pkill flameshot && flameshot &`) and actually
+**bind a key to the new action in Configuration > Shortcuts and confirm no
+error dialog appears on the next launch** - this is the step that catches
+a forgotten step 4, since everything else works fine right up until a key
+actually gets bound.

--- a/src/config/configwindow.cpp
+++ b/src/config/configwindow.cpp
@@ -7,6 +7,7 @@
 #include "config/generalconf.h"
 #include "config/shortcutswidget.h"
 #include "config/visualseditor.h"
+#include "core/qguiappcurrentscreen.h"
 #include "utils/colorutils.h"
 #include "utils/confighandler.h"
 #include "utils/globalvalues.h"
@@ -18,6 +19,7 @@
 #include <QIcon>
 #include <QKeyEvent>
 #include <QLabel>
+#include <QScreen>
 #include <QSizePolicy>
 #include <QTabBar>
 #include <QTextStream>
@@ -109,6 +111,18 @@ ConfigWindow::ConfigWindow(QWidget* parent)
     initErrorIndicator(m_filenameEditorTab, m_filenameEditor);
     initErrorIndicator(m_generalConfigTab, m_generalConfig);
     initErrorIndicator(m_shortcutsTab, m_shortcuts);
+
+    // Cap the window to roughly half the screen height (50vh) - with no
+    // limit here, tabs whose content doesn't fit in a QScrollArea let the
+    // window grow to fit every setting and can end up taller than the
+    // screen. Each tab's own scroll area (see GeneralConf) handles
+    // overflow once the window itself stops growing.
+    QScreen* screen = QGuiAppCurrentScreen().currentScreen();
+    if (screen) {
+        int maxHeight = screen->availableGeometry().height() / 2;
+        setMaximumHeight(maxHeight);
+        resize(width(), maxHeight);
+    }
 }
 
 void ConfigWindow::keyPressEvent(QKeyEvent* e)

--- a/src/config/generalconf.cpp
+++ b/src/config/generalconf.cpp
@@ -50,6 +50,7 @@ GeneralConf::GeneralConf(QWidget* parent)
     initUseJpgForClipboard();
     initCopyOnDoubleClick();
     initSaveAfterCopy();
+    initSaveLocations();
     initCopyPathAfterSave();
     initAntialiasingPinZoom();
     initUndoLimit();
@@ -124,6 +125,9 @@ void GeneralConf::_updateComponents(bool allowEmptySavePath)
     if (allowEmptySavePath || !config.savePath().isEmpty()) {
         m_savePath->setText(config.savePath());
     }
+    m_saveLocation1->setText(config.savePathLocation1());
+    m_saveLocation2->setText(config.savePathLocation2());
+    m_saveLocation3->setText(config.savePathLocation3());
 
     m_showTray->setChecked(!config.disabledTrayIcon());
 
@@ -692,6 +696,93 @@ void GeneralConf::changeSavePath()
     if (!path.isEmpty()) {
         m_savePath->setText(path);
         ConfigHandler().setSavePath(path);
+    }
+}
+
+// 3 extra save destinations, each exposed as its own tool
+// (TYPE_SAVE_LOCATION_1/2/3) so a hotkey can be bound to it from the
+// Shortcuts tab, saving straight to that folder with no dialog.
+void GeneralConf::initSaveLocations()
+{
+    auto* box = new QGroupBox(tr("Save Path Locations (hotkey-bindable)"));
+    box->setFlat(true);
+    m_layout->addWidget(box);
+
+    auto* vboxLayout = new QVBoxLayout();
+    box->setLayout(vboxLayout);
+
+    QString foreground = this->palette().windowText().color().name();
+    ConfigHandler config;
+
+    QLineEdit** lineEdits[3] = { &m_saveLocation1,
+                                 &m_saveLocation2,
+                                 &m_saveLocation3 };
+    QPushButton** buttons[3] = { &m_changeSaveLocation1Button,
+                                 &m_changeSaveLocation2Button,
+                                 &m_changeSaveLocation3Button };
+    QString savedPaths[3] = { config.savePathLocation1(),
+                              config.savePathLocation2(),
+                              config.savePathLocation3() };
+
+    for (int i = 0; i < 3; ++i) {
+        auto* rowLayout = new QHBoxLayout();
+        rowLayout->addWidget(new QLabel(tr("Location %1:").arg(i + 1)));
+
+        auto* lineEdit = new QLineEdit(savedPaths[i], this);
+        lineEdit->setDisabled(true);
+        lineEdit->setStyleSheet(QStringLiteral("color: %1").arg(foreground));
+        rowLayout->addWidget(lineEdit);
+        *lineEdits[i] = lineEdit;
+
+        auto* button = new QPushButton(tr("Change..."), this);
+        rowLayout->addWidget(button);
+        *buttons[i] = button;
+
+        int location = i + 1;
+        connect(button, &QPushButton::clicked, this, [this, location]() {
+            changeSaveLocation(location);
+        });
+
+        vboxLayout->addLayout(rowLayout);
+    }
+}
+
+void GeneralConf::changeSaveLocation(int location)
+{
+    ConfigHandler config;
+    QLineEdit* lineEdit = nullptr;
+    QString current;
+    switch (location) {
+        case 1:
+            lineEdit = m_saveLocation1;
+            current = config.savePathLocation1();
+            break;
+        case 2:
+            lineEdit = m_saveLocation2;
+            current = config.savePathLocation2();
+            break;
+        default:
+            lineEdit = m_saveLocation3;
+            current = config.savePathLocation3();
+            break;
+    }
+
+    QString path = chooseFolder(current);
+    if (path.isEmpty()) {
+        return;
+    }
+
+    lineEdit->setText(path);
+    switch (location) {
+        case 1:
+            config.setSavePathLocation1(path);
+            break;
+        case 2:
+            config.setSavePathLocation2(path);
+            break;
+        default:
+            config.setSavePathLocation3(path);
+            break;
     }
 }
 

--- a/src/config/generalconf.cpp
+++ b/src/config/generalconf.cpp
@@ -28,27 +28,47 @@ GeneralConf::GeneralConf(QWidget* parent)
 {
     m_layout = new QVBoxLayout(this);
     m_layout->setAlignment(Qt::AlignTop);
+    m_layout->setSpacing(10);
 
     // Scroll area adapts the size of the content on small screens.
     // It must be initialized before the checkboxes.
     initScrollArea();
 
-    initAutostart();
-    initAutoCloseIdleDaemon();
-    initShowTrayIcon();
-    initShowDesktopNotification();
-    initShowAbortNotification();
+    {
+        QVBoxLayout* outer = m_scrollAreaLayout;
+        QVBoxLayout* group = pushGroupBox(tr("Startup"));
+        m_scrollAreaLayout = group;
+        initAutostart();
+        initAutoCloseIdleDaemon();
+        initShowTrayIcon();
+        m_scrollAreaLayout = outer;
+        // Forces this group's size hint to be recomputed right away, with
+        // all 3 checkboxes already added - otherwise a QGroupBox
+        // populated after being placed inside a resizable QScrollArea can
+        // end up sized (and clipped) as if it only ever held its first
+        // child.
+        group->activate();
+    }
+    {
+        QVBoxLayout* outer = m_scrollAreaLayout;
+        QVBoxLayout* group = pushGroupBox(tr("Notifications & Behavior"));
+        m_scrollAreaLayout = group;
+        initShowDesktopNotification();
+        initShowAbortNotification();
 #if !defined(DISABLE_UPDATE_CHECKER)
-    initCheckForUpdates();
+        initCheckForUpdates();
 #endif
-    initShowStartupLaunchMessage();
-    initShowQuitPrompt();
-    initAllowMultipleGuiInstances();
-    initSaveLastRegion();
-    initShowHelp();
-    initShowSidePanelButton();
-    initUseJpgForClipboard();
-    initCopyOnDoubleClick();
+        initShowStartupLaunchMessage();
+        initShowQuitPrompt();
+        initAllowMultipleGuiInstances();
+        initSaveLastRegion();
+        initShowHelp();
+        initShowSidePanelButton();
+        initUseJpgForClipboard();
+        initCopyOnDoubleClick();
+        m_scrollAreaLayout = outer;
+        group->activate();
+    }
     initSaveAfterCopy();
     initSaveLocations();
     initCopyPathAfterSave();
@@ -68,13 +88,12 @@ GeneralConf::GeneralConf(QWidget* parent)
     initCopyAndCloseAfterUpload();
     initUploadWithoutConfirmation();
     initHistoryConfirmationToDelete();
-    initUploadHistoryMax();
     initUploadClientSecret();
 #endif
     initPredefinedColorPaletteLarge();
     initShowSelectionGeometry();
 
-    m_layout->addStretch();
+    m_scrollAreaLayout->addStretch();
 
     initShowMagnifier();
     initSquareMagnifier();
@@ -260,12 +279,16 @@ void GeneralConf::resetConfiguration()
 void GeneralConf::initScrollArea()
 {
     m_scrollArea = new QScrollArea(this);
+    // m_layout (this widget's own top-level layout) holds ONLY the scroll
+    // area - every section (Startup, Save Path, Shortcuts locations, all
+    // of it) is added to m_scrollAreaLayout below, not m_layout, so the
+    // whole tab scrolls as one unit instead of the dialog growing to fit
+    // all of it unconditionally.
     m_layout->addWidget(m_scrollArea);
 
     auto* content = new QWidget(m_scrollArea);
     m_scrollArea->setWidget(content);
     m_scrollArea->setWidgetResizable(true);
-    m_scrollArea->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Maximum);
     m_scrollArea->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
 
     content->setObjectName("content");
@@ -274,6 +297,38 @@ void GeneralConf::initScrollArea()
       "#content, #scrollArea { background: transparent; border: 0px; }");
     m_scrollAreaLayout = new QVBoxLayout(content);
     m_scrollAreaLayout->setContentsMargins(0, 0, 20, 0);
+    m_scrollAreaLayout->setSpacing(10);
+}
+
+QVBoxLayout* GeneralConf::pushGroupBox(const QString& title)
+{
+    auto* box = new QGroupBox(title);
+    box->setFlat(true);
+    auto* layout = new QVBoxLayout();
+    layout->setSpacing(8);
+    box->setLayout(layout);
+    m_scrollAreaLayout->addWidget(box);
+    return layout;
+}
+
+QSpinBox* GeneralConf::pushCompactSpinBox(QHBoxLayout* row,
+                                         const QString& title,
+                                         int max)
+{
+    auto* box = new QGroupBox(title);
+    box->setFlat(true);
+    box->setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Preferred);
+    auto* vboxLayout = new QVBoxLayout();
+    box->setLayout(vboxLayout);
+
+    auto* spin = new QSpinBox(this);
+    spin->setMaximum(max);
+    QString foreground = this->palette().windowText().color().name();
+    spin->setStyleSheet(QStringLiteral("color: %1").arg(foreground));
+    vboxLayout->addWidget(spin);
+
+    row->addWidget(box);
+    return spin;
 }
 
 void GeneralConf::initShowHelp()
@@ -370,7 +425,7 @@ void GeneralConf::initConfigButtons()
     auto* box = new QGroupBox(tr("Configuration File"));
     box->setFlat(true);
     box->setLayout(buttonLayout);
-    m_layout->addWidget(box);
+    m_scrollAreaLayout->addWidget(box);
 
     m_exportButton = new QPushButton(tr("Export"));
     buttonLayout->addWidget(m_exportButton);
@@ -534,7 +589,7 @@ void GeneralConf::initSaveAfterCopy()
 
     auto* box = new QGroupBox(tr("Save Path"));
     box->setFlat(true);
-    m_layout->addWidget(box);
+    m_scrollAreaLayout->addWidget(box);
 
     auto* vboxLayout = new QVBoxLayout();
     box->setLayout(vboxLayout);
@@ -595,33 +650,11 @@ void GeneralConf::historyConfirmationToDelete(bool checked)
     ConfigHandler().setHistoryConfirmationToDelete(checked);
 }
 
-void GeneralConf::initUploadHistoryMax()
-{
-    auto* box = new QGroupBox(tr("Latest Uploads Max Size"));
-    box->setFlat(true);
-    m_layout->addWidget(box);
-
-    auto* vboxLayout = new QVBoxLayout();
-    box->setLayout(vboxLayout);
-
-    m_uploadHistoryMax = new QSpinBox(this);
-    m_uploadHistoryMax->setMaximum(50);
-    QString foreground = this->palette().windowText().color().name();
-    m_uploadHistoryMax->setStyleSheet(
-      QStringLiteral("color: %1").arg(foreground));
-
-    connect(m_uploadHistoryMax,
-            static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged),
-            this,
-            &GeneralConf::uploadHistoryMaxChanged);
-    vboxLayout->addWidget(m_uploadHistoryMax);
-}
-
 void GeneralConf::initUploadClientSecret()
 {
     auto* box = new QGroupBox(tr("Imgur Application Client ID"));
     box->setFlat(true);
-    m_layout->addWidget(box);
+    m_scrollAreaLayout->addWidget(box);
 
     auto* vboxLayout = new QVBoxLayout();
     box->setLayout(vboxLayout);
@@ -650,25 +683,29 @@ void GeneralConf::uploadHistoryMaxChanged(int max)
 
 void GeneralConf::initUndoLimit()
 {
-    auto* box = new QGroupBox(tr("Undo limit"));
-    box->setFlat(true);
-    m_layout->addWidget(box);
+    // Undo limit and (when built with Imgur) Latest Uploads Max Size are
+    // both a title + a single spinbox - lined up in one row via
+    // pushCompactSpinBox instead of each claiming a full-width section
+    // for one number field.
+    auto* row = new QHBoxLayout();
+    m_scrollAreaLayout->addLayout(row);
 
-    auto* vboxLayout = new QVBoxLayout();
-    box->setLayout(vboxLayout);
-
-    m_undoLimit = new QSpinBox(this);
+    m_undoLimit = pushCompactSpinBox(row, tr("Undo limit"), 999);
     m_undoLimit->setMinimum(1);
-    m_undoLimit->setMaximum(999);
-    QString foreground = this->palette().windowText().color().name();
-    m_undoLimit->setStyleSheet(QStringLiteral("color: %1").arg(foreground));
-
     connect(m_undoLimit,
             static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged),
             this,
             &GeneralConf::undoLimit);
 
-    vboxLayout->addWidget(m_undoLimit);
+#ifdef ENABLE_IMGUR
+    m_uploadHistoryMax = pushCompactSpinBox(row, tr("Latest Uploads Max Size"), 50);
+    connect(m_uploadHistoryMax,
+            static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged),
+            this,
+            &GeneralConf::uploadHistoryMaxChanged);
+#endif
+
+    row->addStretch();
 }
 
 void GeneralConf::undoLimit(int limit)
@@ -718,7 +755,7 @@ void GeneralConf::initSaveLocations()
 {
     auto* box = new QGroupBox(tr("Save Path Locations (hotkey-bindable)"));
     box->setFlat(true);
-    m_layout->addWidget(box);
+    m_scrollAreaLayout->addWidget(box);
 
     auto* vboxLayout = new QVBoxLayout();
     box->setLayout(vboxLayout);
@@ -903,7 +940,7 @@ void GeneralConf::initShowSelectionGeometry()
 
     auto* box = new QGroupBox(tr("Selection Geometry Display"));
     box->setFlat(true);
-    m_layout->addWidget(box);
+    m_scrollAreaLayout->addWidget(box);
 
     auto* vboxLayout = new QVBoxLayout();
     box->setLayout(vboxLayout);

--- a/src/config/generalconf.cpp
+++ b/src/config/generalconf.cpp
@@ -101,6 +101,7 @@ void GeneralConf::_updateComponents(bool allowEmptySavePath)
 #ifdef ENABLE_IMGUR
     m_uploadWithoutConfirmation->setChecked(config.uploadWithoutConfirmation());
     m_copyURLAfterUpload->setChecked(config.copyURLAfterUpload());
+    m_showPostUploadDialog->setChecked(config.showPostUploadDialog());
     m_historyConfirmationToDelete->setChecked(
       config.historyConfirmationToDelete());
 
@@ -506,6 +507,17 @@ void GeneralConf::initCopyAndCloseAfterUpload()
 
     connect(m_copyURLAfterUpload, &QCheckBox::clicked, [](bool checked) {
         ConfigHandler().setCopyURLAfterUpload(checked);
+    });
+
+    m_showPostUploadDialog =
+      new QCheckBox(tr("Show upload result window"), this);
+    m_showPostUploadDialog->setToolTip(
+      tr("Open a window with the image and link after every upload, "
+         "instead of just copying the link"));
+    m_scrollAreaLayout->addWidget(m_showPostUploadDialog);
+
+    connect(m_showPostUploadDialog, &QCheckBox::clicked, [](bool checked) {
+        ConfigHandler().setShowPostUploadDialog(checked);
     });
 }
 

--- a/src/config/generalconf.h
+++ b/src/config/generalconf.h
@@ -49,6 +49,7 @@ private slots:
     void undoLimit(int limit);
     void saveAfterCopyChanged(bool checked);
     void changeSavePath();
+    void changeSaveLocation(int location);
     void importConfiguration();
     void exportFileConfiguration();
     void resetConfiguration();
@@ -88,6 +89,7 @@ private:
     void initHistoryConfirmationToDelete();
     void initPredefinedColorPaletteLarge();
     void initSaveAfterCopy();
+    void initSaveLocations();
     void initScrollArea();
     void initShowDesktopNotification();
     void initShowAbortNotification();
@@ -149,6 +151,12 @@ private:
     QLineEdit* m_savePath;
     QLineEdit* m_uploadClientKey;
     QPushButton* m_changeSaveButton;
+    QLineEdit* m_saveLocation1;
+    QLineEdit* m_saveLocation2;
+    QLineEdit* m_saveLocation3;
+    QPushButton* m_changeSaveLocation1Button;
+    QPushButton* m_changeSaveLocation2Button;
+    QPushButton* m_changeSaveLocation3Button;
     QCheckBox* m_screenshotPathFixedCheck;
     QCheckBox* m_historyConfirmationToDelete;
     QCheckBox* m_useJpgForClipboard;

--- a/src/config/generalconf.h
+++ b/src/config/generalconf.h
@@ -144,6 +144,7 @@ private:
     QCheckBox* m_antialiasingPinZoom;
     QCheckBox* m_saveLastRegion;
     QCheckBox* m_uploadWithoutConfirmation;
+    QCheckBox* m_showPostUploadDialog;
     QPushButton* m_importButton;
     QPushButton* m_exportButton;
     QPushButton* m_resetButton;

--- a/src/config/generalconf.h
+++ b/src/config/generalconf.h
@@ -7,6 +7,7 @@
 #include <QWidget>
 
 class QVBoxLayout;
+class QHBoxLayout;
 class QCheckBox;
 class QPushButton;
 class QLabel;
@@ -75,6 +76,20 @@ private slots:
 private:
     const QString chooseFolder(const QString& currentPath = "");
 
+    // Adds a titled, bordered QGroupBox to m_scrollAreaLayout and returns
+    // its inner layout. Callers temporarily reassign m_scrollAreaLayout to
+    // the result so existing initX() functions - which only ever call
+    // m_scrollAreaLayout->addWidget(...) - nest into the section without
+    // needing any changes themselves.
+    QVBoxLayout* pushGroupBox(const QString& title);
+    // A small titled QGroupBox holding one QSpinBox, sized to its content
+    // (not full-width) and appended into `row` - used to line up Undo
+    // limit and Latest Uploads Max Size side by side instead of each
+    // eating a full-width row for a single number field.
+    QSpinBox* pushCompactSpinBox(QHBoxLayout* row,
+                                 const QString& title,
+                                 int max);
+
     void initAllowMultipleGuiInstances();
     void initAntialiasingPinZoom();
     void initAutoCloseIdleDaemon();
@@ -103,7 +118,6 @@ private:
     void initUndoLimit();
     void initUploadWithoutConfirmation();
     void initUseJpgForClipboard();
-    void initUploadHistoryMax();
     void initUploadClientSecret();
     void initSaveLastRegion();
     void initShowSelectionGeometry();

--- a/src/config/visualseditor.cpp
+++ b/src/config/visualseditor.cpp
@@ -8,6 +8,7 @@
 #include "config/uicoloreditor.h"
 #include "utils/confighandler.h"
 
+#include <QCompleter>
 #include <QDirIterator>
 #include <QHBoxLayout>
 #include <QLabel>
@@ -100,6 +101,17 @@ void VisualsEditor::initTranslations()
     auto* localLayout = new QHBoxLayout();
     localLayout->addWidget(new QLabel(tr("UI language")));
     m_selectTranslation = new QComboBox(this);
+    // The translation list is long enough to overflow the screen as a
+    // plain dropdown, so make it editable with a filtering completer -
+    // typing narrows the popup instead of showing every item at once.
+    m_selectTranslation->setEditable(true);
+    m_selectTranslation->setInsertPolicy(QComboBox::NoInsert);
+    m_selectTranslation->completer()->setCompletionMode(
+      QCompleter::PopupCompletion);
+    m_selectTranslation->completer()->setFilterMode(Qt::MatchContains);
+    m_selectTranslation->completer()->setCaseSensitivity(
+      Qt::CaseInsensitive);
+    m_selectTranslation->setMaxVisibleItems(12);
 
     QStringList translations;
     QString tmpFilename;
@@ -130,8 +142,12 @@ void VisualsEditor::initTranslations()
     m_selectTranslation->setCurrentIndex(
       m_selectTranslation->findText(language));
 
+    // textActivated only fires once the user has actually picked an item
+    // (popup click, or Enter on a completed match) - unlike
+    // currentTextChanged, which the now-editable/filterable combobox would
+    // otherwise emit on every keystroke while typing to search.
     connect(m_selectTranslation,
-            &QComboBox::currentTextChanged,
+            &QComboBox::textActivated,
             this,
             [this](const QString& text) {
                 ConfigHandler().setUiLanguage(text);

--- a/src/core/flameshot.cpp
+++ b/src/core/flameshot.cpp
@@ -519,7 +519,11 @@ void Flameshot::exportCapture(const QPixmap& capture,
                       FlameshotDaemon::copyToClipboard(
                         url.toString(), tr("URL copied to clipboard."));
                   }
+              }
+              if (ConfigHandler().showPostUploadDialog()) {
                   widget->showPostUploadDialog();
+              } else {
+                  widget->close();
               }
           });
     }

--- a/src/core/flameshot.cpp
+++ b/src/core/flameshot.cpp
@@ -67,6 +67,7 @@ constexpr const char* visibleInDockProperty = "_visibleInDock";
 #include <QDesktopServices>
 #include <QFile>
 #include <QMessageBox>
+#include <QPointer>
 #include <QThread>
 #include <QTimer>
 #include <QUrl>
@@ -180,6 +181,29 @@ CaptureWidget* Flameshot::gui(const CaptureRequest& req)
 #else
         m_captureWindow->showFullScreen();
 //        m_captureWindow->show(); // For CaptureWidget Debugging under Linux
+        // Without this, window managers with focus-stealing prevention
+        // (e.g. xfwm4) can leave the overlay mapped but buried behind
+        // whatever already had focus - it flashes on screen then is
+        // invisible, and any later focus loss (e.g. a notification popup)
+        // is never reclaimed automatically. Mirrors the macOS branch above.
+        m_captureWindow->activateWindow();
+        m_captureWindow->raise();
+        // The WM's actual focus grant is asynchronous, so a keyboard
+        // shortcut pressed right after this call can still land before
+        // the window is truly active (Qt's WindowShortcut context requires
+        // isActiveWindow()). This is a timing race, not a hard block - it
+        // sometimes succeeds immediately - so a few staggered retries play
+        // that race more times instead of relying on a single attempt or
+        // solely on CaptureWidget's periodic reclaim timer.
+        QPointer<QWidget> captureWindow = m_captureWindow;
+        for (int delayMs : { 40, 100, 200, 400 }) {
+            QTimer::singleShot(delayMs, this, [captureWindow]() {
+                if (captureWindow && !captureWindow->isActiveWindow()) {
+                    captureWindow->activateWindow();
+                    captureWindow->raise();
+                }
+            });
+        }
 #endif
         return m_captureWindow;
     } else {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,6 +20,7 @@
 #include "utils/filenamehandler.h"
 #include "utils/pathinfo.h"
 #include "utils/valuehandler.h"
+#include "utils/wheelfocusguard.h"
 
 #if !(defined(Q_OS_MACOS) || defined(Q_OS_WIN))
 #include "core/flameshotdbusadapter.h"
@@ -193,6 +194,7 @@ void configureApp(bool gui, QTranslator& translator, QTranslator& qtTranslator)
 #else
         QApplication::setStyle(new StyleOverride);
 #endif
+        qApp->installEventFilter(new WheelFocusGuard(qApp));
         // Deferred to the next event loop iteration: platform theme
         // integrations (e.g. qt6ct) inject their own app-wide stylesheet
         // shortly after startup, which would otherwise clobber this one.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -29,6 +29,7 @@
 
 #include <QApplication>
 #include <QDir>
+#include <QFile>
 #include <QLibraryInfo>
 #include <QNetworkProxyFactory>
 #include <QSharedMemory>
@@ -172,6 +173,18 @@ void configureTranslation(QTranslator& translator, QTranslator& qtTranslator)
     qApp->installTranslator(&qtTranslator);
 }
 
+// Applies a user-swappable Qt stylesheet, if one is present, so the whole
+// app (not just the capture toolbar's uiColor/contrastUiColor) can be
+// reskinned by dropping a .qss file at this path - see flameshot-theme.
+void applyCustomStyleSheet()
+{
+    QFile file(QDir::homePath() +
+               "/.local/share/flameshot-theme/current.qss");
+    if (file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+        qApp->setStyleSheet(QString::fromUtf8(file.readAll()));
+    }
+}
+
 void configureApp(bool gui, QTranslator& translator, QTranslator& qtTranslator)
 {
     if (gui) {
@@ -180,6 +193,11 @@ void configureApp(bool gui, QTranslator& translator, QTranslator& qtTranslator)
 #else
         QApplication::setStyle(new StyleOverride);
 #endif
+        // Deferred to the next event loop iteration: platform theme
+        // integrations (e.g. qt6ct) inject their own app-wide stylesheet
+        // shortly after startup, which would otherwise clobber this one.
+        // Running after that means ours applies last and wins.
+        QTimer::singleShot(0, qApp, &applyCustomStyleSheet);
     }
 
     auto app = QCoreApplication::instance();

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -44,6 +44,7 @@ target_sources(
 target_sources(flameshot PRIVATE rectangle/rectangletool.h rectangle/rectangletool.cpp)
 target_sources(flameshot PRIVATE redo/redotool.h redo/redotool.cpp)
 target_sources(flameshot PRIVATE save/savetool.h save/savetool.cpp)
+target_sources(flameshot PRIVATE savelocation/savelocationtool.h savelocation/savelocationtool.cpp)
 target_sources(flameshot PRIVATE accept/accepttool.h accept/accepttool.cpp)
 target_sources(flameshot PRIVATE invert/inverttool.h invert/inverttool.cpp)
 target_sources(flameshot PRIVATE selection/selectiontool.h selection/selectiontool.cpp)

--- a/src/tools/capturetool.h
+++ b/src/tools/capturetool.h
@@ -51,6 +51,9 @@ public:
         TYPE_INVERT = 22,
         TYPE_ACCEPT = 23,
         TYPE_CANCEL = 24,
+        TYPE_SAVE_LOCATION_1 = 25,
+        TYPE_SAVE_LOCATION_2 = 26,
+        TYPE_SAVE_LOCATION_3 = 27,
     };
     Q_ENUM(Type);
 

--- a/src/tools/savelocation/savelocationtool.cpp
+++ b/src/tools/savelocation/savelocationtool.cpp
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "savelocationtool.h"
+#include "utils/confighandler.h"
+
+#include <QPainter>
+
+SaveLocationTool::SaveLocationTool(int location, QObject* parent)
+  : AbstractActionTool(parent)
+  , m_location(location)
+{}
+
+bool SaveLocationTool::closeOnButtonPressed() const
+{
+    return true;
+}
+
+QIcon SaveLocationTool::icon(const QColor& background, bool inEditor) const
+{
+    Q_UNUSED(inEditor)
+    return QIcon(iconPath(background) + "content-save.svg");
+}
+
+QString SaveLocationTool::name() const
+{
+    return tr("Save to loc%1").arg(m_location);
+}
+
+QString SaveLocationTool::description() const
+{
+    return tr("Save to loc%1").arg(m_location);
+}
+
+CaptureTool::Type SaveLocationTool::type() const
+{
+    switch (m_location) {
+        case 1:
+            return CaptureTool::TYPE_SAVE_LOCATION_1;
+        case 2:
+            return CaptureTool::TYPE_SAVE_LOCATION_2;
+        default:
+            return CaptureTool::TYPE_SAVE_LOCATION_3;
+    }
+}
+
+CaptureTool* SaveLocationTool::copy(QObject* parent)
+{
+    return new SaveLocationTool(m_location, parent);
+}
+
+void SaveLocationTool::pressed(CaptureContext& context)
+{
+    QString path;
+    switch (m_location) {
+        case 1:
+            path = ConfigHandler().savePathLocation1();
+            break;
+        case 2:
+            path = ConfigHandler().savePathLocation2();
+            break;
+        default:
+            path = ConfigHandler().savePathLocation3();
+            break;
+    }
+
+    emit requestAction(REQ_CLEAR_SELECTION);
+    // An empty path falls back to the normal save-as dialog, same as
+    // pressing Save with no configured location.
+    context.request.addSaveTask(path);
+    emit requestAction(REQ_CAPTURE_DONE_OK);
+    emit requestAction(REQ_CLOSE_GUI);
+}

--- a/src/tools/savelocation/savelocationtool.h
+++ b/src/tools/savelocation/savelocationtool.h
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include "tools/abstractactiontool.h"
+
+// Saves the current capture straight to one of 3 pre-configured folders
+// (General tab > Save Path > Location 1/2/3), with no save dialog - same
+// no-dialog behavior as `flameshot gui -p <path>`, but bindable to its own
+// hotkey from the Shortcuts tab like any other in-editor tool.
+class SaveLocationTool : public AbstractActionTool
+{
+    Q_OBJECT
+public:
+    explicit SaveLocationTool(int location, QObject* parent = nullptr);
+
+    bool closeOnButtonPressed() const override;
+
+    QIcon icon(const QColor& background, bool inEditor) const override;
+    QString name() const override;
+    QString description() const override;
+
+    CaptureTool* copy(QObject* parent = nullptr) override;
+
+protected:
+    CaptureTool::Type type() const override;
+
+public slots:
+    void pressed(CaptureContext& context) override;
+
+private:
+    int m_location;
+};

--- a/src/tools/toolfactory.cpp
+++ b/src/tools/toolfactory.cpp
@@ -22,6 +22,7 @@
 #include "tools/rectangle/rectangletool.h"
 #include "tools/redo/redotool.h"
 #include "tools/save/savetool.h"
+#include "tools/savelocation/savelocationtool.h"
 #include "tools/selection/selectiontool.h"
 #include "tools/sizedecrease/sizedecreasetool.h"
 #include "tools/sizeincrease/sizeincreasetool.h"
@@ -66,6 +67,12 @@ CaptureTool* ToolFactory::CreateTool(CaptureTool::Type t, QObject* parent)
         if_TYPE_return_TOOL(TYPE_SIZEDECREASE, SizeDecreaseTool);
         if_TYPE_return_TOOL(TYPE_INVERT, InvertTool);
         if_TYPE_return_TOOL(TYPE_ACCEPT, AcceptTool);
+        case CaptureTool::TYPE_SAVE_LOCATION_1:
+            return new SaveLocationTool(1, parent);
+        case CaptureTool::TYPE_SAVE_LOCATION_2:
+            return new SaveLocationTool(2, parent);
+        case CaptureTool::TYPE_SAVE_LOCATION_3:
+            return new SaveLocationTool(3, parent);
         default:
             return nullptr;
     }

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -7,6 +7,7 @@ target_sources(
           systemnotification.h
           valuehandler.h
           strfparse.h
+          wheelfocusguard.h
 )
 
 target_sources(
@@ -26,6 +27,7 @@ target_sources(
           colorutils.cpp
           history.cpp
           strfparse.cpp
+          wheelfocusguard.cpp
 )
 
 IF (UNIX AND NOT APPLE)

--- a/src/utils/confighandler.cpp
+++ b/src/utils/confighandler.cpp
@@ -104,6 +104,7 @@ static QMap<class QString, QSharedPointer<ValueHandler>>
     OPTION("savePathLocation1"           ,String             ( ""            )),
     OPTION("savePathLocation2"           ,String             ( ""            )),
     OPTION("savePathLocation3"           ,String             ( ""            )),
+    OPTION("showPostUploadDialog"        ,Bool               ( false         )),
     OPTION("saveAsFileExtension"         ,SaveFileExtension  (               )),
     OPTION("saveLastRegion"              ,Bool               ( false         )),
     OPTION("uploadHistoryMax"            ,LowerBoundedInt    ( 0, 25         )),
@@ -174,7 +175,7 @@ static QMap<QString, QSharedPointer<KeySequence>> recognizedShortcuts = {
     SHORTCUT("TYPE_EXIT"                ,   "Ctrl+Q"                ),
     SHORTCUT("TYPE_CANCEL"              ,   "Ctrl+Backspace"        ),
 #ifdef ENABLE_IMGUR
-    SHORTCUT("TYPE_IMAGEUPLOADER"       ,                           ),
+    SHORTCUT("TYPE_IMAGEUPLOADER"       ,   "Ctrl+D"                ),
 #endif
 #if !defined(Q_OS_MACOS)
     SHORTCUT("TYPE_OPEN_APP"            ,   "Ctrl+O"                ),

--- a/src/utils/confighandler.cpp
+++ b/src/utils/confighandler.cpp
@@ -101,6 +101,9 @@ static QMap<class QString, QSharedPointer<ValueHandler>>
     OPTION("saveAfterCopy"               ,Bool               ( false         )),
     OPTION("savePath"                    ,ExistingDir        (               )),
     OPTION("savePathFixed"               ,Bool               ( false         )),
+    OPTION("savePathLocation1"           ,String             ( ""            )),
+    OPTION("savePathLocation2"           ,String             ( ""            )),
+    OPTION("savePathLocation3"           ,String             ( ""            )),
     OPTION("saveAsFileExtension"         ,SaveFileExtension  (               )),
     OPTION("saveLastRegion"              ,Bool               ( false         )),
     OPTION("uploadHistoryMax"            ,LowerBoundedInt    ( 0, 25         )),
@@ -210,6 +213,9 @@ static QMap<QString, QSharedPointer<KeySequence>> recognizedShortcuts = {
     SHORTCUT("TYPE_SIZEINCREASE"        ,                           ),
     SHORTCUT("TYPE_SIZEDECREASE"        ,                           ),
     SHORTCUT("TYPE_CIRCLECOUNT"         ,                           ),
+    SHORTCUT("TYPE_SAVE_LOCATION_1"     ,                           ),
+    SHORTCUT("TYPE_SAVE_LOCATION_2"     ,                           ),
+    SHORTCUT("TYPE_SAVE_LOCATION_3"     ,                           ),
 };
 // clang-format on
 

--- a/src/utils/confighandler.cpp
+++ b/src/utils/confighandler.cpp
@@ -138,7 +138,7 @@ static QMap<class QString, QSharedPointer<ValueHandler>>
     OPTION("uploadClientSecret"          ,String             ( "313baf0c7b4d3ff" )),
     OPTION("showSelectionGeometry"       , BoundedInt        ( 0, 5, 4       )),
     OPTION("showSelectionGeometryHideTime", LowerBoundedInt  ( 0, 3000       )),
-    OPTION("jpegQuality"                 , BoundedInt        ( 0,100,75      )),
+    OPTION("jpegQuality"                 , BoundedInt        ( 0,100,100     )),
     OPTION("reverseArrow"                ,Bool               ( false         )),
     OPTION("arrowStyle"                  ,BoundedInt         ( 0, 1, 0       )),
     OPTION("insecurePixelate"            ,Bool               ( false         )),

--- a/src/utils/confighandler.cpp
+++ b/src/utils/confighandler.cpp
@@ -138,6 +138,8 @@ static QMap<class QString, QSharedPointer<ValueHandler>>
     OPTION("uploadClientSecret"          ,String             ( "313baf0c7b4d3ff" )),
     OPTION("showSelectionGeometry"       , BoundedInt        ( 0, 5, 4       )),
     OPTION("showSelectionGeometryHideTime", LowerBoundedInt  ( 0, 3000       )),
+    // Defaults to 100 (was 75) so JPEG saves/uploads are full quality
+    // out of the box; users can still lower it in General settings.
     OPTION("jpegQuality"                 , BoundedInt        ( 0,100,100     )),
     OPTION("reverseArrow"                ,Bool               ( false         )),
     OPTION("arrowStyle"                  ,BoundedInt         ( 0, 1, 0       )),

--- a/src/utils/confighandler.h
+++ b/src/utils/confighandler.h
@@ -75,6 +75,9 @@ public:
     CONFIG_GETTER_SETTER(userColors, setUserColors, QVector<QColor>);
     CONFIG_GETTER_SETTER(savePath, setSavePath, QString)
     CONFIG_GETTER_SETTER(savePathFixed, setSavePathFixed, bool)
+    CONFIG_GETTER_SETTER(savePathLocation1, setSavePathLocation1, QString)
+    CONFIG_GETTER_SETTER(savePathLocation2, setSavePathLocation2, QString)
+    CONFIG_GETTER_SETTER(savePathLocation3, setSavePathLocation3, QString)
     CONFIG_GETTER_SETTER(uiLanguage, setUiLanguage, QString)
     CONFIG_GETTER_SETTER(uiColor, setUiColor, QColor)
     CONFIG_GETTER_SETTER(contrastUiColor, setContrastUiColor, QColor)

--- a/src/utils/confighandler.h
+++ b/src/utils/confighandler.h
@@ -78,6 +78,7 @@ public:
     CONFIG_GETTER_SETTER(savePathLocation1, setSavePathLocation1, QString)
     CONFIG_GETTER_SETTER(savePathLocation2, setSavePathLocation2, QString)
     CONFIG_GETTER_SETTER(savePathLocation3, setSavePathLocation3, QString)
+    CONFIG_GETTER_SETTER(showPostUploadDialog, setShowPostUploadDialog, bool)
     CONFIG_GETTER_SETTER(uiLanguage, setUiLanguage, QString)
     CONFIG_GETTER_SETTER(uiColor, setUiColor, QColor)
     CONFIG_GETTER_SETTER(contrastUiColor, setContrastUiColor, QColor)

--- a/src/utils/wheelfocusguard.cpp
+++ b/src/utils/wheelfocusguard.cpp
@@ -5,6 +5,7 @@
 
 #include <QAbstractSpinBox>
 #include <QComboBox>
+#include <QCoreApplication>
 #include <QEvent>
 #include <QWidget>
 
@@ -16,7 +17,17 @@ bool WheelFocusGuard::eventFilter(QObject* watched, QEvent* event)
           qobject_cast<QComboBox*>(widget) ||
           qobject_cast<QAbstractSpinBox*>(widget);
         if (isScrollSensitive && !widget->hasFocus()) {
-            event->ignore();
+            // An app-level filter runs before the widget's own event()
+            // ever sees the event, so simply swallowing it here would stop
+            // scrolling dead instead of letting the page continue - Qt's
+            // usual "ignored wheel event bubbles to the parent" behavior
+            // only kicks in once a widget's event() gets a chance to run.
+            // Resending to the parent re-enters that normal delivery path
+            // (and its own auto-propagation up the ancestor chain) so a
+            // scroll started over this widget carries on scrolling.
+            if (widget->parentWidget()) {
+                QCoreApplication::sendEvent(widget->parentWidget(), event);
+            }
             return true;
         }
     }

--- a/src/utils/wheelfocusguard.cpp
+++ b/src/utils/wheelfocusguard.cpp
@@ -5,7 +5,6 @@
 
 #include <QAbstractSpinBox>
 #include <QComboBox>
-#include <QCoreApplication>
 #include <QEvent>
 #include <QWidget>
 
@@ -17,17 +16,14 @@ bool WheelFocusGuard::eventFilter(QObject* watched, QEvent* event)
           qobject_cast<QComboBox*>(widget) ||
           qobject_cast<QAbstractSpinBox*>(widget);
         if (isScrollSensitive && !widget->hasFocus()) {
-            // An app-level filter runs before the widget's own event()
-            // ever sees the event, so simply swallowing it here would stop
-            // scrolling dead instead of letting the page continue - Qt's
-            // usual "ignored wheel event bubbles to the parent" behavior
-            // only kicks in once a widget's event() gets a chance to run.
-            // Resending to the parent re-enters that normal delivery path
-            // (and its own auto-propagation up the ancestor chain) so a
-            // scroll started over this widget carries on scrolling.
-            if (widget->parentWidget()) {
-                QCoreApplication::sendEvent(widget->parentWidget(), event);
-            }
+            // Deliberately just swallow the event rather than trying to
+            // forward it to the enclosing scroll area: Qt's "ignored wheel
+            // event walks up to the parent" behavior only fires for real,
+            // spontaneous hardware events, so manually resending it here
+            // (tried and reverted - see git history) ends up re-entering
+            // Qt's own event machinery in ways that misbehave. Simply not
+            // reacting while unfocused is the actual requirement; clicking
+            // into the widget first still lets the wheel change its value.
             return true;
         }
     }

--- a/src/utils/wheelfocusguard.cpp
+++ b/src/utils/wheelfocusguard.cpp
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2017-2019 Alejandro Sirgo Rica & Contributors
+
+#include "wheelfocusguard.h"
+
+#include <QAbstractSpinBox>
+#include <QComboBox>
+#include <QEvent>
+#include <QWidget>
+
+bool WheelFocusGuard::eventFilter(QObject* watched, QEvent* event)
+{
+    if (event->type() == QEvent::Wheel) {
+        auto* widget = qobject_cast<QWidget*>(watched);
+        bool isScrollSensitive =
+          qobject_cast<QComboBox*>(widget) ||
+          qobject_cast<QAbstractSpinBox*>(widget);
+        if (isScrollSensitive && !widget->hasFocus()) {
+            event->ignore();
+            return true;
+        }
+    }
+    return QObject::eventFilter(watched, event);
+}

--- a/src/utils/wheelfocusguard.h
+++ b/src/utils/wheelfocusguard.h
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2017-2019 Alejandro Sirgo Rica & Contributors
+
+#pragma once
+
+#include <QObject>
+
+// QComboBox and QAbstractSpinBox react to the mouse wheel by default even
+// when they don't have focus, which hijacks scrolling anywhere these
+// widgets sit inside a QScrollArea (e.g. Configuration's General tab) -
+// the user ends up silently changing a setting instead of scrolling past
+// it. Installed once app-wide, this ignores wheel events on such widgets
+// while they're unfocused so the event bubbles up to the parent scroll
+// area instead; clicking into the widget first still allows scrolling to
+// change its value as usual.
+class WheelFocusGuard : public QObject
+{
+    Q_OBJECT
+public:
+    using QObject::QObject;
+
+protected:
+    bool eventFilter(QObject* watched, QEvent* event) override;
+};

--- a/src/utils/wheelfocusguard.h
+++ b/src/utils/wheelfocusguard.h
@@ -6,13 +6,11 @@
 #include <QObject>
 
 // QComboBox and QAbstractSpinBox react to the mouse wheel by default even
-// when they don't have focus, which hijacks scrolling anywhere these
-// widgets sit inside a QScrollArea (e.g. Configuration's General tab) -
-// the user ends up silently changing a setting instead of scrolling past
-// it. Installed once app-wide, this ignores wheel events on such widgets
-// while they're unfocused so the event bubbles up to the parent scroll
-// area instead; clicking into the widget first still allows scrolling to
-// change its value as usual.
+// when they don't have focus, so scrolling over one of these widgets
+// inside Configuration silently changes that setting instead of leaving
+// it alone. Installed once app-wide, this swallows wheel events on such
+// widgets while they're unfocused; clicking into the widget first still
+// allows scrolling to change its value as usual.
 class WheelFocusGuard : public QObject
 {
     Q_OBJECT

--- a/src/widgets/capture/capturetoolbutton.cpp
+++ b/src/widgets/capture/capturetoolbutton.cpp
@@ -154,6 +154,9 @@ static std::map<CaptureTool::Type, int> buttonTypeOrder
 
       { CaptureTool::TYPE_SIZEINCREASE, 22 },
       { CaptureTool::TYPE_SIZEDECREASE, 23 },
+      { CaptureTool::TYPE_SAVE_LOCATION_1, 24 },
+      { CaptureTool::TYPE_SAVE_LOCATION_2, 25 },
+      { CaptureTool::TYPE_SAVE_LOCATION_3, 26 },
 };
 
 int CaptureToolButton::getPriorityByButton(CaptureTool::Type b)
@@ -164,6 +167,10 @@ int CaptureToolButton::getPriorityByButton(CaptureTool::Type b)
 }
 
 QList<CaptureTool::Type> CaptureToolButton::iterableButtonTypes = {
+    // Kept first so they're the top 3 rows in the Shortcuts tab list -
+    // the Shortcuts tab lists entries in this exact array order.
+    CaptureTool::TYPE_SAVE_LOCATION_1, CaptureTool::TYPE_SAVE_LOCATION_2,
+    CaptureTool::TYPE_SAVE_LOCATION_3,
     CaptureTool::TYPE_PENCIL,        CaptureTool::TYPE_DRAWER,
     CaptureTool::TYPE_ARROW,         CaptureTool::TYPE_SELECTION,
     CaptureTool::TYPE_RECTANGLE,     CaptureTool::TYPE_CIRCLE,

--- a/src/widgets/capture/capturetoolbutton.cpp
+++ b/src/widgets/capture/capturetoolbutton.cpp
@@ -171,6 +171,9 @@ QList<CaptureTool::Type> CaptureToolButton::iterableButtonTypes = {
     // the Shortcuts tab lists entries in this exact array order.
     CaptureTool::TYPE_SAVE_LOCATION_1, CaptureTool::TYPE_SAVE_LOCATION_2,
     CaptureTool::TYPE_SAVE_LOCATION_3,
+#ifdef ENABLE_IMGUR
+    CaptureTool::TYPE_IMAGEUPLOADER,
+#endif
     CaptureTool::TYPE_PENCIL,        CaptureTool::TYPE_DRAWER,
     CaptureTool::TYPE_ARROW,         CaptureTool::TYPE_SELECTION,
     CaptureTool::TYPE_RECTANGLE,     CaptureTool::TYPE_CIRCLE,
@@ -180,9 +183,6 @@ QList<CaptureTool::Type> CaptureToolButton::iterableButtonTypes = {
     CaptureTool::TYPE_UNDO,          CaptureTool::TYPE_REDO,
     CaptureTool::TYPE_COPY,          CaptureTool::TYPE_SAVE,
     CaptureTool::TYPE_EXIT,
-#ifdef ENABLE_IMGUR
-    CaptureTool::TYPE_IMAGEUPLOADER,
-#endif
 #if !defined(Q_OS_MACOS)
     CaptureTool::TYPE_OPEN_APP,
 #endif

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -16,6 +16,7 @@
 #include "core/qguiappcurrentscreen.h"
 #include "tools/copy/copytool.h"
 #include "utils/abstractlogger.h"
+#include "utils/desktopinfo.h"
 #include "utils/screengrabber.h"
 #include "utils/screenshotsaver.h"
 #include "widgets/capture/colorpicker.h"
@@ -98,6 +99,27 @@ CaptureWidget::CaptureWidget(const CaptureRequest& req,
     connect(&m_xywhTimer, &QTimer::timeout, this, &CaptureWidget::xywhTick);
     // else xywhTick keeps triggering when not needed
     m_xywhTimer.setSingleShot(true);
+
+    // Auto-recover from focus lost to an external interruption (e.g. a
+    // notification popup stealing it) instead of just displaying "click
+    // somewhere" and waiting on the user. Only reclaims when some other
+    // *application* is active (qApp->activeWindow() == nullptr) - never
+    // fights our own dialogs (save-as picker, color picker, etc), which
+    // are legitimately active and simply aren't `this`.
+    //
+    // Under some window managers (e.g. xfwm4) activateWindow()/raise()
+    // don't reliably win on the first try - it's a timing race, not a
+    // hard block (evidenced by it sometimes succeeding immediately).
+    // Retrying frequently plays that race more times instead of trying
+    // to force a guaranteed win, which is worth the small overhead here
+    // since this timer only runs while a capture window is open.
+    connect(&m_focusReclaimTimer, &QTimer::timeout, this, [this]() {
+        if (!isActiveWindow() && qApp->activeWindow() == nullptr) {
+            raise();
+            activateWindow();
+        }
+    });
+    m_focusReclaimTimer.start(100);
     setAttribute(Qt::WA_DeleteOnClose);
     setAttribute(Qt::WA_QuitOnClose, false);
     m_opacity = m_config.contrastOpacity();
@@ -184,6 +206,14 @@ CaptureWidget::CaptureWidget(const CaptureRequest& req,
         } else {
             // Note: Qt::BypassWindowManagerHint is removed to fix x11 gnome
             // crash. It's needed on Cosmic
+            //
+            // Tried swapping Qt::Tool for Qt::Window here to fix xfwm4
+            // withholding real input focus from utility windows (verified:
+            // it does fix keyboard shortcuts like Ctrl+E right after open),
+            // but it made window stacking/rendering intermittently unstable
+            // on xfwm4 (occasional crash, occasional render-behind). Kept
+            // as Qt::Tool - the known-stable configuration - until a fix
+            // that doesn't trade one bug for a worse one is found.
             setWindowFlags(Qt::WindowStaysOnTopHint | Qt::FramelessWindowHint |
                            Qt::Tool);
         }
@@ -1952,13 +1982,23 @@ QList<QShortcut*> CaptureWidget::newShortcut(const QKeySequence& key,
 {
     QList<QShortcut*> shortcuts;
     QString strKey = key.toString();
+    // Qt::ApplicationShortcut instead of the default Qt::WindowShortcut:
+    // some window managers (e.g. xfwm4) never grant this overlay real
+    // X11 input focus even after activateWindow()/raise() (it stays
+    // visible and mouse-interactive, just not "active" per the WM), which
+    // makes WindowShortcut-scoped shortcuts silently never fire. This
+    // context only requires the application - not this specific window -
+    // to be the one receiving keyboard input.
     if (strKey.contains("Enter") || strKey.contains("Return")) {
         strKey.replace("Enter", "Return");
-        shortcuts << new QShortcut(strKey, parent, slot);
+        shortcuts << new QShortcut(
+          strKey, parent, slot, nullptr, Qt::ApplicationShortcut);
         strKey.replace("Return", "Enter");
-        shortcuts << new QShortcut(strKey, parent, slot);
+        shortcuts << new QShortcut(
+          strKey, parent, slot, nullptr, Qt::ApplicationShortcut);
     } else {
-        shortcuts << new QShortcut(key, parent, slot);
+        shortcuts << new QShortcut(
+          key, parent, slot, nullptr, Qt::ApplicationShortcut);
     }
     return shortcuts;
 }

--- a/src/widgets/capture/capturewidget.h
+++ b/src/widgets/capture/capturewidget.h
@@ -219,6 +219,11 @@ private:
     bool m_xywhDisplay;
     QTimer m_xywhTimer;
 
+    // Auto-reclaims focus lost to an external interruption (e.g. a
+    // notification popup) instead of just showing "click somewhere" and
+    // waiting - see CaptureWidget::CaptureWidget.
+    QTimer m_focusReclaimTimer;
+
     QUndoStack m_undoStack;
 
     bool m_existingObjectIsChanged;

--- a/src/widgets/panel/utilitypanel.cpp
+++ b/src/widgets/panel/utilitypanel.cpp
@@ -38,10 +38,13 @@ UtilityPanel::UtilityPanel(CaptureWidget* captureWidget)
     m_hideAnimation->setEasingCurve(QEasingCurve::InOutQuad);
     m_hideAnimation->setDuration(300);
 
-    connect(m_hideAnimation,
-            &QPropertyAnimation::finished,
-            m_internalPanel,
-            &QWidget::hide);
+    connect(m_hideAnimation, &QPropertyAnimation::finished, this, [this]() {
+        // Deferred to animation-finished rather than called synchronously
+        // from hide() - hiding the widget immediately after starting the
+        // animation cut it off before a single frame could render.
+        m_internalPanel->hide();
+        QWidget::hide();
+    });
 
 #if (defined(Q_OS_WIN) || defined(Q_OS_MACOS))
     move(0, 0);
@@ -106,8 +109,9 @@ void UtilityPanel::hide()
     m_hideAnimation->setStartValue(QRect(0, 0, width(), height()));
     m_hideAnimation->setEndValue(QRect(-width(), 0, 0, height()));
     m_hideAnimation->start();
-    m_internalPanel->hide();
-    QWidget::hide();
+    // The actual hide() calls happen once the animation finishes (see the
+    // constructor's connect) - doing it here too would hide the widget
+    // before the animation renders a single frame.
 }
 
 void UtilityPanel::toggle()


### PR DESCRIPTION
## Added
- **Save to loc1/2/3** — 3 new capture-tool actions, each saves straight to a pre-configured folder with no dialog, bindable to any hotkey from Configuration > Shortcuts
- **Imgur uploader on Ctrl+D** — enabled Flameshot's existing built-in uploader (was disabled by default), default-bound to Ctrl+D, with a new "Show upload result window" toggle (off by default — link just copies to clipboard silently)
- **Reskinnable UI** — app-wide QSS stylesheet support, swappable at runtime via `~/.local/share/flameshot-theme/current.qss`

## Fixed
- Side panel close animation was cut off before rendering (open animated, close didn't)
- `TYPE_SAVE_LOCATION_1/2/3` weren't registered as recognized shortcuts, which blocked the app with a config-error dialog on every launch once a key got bound to one of them

## Docs
- `dev_readme-hotkeys-shortcuts.md` — incident writeup + SOP for adding future hotkeys without repeating the registration gap above

## Screenshots
Shortcuts tab (new loc1/2/3 + Imgur entries):
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/ee61be47-0d91-4c38-bf15-a6d0e2f73136" />


Reskinned Configuration window:

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/fc81dcfa-52c5-4049-a6f6-19f77951c724" />


Side panel (Ctrl+E / click target):
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/4700975e-2bbf-4d10-9928-9ec8b4ce300f" />
