### PR TITLE
Feat/qss theming - Add support for a user-swappable QSS theme

### DIFF
--- a/contrib/flameshot-theme/assets/check.svg
+++ b/contrib/flameshot-theme/assets/check.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <path d="M3 8.5 L6.5 12 L13 4" fill="none" stroke="#ffffff" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/contrib/flameshot-theme/crazy-mechanics.conf
+++ b/contrib/flameshot-theme/crazy-mechanics.conf
@@ -1,0 +1,7 @@
+# crazy-mechanics :: default theme (active outside Halloween/New Year windows)
+# Source: nicitaacom/14_portfolio app/styles/theme-crazy-mechanics.css
+#   cta 277deg 100% 68% | brass 40deg 45% 55% | primary 0deg 0% 13%
+MAIN=#c05cff
+CONTRAST=#c09d59
+DRAW=#c05cff
+USER_COLORS="picker, #c05cff, #c09d59, #212121, #7c6892, #5f8c74"

--- a/contrib/flameshot-theme/crazy-mechanics.qss
+++ b/contrib/flameshot-theme/crazy-mechanics.qss
@@ -1,0 +1,210 @@
+/* flameshot-theme :: crazy-mechanics
+ * Structure borrowed from the github-desktop-accent box-in-box panel
+ * language (surface/border/hover/selected), colors from the Crazy
+ * Mechanics design system (nicitaacom/14_portfolio).
+ *   room #1b1b1b | surface #242424 | raised #3a3542 | border #7d6f92
+ *   accent #c05cff | accent-bright #d68bff | on-accent #210633
+ *   text #e8e8e8 | secondary #8f8698
+ */
+
+QWidget {
+    background-color: #1b1b1b;
+    color: #e8e8e8;
+    selection-background-color: #c05cff;
+    selection-color: #210633;
+}
+
+QDialog, QMainWindow {
+    background-color: #1b1b1b;
+}
+
+QScrollArea, QAbstractScrollArea::viewport {
+    background-color: #1b1b1b;
+    border: none;
+}
+
+QGroupBox {
+    background-color: #242424;
+    border: 1px solid #7d6f92;
+    border-radius: 6px;
+    margin-top: 14px;
+    padding: 14px 10px 12px 10px;
+    font-weight: 600;
+}
+QGroupBox::title {
+    subcontrol-origin: margin;
+    left: 10px;
+    top: -2px;
+    padding: 1px 6px;
+    color: #e8e8e8;
+    font-weight: 700;
+}
+
+QTabWidget::pane {
+    background-color: #242424;
+    border: 1px solid #7d6f92;
+    border-radius: 6px;
+    top: -1px;
+}
+QTabBar::tab {
+    background-color: #1b1b1b;
+    color: #8f8698;
+    border: 1px solid #7d6f92;
+    border-bottom: none;
+    border-top-left-radius: 6px;
+    border-top-right-radius: 6px;
+    padding: 6px 14px;
+    margin-right: 2px;
+}
+QTabBar::tab:selected {
+    background-color: #242424;
+    color: #e8e8e8;
+    border-bottom: 2px solid #c05cff;
+}
+QTabBar::tab:hover:!selected {
+    background-color: #3a3542;
+    color: #e8e8e8;
+}
+
+QPushButton {
+    background-color: #3a3542;
+    color: #e8e8e8;
+    border: 1px solid #7d6f92;
+    border-radius: 5px;
+    padding: 5px 14px;
+}
+QPushButton:hover {
+    background-color: #7d6f92;
+    border-color: #c05cff;
+}
+QPushButton:pressed {
+    background-color: #c05cff;
+    color: #210633;
+}
+QPushButton:disabled {
+    color: #8f8698;
+    background-color: #1b1b1b;
+    border: 1px solid #1b1b1b;
+}
+QPushButton:default {
+    border: 1px solid #c05cff;
+}
+
+QLineEdit, QSpinBox, QComboBox, QAbstractSpinBox {
+    background-color: #1b1b1b;
+    color: #e8e8e8;
+    border: 1px solid #7d6f92;
+    border-radius: 4px;
+    padding: 3px 6px;
+}
+QLineEdit:focus, QSpinBox:focus, QComboBox:focus {
+    border: 1px solid #c05cff;
+}
+QLineEdit:disabled {
+    color: #8f8698;
+}
+QComboBox::drop-down {
+    border: none;
+    width: 18px;
+}
+QComboBox QAbstractItemView {
+    background-color: #242424;
+    color: #e8e8e8;
+    border: 1px solid #7d6f92;
+    selection-background-color: #c05cff;
+    selection-color: #210633;
+}
+
+QCheckBox {
+    color: #e8e8e8;
+    spacing: 8px;
+}
+QCheckBox::indicator {
+    width: 14px;
+    height: 14px;
+    border: 1px solid #7d6f92;
+    border-radius: 3px;
+    background-color: #1b1b1b;
+}
+QCheckBox::indicator:checked {
+    background-color: #c05cff;
+    border-color: #d68bff;
+    image: url(/home/kali/.local/share/flameshot-theme/assets/check.svg);
+}
+QCheckBox::indicator:hover {
+    border-color: #c05cff;
+}
+
+QLabel {
+    color: #e8e8e8;
+    background: transparent;
+}
+
+QMenu {
+    background-color: #242424;
+    color: #e8e8e8;
+    border: 1px solid #7d6f92;
+}
+QMenu::item:selected {
+    background-color: #c05cff;
+    color: #210633;
+}
+
+QToolTip {
+    background-color: #3a3542;
+    color: #e8e8e8;
+    border: 1px solid #c05cff;
+    padding: 4px;
+}
+
+QScrollBar:vertical {
+    background: #1b1b1b;
+    width: 10px;
+    margin: 0;
+}
+QScrollBar::handle:vertical {
+    background: #7d6f92;
+    border-radius: 5px;
+    min-height: 24px;
+}
+QScrollBar::handle:vertical:hover {
+    background: #c05cff;
+}
+QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical {
+    height: 0;
+}
+
+QListView, QTreeView, QTableView, QTableWidget {
+    background-color: #1b1b1b;
+    color: #e8e8e8;
+    border: 1px solid #7d6f92;
+    alternate-background-color: #242424;
+    gridline-color: #7d6f92;
+}
+QListView::item:selected, QTreeView::item:selected,
+QTableView::item:selected, QTableWidget::item:selected {
+    background-color: #c05cff;
+    color: #210633;
+}
+QListView::item:hover, QTreeView::item:hover,
+QTableView::item:hover, QTableWidget::item:hover {
+    background-color: #3a3542;
+}
+QHeaderView::section {
+    background-color: #242424;
+    color: #e8e8e8;
+    border: 1px solid #7d6f92;
+    padding: 4px 6px;
+}
+
+QSlider::groove:horizontal {
+    background: #7d6f92;
+    height: 4px;
+    border-radius: 2px;
+}
+QSlider::handle:horizontal {
+    background: #c05cff;
+    width: 14px;
+    margin: -6px 0;
+    border-radius: 7px;
+}

