### PR TITLE
Improve windows-cli

### DIFF
--- a/src/windows-cli.cpp
+++ b/src/windows-cli.cpp
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2017-2019 Alejandro Sirgo Rica & Contributors
+
 #include <iostream>
 #include <string>
 #include <vector>
@@ -38,12 +41,17 @@ static void appendQuotedArg(std::wstring& cmdline, const std::wstring& arg)
 // forwarding each argument as literal data. flameshot.exe is passed via
 // lpApplicationName so no command interpreter is involved and shell
 // metacharacters have no effect. When wait is true, the child's stdout is
-// captured and relayed.
-void CallFlameshot(int argc, wchar_t* argv[], bool wait)
+// captured and relayed. Returns child's process exit code. If wait==false,
+// returns 0 (child running).
+int CallFlameshot(int argc, wchar_t* argv[], bool wait)
 {
     // Full path to flameshot.exe, in the same directory as this executable.
     wchar_t path[MAX_PATH];
-    GetModuleFileNameW(NULL, path, MAX_PATH);
+    DWORD len = GetModuleFileNameW(NULL, path, MAX_PATH);
+    if (len == 0 || len == MAX_PATH) {
+        return static_cast<int>(GetLastError());
+    }
+
     std::wstring pathstring(path);
     size_t lastBackslash = pathstring.find_last_of(L'\\');
     std::wstring directory = (lastBackslash != std::wstring::npos)
@@ -70,7 +78,7 @@ void CallFlameshot(int argc, wchar_t* argv[], bool wait)
         sa.nLength = sizeof(sa);
         sa.bInheritHandle = TRUE;
         if (!CreatePipe(&readEnd, &writeEnd, &sa, 0)) {
-            return;
+            return static_cast<int>(GetLastError());
         }
         SetHandleInformation(readEnd, HANDLE_FLAG_INHERIT, 0);
 
@@ -81,51 +89,75 @@ void CallFlameshot(int argc, wchar_t* argv[], bool wait)
     }
 
     PROCESS_INFORMATION pi{};
-    BOOL ok = CreateProcessW(exePath.c_str(),
-                             mutableCmd.data(),
-                             NULL,
-                             NULL,
-                             wait ? TRUE : FALSE,
-                             0,
-                             NULL,
-                             NULL,
-                             &si,
-                             &pi);
+    BOOL ok = CreateProcessW(
+      exePath.c_str(),
+      mutableCmd.data(),
+      NULL,
+      NULL,
+      wait ? TRUE : FALSE, // only inherit handles when we created a pipe
+      0,
+      NULL,
+      NULL,
+      &si,
+      &pi);
 
     if (writeEnd) {
         CloseHandle(writeEnd);
+        writeEnd = NULL;
     }
+
     if (!ok) {
         if (readEnd) {
             CloseHandle(readEnd);
         }
-        return;
+        return static_cast<int>(GetLastError());
     }
 
+    int exitCode = 0;
+
     if (wait) {
+        // Read child's stdout/stderr
+        SetConsoleOutputCP(CP_UTF8);
+        SetConsoleCP(CP_UTF8);
         char buffer[2048];
         DWORD n = 0;
         while (ReadFile(readEnd, buffer, sizeof(buffer), &n, NULL) && n > 0) {
             std::cout.write(buffer, n);
         }
         CloseHandle(readEnd);
+        readEnd = NULL;
+
         WaitForSingleObject(pi.hProcess, INFINITE);
+        DWORD code = 0;
+        if (GetExitCodeProcess(pi.hProcess, &code)) {
+            exitCode = static_cast<int>(code);
+        } else {
+            exitCode = static_cast<int>(GetLastError());
+        }
+    } else {
+        // Not waiting: Exit code can't be known
+        exitCode = 0;
     }
 
     CloseHandle(pi.hProcess);
     CloseHandle(pi.hThread);
+
+    return exitCode;
 }
 
 // Console 'wrapper' for flameshot on windows
 int wmain(int argc, wchar_t* argv[])
 {
-    // if no args, do not wait for stdout
+    // if no args, do not wait for stdout => return 0.
+    // If args exist, wait and return flameshot's exit code.
     if (argc == 1) {
         std::cout << "Starting flameshot in daemon mode" << std::endl;
-        CallFlameshot(argc, argv, false);
+        int code = CallFlameshot(argc, argv, false);
+        std::cout.flush();
+        return code;
     } else {
-        CallFlameshot(argc, argv, true);
+        int code = CallFlameshot(argc, argv, true);
+        std::cout.flush();
+        return code;
     }
-    std::cout.flush();
-    return 0;
 }


### PR DESCRIPTION
This PR improves the current Windows cli by forwarding Flameshot's return value to the cli and by setting the console output to UTF8 (before Windows CMD didn't handle non-English character encoding correctly, resulting in incorrect display of characters such as e.g. German öäü).