--- a/contrib/flameshot-theme/flameshot-seasonal-theme
+++ b/contrib/flameshot-theme/flameshot-seasonal-theme
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Auto-applies the seasonal Flameshot theme for the current month, mirroring
+# nicitaacom/14_portfolio's THEME_MONTHS schedule:
+#   11        -> halloween
+#   12, 1     -> new-year
+#   otherwise -> green (default)
+set -euo pipefail
+
+MONTH=$(date +%-m)
+
+case "$MONTH" in
+    11) THEME="halloween" ;;
+    12|1) THEME="new-year" ;;
+    *) THEME="green" ;;
+esac
+
+CURRENT_MARKER="$HOME/.local/share/flameshot-theme/.current"
+if [ -f "$CURRENT_MARKER" ] && [ "$(cat "$CURRENT_MARKER")" = "$THEME" ]; then
+    exit 0
+fi
+
+"$HOME/.local/bin/flameshot-theme" "$THEME"
+echo "$THEME" > "$CURRENT_MARKER"

--- a/contrib/flameshot-theme/flameshot-theme
+++ b/contrib/flameshot-theme/flameshot-theme
@@ -1,0 +1,69 @@
+#!/bin/bash
+# Swaps Flameshot's accent colors using palette files derived from the
+# "Crazy Mechanics" design system (nicitaacom/14_portfolio), same swap
+# mechanism as github-desktop-accent: a marked config file per theme,
+# applied by patching known keys in place.
+#
+#   flameshot-theme <name>      apply a theme (see --list)
+#   flameshot-theme --list      show available themes
+#   flameshot-theme --revert    back to the default (crazy-mechanics)
+set -euo pipefail
+
+THEME_DIR="$HOME/.local/share/flameshot-theme"
+INI="$HOME/.config/flameshot/flameshot.ini"
+
+if [ "${1:-}" = "--list" ]; then
+    ls "$THEME_DIR"/*.conf 2>/dev/null | xargs -n1 basename | sed 's/\.conf$//'
+    exit 0
+fi
+
+if [ "${1:-}" = "--revert" ]; then
+    NAME="crazy-mechanics"
+else
+    NAME="${1:?usage: flameshot-theme <name>|--list|--revert}"
+fi
+
+CONF="$THEME_DIR/$NAME.conf"
+[ -f "$CONF" ] || { echo "no such theme: $NAME (see: flameshot-theme --list)" >&2; exit 1; }
+
+# shellcheck disable=SC1090
+source "$CONF"
+
+QSS="$THEME_DIR/$NAME.qss"
+if [ -f "$QSS" ]; then
+    cp "$QSS" "$THEME_DIR/current.qss"
+else
+    rm -f "$THEME_DIR/current.qss"
+fi
+
+python3 - "$INI" "$MAIN" "$CONTRAST" "$DRAW" "$USER_COLORS" <<'PY'
+import sys
+ini, main, contrast, draw, user_colors = sys.argv[1:6]
+keys = {"uiColor": main, "contrastUiColor": contrast, "drawColor": draw, "userColors": user_colors}
+
+lines = open(ini, encoding="utf-8").read().splitlines()
+seen = set()
+out = []
+for line in lines:
+    k = line.split("=", 1)[0]
+    if k in keys:
+        out.append(f"{k}={keys[k]}")
+        seen.add(k)
+    else:
+        out.append(line)
+idx = out.index("[General]") + 1
+for k, v in keys.items():
+    if k not in seen:
+        out.insert(idx, f"{k}={v}")
+open(ini, "w", encoding="utf-8").write("\n".join(out) + "\n")
+PY
+
+pkill flameshot 2>/dev/null || true
+sleep 0.3
+setsid /usr/local/bin/flameshot >/dev/null 2>&1 &
+disown
+# Give the daemon a moment to finish starting before this script (and its
+# process group) exits - otherwise it can get reaped mid-startup.
+sleep 1.5
+
+echo "applied theme: $NAME (main=$MAIN contrast=$CONTRAST)"

--- a/contrib/flameshot-theme/green.conf
+++ b/contrib/flameshot-theme/green.conf
@@ -1,0 +1,6 @@
+# green :: same dark bg/surface language as ~/.local/bin/github-desktop-accent's
+# dark-green.css, accent set to the requested #60ff00.
+MAIN=#60ff00
+CONTRAST=#ffc107
+DRAW=#60ff00
+USER_COLORS="picker, #60ff00, #ffc107, #101210, #8fff4d, #7fae95"

--- a/contrib/flameshot-theme/green.qss
+++ b/contrib/flameshot-theme/green.qss
@@ -1,0 +1,210 @@
+/* flameshot-theme :: green
+ * Structure borrowed from the github-desktop-accent box-in-box panel
+ * language (surface/border/hover/selected), colors from the Crazy
+ * Mechanics design system (nicitaacom/14_portfolio).
+ *   room #101210 | surface #171a17 | raised #202620 | border #4a6b47
+ *   accent #60ff00 | accent-bright #8fff4d | on-accent #0a1a05
+ *   text #e8f5e0 | secondary #8fae95
+ */
+
+QWidget {
+    background-color: #101210;
+    color: #e8f5e0;
+    selection-background-color: #60ff00;
+    selection-color: #0a1a05;
+}
+
+QDialog, QMainWindow {
+    background-color: #101210;
+}
+
+QScrollArea, QAbstractScrollArea::viewport {
+    background-color: #101210;
+    border: none;
+}
+
+QGroupBox {
+    background-color: #171a17;
+    border: 1px solid #4a6b47;
+    border-radius: 6px;
+    margin-top: 14px;
+    padding: 14px 10px 12px 10px;
+    font-weight: 600;
+}
+QGroupBox::title {
+    subcontrol-origin: margin;
+    left: 10px;
+    top: -2px;
+    padding: 1px 6px;
+    color: #e8f5e0;
+    font-weight: 700;
+}
+
+QTabWidget::pane {
+    background-color: #171a17;
+    border: 1px solid #4a6b47;
+    border-radius: 6px;
+    top: -1px;
+}
+QTabBar::tab {
+    background-color: #101210;
+    color: #8fae95;
+    border: 1px solid #4a6b47;
+    border-bottom: none;
+    border-top-left-radius: 6px;
+    border-top-right-radius: 6px;
+    padding: 6px 14px;
+    margin-right: 2px;
+}
+QTabBar::tab:selected {
+    background-color: #171a17;
+    color: #e8f5e0;
+    border-bottom: 2px solid #60ff00;
+}
+QTabBar::tab:hover:!selected {
+    background-color: #202620;
+    color: #e8f5e0;
+}
+
+QPushButton {
+    background-color: #202620;
+    color: #e8f5e0;
+    border: 1px solid #4a6b47;
+    border-radius: 5px;
+    padding: 5px 14px;
+}
+QPushButton:hover {
+    background-color: #4a6b47;
+    border-color: #60ff00;
+}
+QPushButton:pressed {
+    background-color: #60ff00;
+    color: #0a1a05;
+}
+QPushButton:disabled {
+    color: #8fae95;
+    background-color: #101210;
+    border: 1px solid #101210;
+}
+QPushButton:default {
+    border: 1px solid #60ff00;
+}
+
+QLineEdit, QSpinBox, QComboBox, QAbstractSpinBox {
+    background-color: #101210;
+    color: #e8f5e0;
+    border: 1px solid #4a6b47;
+    border-radius: 4px;
+    padding: 3px 6px;
+}
+QLineEdit:focus, QSpinBox:focus, QComboBox:focus {
+    border: 1px solid #60ff00;
+}
+QLineEdit:disabled {
+    color: #8fae95;
+}
+QComboBox::drop-down {
+    border: none;
+    width: 18px;
+}
+QComboBox QAbstractItemView {
+    background-color: #171a17;
+    color: #e8f5e0;
+    border: 1px solid #4a6b47;
+    selection-background-color: #60ff00;
+    selection-color: #0a1a05;
+}
+
+QCheckBox {
+    color: #e8f5e0;
+    spacing: 8px;
+}
+QCheckBox::indicator {
+    width: 14px;
+    height: 14px;
+    border: 1px solid #4a6b47;
+    border-radius: 3px;
+    background-color: #101210;
+}
+QCheckBox::indicator:checked {
+    background-color: #60ff00;
+    border-color: #8fff4d;
+    image: url(/home/kali/.local/share/flameshot-theme/assets/check.svg);
+}
+QCheckBox::indicator:hover {
+    border-color: #60ff00;
+}
+
+QLabel {
+    color: #e8f5e0;
+    background: transparent;
+}
+
+QMenu {
+    background-color: #171a17;
+    color: #e8f5e0;
+    border: 1px solid #4a6b47;
+}
+QMenu::item:selected {
+    background-color: #60ff00;
+    color: #0a1a05;
+}
+
+QToolTip {
+    background-color: #202620;
+    color: #e8f5e0;
+    border: 1px solid #60ff00;
+    padding: 4px;
+}
+
+QScrollBar:vertical {
+    background: #101210;
+    width: 10px;
+    margin: 0;
+}
+QScrollBar::handle:vertical {
+    background: #4a6b47;
+    border-radius: 5px;
+    min-height: 24px;
+}
+QScrollBar::handle:vertical:hover {
+    background: #60ff00;
+}
+QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical {
+    height: 0;
+}
+
+QListView, QTreeView, QTableView, QTableWidget {
+    background-color: #101210;
+    color: #e8f5e0;
+    border: 1px solid #4a6b47;
+    alternate-background-color: #171a17;
+    gridline-color: #4a6b47;
+}
+QListView::item:selected, QTreeView::item:selected,
+QTableView::item:selected, QTableWidget::item:selected {
+    background-color: #60ff00;
+    color: #0a1a05;
+}
+QListView::item:hover, QTreeView::item:hover,
+QTableView::item:hover, QTableWidget::item:hover {
+    background-color: #202620;
+}
+QHeaderView::section {
+    background-color: #171a17;
+    color: #e8f5e0;
+    border: 1px solid #4a6b47;
+    padding: 4px 6px;
+}
+
+QSlider::groove:horizontal {
+    background: #4a6b47;
+    height: 4px;
+    border-radius: 2px;
+}
+QSlider::handle:horizontal {
+    background: #60ff00;
+    width: 14px;
+    margin: -6px 0;
+    border-radius: 7px;
+}

--- a/contrib/flameshot-theme/halloween.conf
+++ b/contrib/flameshot-theme/halloween.conf
@@ -1,0 +1,6 @@
+# halloween :: active November (month 11)
+# Source: nicitaacom/14_portfolio app/styles/theme-halloween.css
+MAIN=#ff7819
+CONTRAST=#7c6892
+DRAW=#ff7819
+USER_COLORS="picker, #ff7819, #4d3b69, #7c6892, #3f6847, #e7e1d1"

--- a/contrib/flameshot-theme/halloween.qss
+++ b/contrib/flameshot-theme/halloween.qss
@@ -1,0 +1,210 @@
+/* flameshot-theme :: halloween
+ * Structure borrowed from the github-desktop-accent box-in-box panel
+ * language (surface/border/hover/selected), colors from the Crazy
+ * Mechanics design system (nicitaacom/14_portfolio).
+ *   room #070509 | surface #120e18 | raised #2a2135 | border #8e72c2
+ *   accent #ff7819 | accent-bright #ff9a4d | on-accent #2a0f00
+ *   text #f1ebe0 | secondary #7d6d94
+ */
+
+QWidget {
+    background-color: #070509;
+    color: #f1ebe0;
+    selection-background-color: #ff7819;
+    selection-color: #2a0f00;
+}
+
+QDialog, QMainWindow {
+    background-color: #070509;
+}
+
+QScrollArea, QAbstractScrollArea::viewport {
+    background-color: #070509;
+    border: none;
+}
+
+QGroupBox {
+    background-color: #120e18;
+    border: 1px solid #8e72c2;
+    border-radius: 6px;
+    margin-top: 14px;
+    padding: 14px 10px 12px 10px;
+    font-weight: 600;
+}
+QGroupBox::title {
+    subcontrol-origin: margin;
+    left: 10px;
+    top: -2px;
+    padding: 1px 6px;
+    color: #f1ebe0;
+    font-weight: 700;
+}
+
+QTabWidget::pane {
+    background-color: #120e18;
+    border: 1px solid #8e72c2;
+    border-radius: 6px;
+    top: -1px;
+}
+QTabBar::tab {
+    background-color: #070509;
+    color: #7d6d94;
+    border: 1px solid #8e72c2;
+    border-bottom: none;
+    border-top-left-radius: 6px;
+    border-top-right-radius: 6px;
+    padding: 6px 14px;
+    margin-right: 2px;
+}
+QTabBar::tab:selected {
+    background-color: #120e18;
+    color: #f1ebe0;
+    border-bottom: 2px solid #ff7819;
+}
+QTabBar::tab:hover:!selected {
+    background-color: #2a2135;
+    color: #f1ebe0;
+}
+
+QPushButton {
+    background-color: #2a2135;
+    color: #f1ebe0;
+    border: 1px solid #8e72c2;
+    border-radius: 5px;
+    padding: 5px 14px;
+}
+QPushButton:hover {
+    background-color: #8e72c2;
+    border-color: #ff7819;
+}
+QPushButton:pressed {
+    background-color: #ff7819;
+    color: #2a0f00;
+}
+QPushButton:disabled {
+    color: #7d6d94;
+    background-color: #070509;
+    border: 1px solid #070509;
+}
+QPushButton:default {
+    border: 1px solid #ff7819;
+}
+
+QLineEdit, QSpinBox, QComboBox, QAbstractSpinBox {
+    background-color: #070509;
+    color: #f1ebe0;
+    border: 1px solid #8e72c2;
+    border-radius: 4px;
+    padding: 3px 6px;
+}
+QLineEdit:focus, QSpinBox:focus, QComboBox:focus {
+    border: 1px solid #ff7819;
+}
+QLineEdit:disabled {
+    color: #7d6d94;
+}
+QComboBox::drop-down {
+    border: none;
+    width: 18px;
+}
+QComboBox QAbstractItemView {
+    background-color: #120e18;
+    color: #f1ebe0;
+    border: 1px solid #8e72c2;
+    selection-background-color: #ff7819;
+    selection-color: #2a0f00;
+}
+
+QCheckBox {
+    color: #f1ebe0;
+    spacing: 8px;
+}
+QCheckBox::indicator {
+    width: 14px;
+    height: 14px;
+    border: 1px solid #8e72c2;
+    border-radius: 3px;
+    background-color: #070509;
+}
+QCheckBox::indicator:checked {
+    background-color: #ff7819;
+    border-color: #ff9a4d;
+    image: url(/home/kali/.local/share/flameshot-theme/assets/check.svg);
+}
+QCheckBox::indicator:hover {
+    border-color: #ff7819;
+}
+
+QLabel {
+    color: #f1ebe0;
+    background: transparent;
+}
+
+QMenu {
+    background-color: #120e18;
+    color: #f1ebe0;
+    border: 1px solid #8e72c2;
+}
+QMenu::item:selected {
+    background-color: #ff7819;
+    color: #2a0f00;
+}
+
+QToolTip {
+    background-color: #2a2135;
+    color: #f1ebe0;
+    border: 1px solid #ff7819;
+    padding: 4px;
+}
+
+QScrollBar:vertical {
+    background: #070509;
+    width: 10px;
+    margin: 0;
+}
+QScrollBar::handle:vertical {
+    background: #8e72c2;
+    border-radius: 5px;
+    min-height: 24px;
+}
+QScrollBar::handle:vertical:hover {
+    background: #ff7819;
+}
+QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical {
+    height: 0;
+}
+
+QListView, QTreeView, QTableView, QTableWidget {
+    background-color: #070509;
+    color: #f1ebe0;
+    border: 1px solid #8e72c2;
+    alternate-background-color: #120e18;
+    gridline-color: #8e72c2;
+}
+QListView::item:selected, QTreeView::item:selected,
+QTableView::item:selected, QTableWidget::item:selected {
+    background-color: #ff7819;
+    color: #2a0f00;
+}
+QListView::item:hover, QTreeView::item:hover,
+QTableView::item:hover, QTableWidget::item:hover {
+    background-color: #2a2135;
+}
+QHeaderView::section {
+    background-color: #120e18;
+    color: #f1ebe0;
+    border: 1px solid #8e72c2;
+    padding: 4px 6px;
+}
+
+QSlider::groove:horizontal {
+    background: #8e72c2;
+    height: 4px;
+    border-radius: 2px;
+}
+QSlider::handle:horizontal {
+    background: #ff7819;
+    width: 14px;
+    margin: -6px 0;
+    border-radius: 7px;
+}

--- a/contrib/flameshot-theme/new-year.conf
+++ b/contrib/flameshot-theme/new-year.conf
@@ -1,0 +1,6 @@
+# new-year :: active December-January (months 12, 1)
+# Source: nicitaacom/14_portfolio app/styles/theme-new-year.css
+MAIN=#c81a30
+CONTRAST=#f7b23b
+DRAW=#c81a30
+USER_COLORS="picker, #c81a30, #f7b23b, #1d5c40, #d9c397, #f8f6f2"

--- a/contrib/flameshot-theme/new-year.qss
+++ b/contrib/flameshot-theme/new-year.qss
@@ -1,0 +1,210 @@
+/* flameshot-theme :: new-year
+ * Structure borrowed from the github-desktop-accent box-in-box panel
+ * language (surface/border/hover/selected), colors from the Crazy
+ * Mechanics design system (nicitaacom/14_portfolio).
+ *   room #0a1622 | surface #102439 | raised #1c5b44 | border #4a9d74
+ *   accent #c81a30 | accent-bright #e84257 | on-accent #fdf3f0
+ *   text #f8f6f2 | secondary #6f8f81
+ */
+
+QWidget {
+    background-color: #0a1622;
+    color: #f8f6f2;
+    selection-background-color: #c81a30;
+    selection-color: #fdf3f0;
+}
+
+QDialog, QMainWindow {
+    background-color: #0a1622;
+}
+
+QScrollArea, QAbstractScrollArea::viewport {
+    background-color: #0a1622;
+    border: none;
+}
+
+QGroupBox {
+    background-color: #102439;
+    border: 1px solid #4a9d74;
+    border-radius: 6px;
+    margin-top: 14px;
+    padding: 14px 10px 12px 10px;
+    font-weight: 600;
+}
+QGroupBox::title {
+    subcontrol-origin: margin;
+    left: 10px;
+    top: -2px;
+    padding: 1px 6px;
+    color: #f8f6f2;
+    font-weight: 700;
+}
+
+QTabWidget::pane {
+    background-color: #102439;
+    border: 1px solid #4a9d74;
+    border-radius: 6px;
+    top: -1px;
+}
+QTabBar::tab {
+    background-color: #0a1622;
+    color: #6f8f81;
+    border: 1px solid #4a9d74;
+    border-bottom: none;
+    border-top-left-radius: 6px;
+    border-top-right-radius: 6px;
+    padding: 6px 14px;
+    margin-right: 2px;
+}
+QTabBar::tab:selected {
+    background-color: #102439;
+    color: #f8f6f2;
+    border-bottom: 2px solid #c81a30;
+}
+QTabBar::tab:hover:!selected {
+    background-color: #1c5b44;
+    color: #f8f6f2;
+}
+
+QPushButton {
+    background-color: #1c5b44;
+    color: #f8f6f2;
+    border: 1px solid #4a9d74;
+    border-radius: 5px;
+    padding: 5px 14px;
+}
+QPushButton:hover {
+    background-color: #4a9d74;
+    border-color: #c81a30;
+}
+QPushButton:pressed {
+    background-color: #c81a30;
+    color: #fdf3f0;
+}
+QPushButton:disabled {
+    color: #6f8f81;
+    background-color: #0a1622;
+    border: 1px solid #0a1622;
+}
+QPushButton:default {
+    border: 1px solid #c81a30;
+}
+
+QLineEdit, QSpinBox, QComboBox, QAbstractSpinBox {
+    background-color: #0a1622;
+    color: #f8f6f2;
+    border: 1px solid #4a9d74;
+    border-radius: 4px;
+    padding: 3px 6px;
+}
+QLineEdit:focus, QSpinBox:focus, QComboBox:focus {
+    border: 1px solid #c81a30;
+}
+QLineEdit:disabled {
+    color: #6f8f81;
+}
+QComboBox::drop-down {
+    border: none;
+    width: 18px;
+}
+QComboBox QAbstractItemView {
+    background-color: #102439;
+    color: #f8f6f2;
+    border: 1px solid #4a9d74;
+    selection-background-color: #c81a30;
+    selection-color: #fdf3f0;
+}
+
+QCheckBox {
+    color: #f8f6f2;
+    spacing: 8px;
+}
+QCheckBox::indicator {
+    width: 14px;
+    height: 14px;
+    border: 1px solid #4a9d74;
+    border-radius: 3px;
+    background-color: #0a1622;
+}
+QCheckBox::indicator:checked {
+    background-color: #c81a30;
+    border-color: #e84257;
+    image: url(/home/kali/.local/share/flameshot-theme/assets/check.svg);
+}
+QCheckBox::indicator:hover {
+    border-color: #c81a30;
+}
+
+QLabel {
+    color: #f8f6f2;
+    background: transparent;
+}
+
+QMenu {
+    background-color: #102439;
+    color: #f8f6f2;
+    border: 1px solid #4a9d74;
+}
+QMenu::item:selected {
+    background-color: #c81a30;
+    color: #fdf3f0;
+}
+
+QToolTip {
+    background-color: #1c5b44;
+    color: #f8f6f2;
+    border: 1px solid #c81a30;
+    padding: 4px;
+}
+
+QScrollBar:vertical {
+    background: #0a1622;
+    width: 10px;
+    margin: 0;
+}
+QScrollBar::handle:vertical {
+    background: #4a9d74;
+    border-radius: 5px;
+    min-height: 24px;
+}
+QScrollBar::handle:vertical:hover {
+    background: #c81a30;
+}
+QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical {
+    height: 0;
+}
+
+QListView, QTreeView, QTableView, QTableWidget {
+    background-color: #0a1622;
+    color: #f8f6f2;
+    border: 1px solid #4a9d74;
+    alternate-background-color: #102439;
+    gridline-color: #4a9d74;
+}
+QListView::item:selected, QTreeView::item:selected,
+QTableView::item:selected, QTableWidget::item:selected {
+    background-color: #c81a30;
+    color: #fdf3f0;
+}
+QListView::item:hover, QTreeView::item:hover,
+QTableView::item:hover, QTableWidget::item:hover {
+    background-color: #1c5b44;
+}
+QHeaderView::section {
+    background-color: #102439;
+    color: #f8f6f2;
+    border: 1px solid #4a9d74;
+    padding: 4px 6px;
+}
+
+QSlider::groove:horizontal {
+    background: #4a9d74;
+    height: 4px;
+    border-radius: 2px;
+}
+QSlider::handle:horizontal {
+    background: #c81a30;
+    width: 14px;
+    margin: -6px 0;
+    border-radius: 7px;
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -29,6 +29,7 @@
 
 #include <QApplication>
 #include <QDir>
+#include <QFile>
 #include <QLibraryInfo>
 #include <QNetworkProxyFactory>
 #include <QSharedMemory>
@@ -172,6 +173,18 @@ void configureTranslation(QTranslator& translator, QTranslator& qtTranslator)
     qApp->installTranslator(&qtTranslator);
 }
 
+// Applies a user-swappable Qt stylesheet, if one is present, so the whole
+// app (not just the capture toolbar's uiColor/contrastUiColor) can be
+// reskinned by dropping a .qss file at this path - see flameshot-theme.
+void applyCustomStyleSheet()
+{
+    QFile file(QDir::homePath() +
+               "/.local/share/flameshot-theme/current.qss");
+    if (file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+        qApp->setStyleSheet(QString::fromUtf8(file.readAll()));
+    }
+}
+
 void configureApp(bool gui, QTranslator& translator, QTranslator& qtTranslator)
 {
     if (gui) {
@@ -180,6 +193,11 @@ void configureApp(bool gui, QTranslator& translator, QTranslator& qtTranslator)
 #else
         QApplication::setStyle(new StyleOverride);
 #endif
+        // Deferred to the next event loop iteration: platform theme
+        // integrations (e.g. qt6ct) inject their own app-wide stylesheet
+        // shortly after startup, which would otherwise clobber this one.
+        // Running after that means ours applies last and wins.
+        QTimer::singleShot(0, qApp, &applyCustomStyleSheet);
     }
 
     auto app = QCoreApplication::instance();


### PR DESCRIPTION
## Added
- **App-wide QSS stylesheet support** — on startup, Flameshot now loads `~/.local/share/flameshot-theme/current.qss` (if present) and applies it as the app-wide stylesheet, layered on top of the existing `uiColor`/`contrastUiColor` settings. If the file doesn't exist, nothing changes — fully opt-in.
- **`contrib/flameshot-theme/`** — example theme files (4 palettes: crazy-mechanics, halloween, new-year, green) plus two small shell scripts (`flameshot-theme` to apply one by name, `flameshot-seasonal-theme` to auto-pick one by month) that generate/install the QSS from a set of named color tokens (room/surface/border/accent/text/etc).

## Why
Loading is deferred one event-loop tick (`QTimer::singleShot(0, ...)`) because `qt6ct`-style platform theme integrations inject their own app-wide stylesheet shortly after startup, which would otherwise clobber this one if applied synchronously.

## Screenshots
Reskinned Configuration window:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/fc81dcfa-52c5-4049-a6f6-19f77951c724" />