### PR TITLE
Restructure General tab into bordered, titled, scrollable sections

### DIFF
--- a/src/config/configwindow.cpp
+++ b/src/config/configwindow.cpp
@@ -7,6 +7,7 @@
 #include "config/generalconf.h"
 #include "config/shortcutswidget.h"
 #include "config/visualseditor.h"
+#include "core/qguiappcurrentscreen.h"
 #include "utils/colorutils.h"
 #include "utils/confighandler.h"
 #include "utils/globalvalues.h"
@@ -18,6 +19,7 @@
 #include <QIcon>
 #include <QKeyEvent>
 #include <QLabel>
+#include <QScreen>
 #include <QSizePolicy>
 #include <QTabBar>
 #include <QTextStream>
@@ -109,6 +111,18 @@ ConfigWindow::ConfigWindow(QWidget* parent)
     initErrorIndicator(m_filenameEditorTab, m_filenameEditor);
     initErrorIndicator(m_generalConfigTab, m_generalConfig);
     initErrorIndicator(m_shortcutsTab, m_shortcuts);
+
+    // Cap the window to roughly half the screen height (50vh) - with no
+    // limit here, tabs whose content doesn't fit in a QScrollArea let the
+    // window grow to fit every setting and can end up taller than the
+    // screen. Each tab's own scroll area (see GeneralConf) handles
+    // overflow once the window itself stops growing.
+    QScreen* screen = QGuiAppCurrentScreen().currentScreen();
+    if (screen) {
+        int maxHeight = screen->availableGeometry().height() / 2;
+        setMaximumHeight(maxHeight);
+        resize(width(), maxHeight);
+    }
 }
 
 void ConfigWindow::keyPressEvent(QKeyEvent* e)

--- a/src/config/generalconf.cpp
+++ b/src/config/generalconf.cpp
@@ -28,27 +28,47 @@ GeneralConf::GeneralConf(QWidget* parent)
 {
     m_layout = new QVBoxLayout(this);
     m_layout->setAlignment(Qt::AlignTop);
+    m_layout->setSpacing(10);
 
     // Scroll area adapts the size of the content on small screens.
     // It must be initialized before the checkboxes.
     initScrollArea();
 
-    initAutostart();
-    initAutoCloseIdleDaemon();
-    initShowTrayIcon();
-    initShowDesktopNotification();
-    initShowAbortNotification();
+    {
+        QVBoxLayout* outer = m_scrollAreaLayout;
+        QVBoxLayout* group = pushGroupBox(tr("Startup"));
+        m_scrollAreaLayout = group;
+        initAutostart();
+        initAutoCloseIdleDaemon();
+        initShowTrayIcon();
+        m_scrollAreaLayout = outer;
+        // Forces this group's size hint to be recomputed right away, with
+        // all 3 checkboxes already added - otherwise a QGroupBox
+        // populated after being placed inside a resizable QScrollArea can
+        // end up sized (and clipped) as if it only ever held its first
+        // child.
+        group->activate();
+    }
+    {
+        QVBoxLayout* outer = m_scrollAreaLayout;
+        QVBoxLayout* group = pushGroupBox(tr("Notifications & Behavior"));
+        m_scrollAreaLayout = group;
+        initShowDesktopNotification();
+        initShowAbortNotification();
 #if !defined(DISABLE_UPDATE_CHECKER)
-    initCheckForUpdates();
+        initCheckForUpdates();
 #endif
-    initShowStartupLaunchMessage();
-    initShowQuitPrompt();
-    initAllowMultipleGuiInstances();
-    initSaveLastRegion();
-    initShowHelp();
-    initShowSidePanelButton();
-    initUseJpgForClipboard();
-    initCopyOnDoubleClick();
+        initShowStartupLaunchMessage();
+        initShowQuitPrompt();
+        initAllowMultipleGuiInstances();
+        initSaveLastRegion();
+        initShowHelp();
+        initShowSidePanelButton();
+        initUseJpgForClipboard();
+        initCopyOnDoubleClick();
+        m_scrollAreaLayout = outer;
+        group->activate();
+    }
     initSaveAfterCopy();
     initCopyPathAfterSave();
     initAntialiasingPinZoom();
@@ -67,13 +87,12 @@ GeneralConf::GeneralConf(QWidget* parent)
     initCopyAndCloseAfterUpload();
     initUploadWithoutConfirmation();
     initHistoryConfirmationToDelete();
-    initUploadHistoryMax();
     initUploadClientSecret();
 #endif
     initPredefinedColorPaletteLarge();
     initShowSelectionGeometry();
 
-    m_layout->addStretch();
+    m_scrollAreaLayout->addStretch();
 
     initShowMagnifier();
     initSquareMagnifier();
@@ -255,12 +274,16 @@ void GeneralConf::resetConfiguration()
 void GeneralConf::initScrollArea()
 {
     m_scrollArea = new QScrollArea(this);
+    // m_layout (this widget's own top-level layout) holds ONLY the scroll
+    // area - every section (Startup, Save Path, Shortcuts locations, all
+    // of it) is added to m_scrollAreaLayout below, not m_layout, so the
+    // whole tab scrolls as one unit instead of the dialog growing to fit
+    // all of it unconditionally.
     m_layout->addWidget(m_scrollArea);
 
     auto* content = new QWidget(m_scrollArea);
     m_scrollArea->setWidget(content);
     m_scrollArea->setWidgetResizable(true);
-    m_scrollArea->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Maximum);
     m_scrollArea->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
 
     content->setObjectName("content");
@@ -269,6 +292,38 @@ void GeneralConf::initScrollArea()
       "#content, #scrollArea { background: transparent; border: 0px; }");
     m_scrollAreaLayout = new QVBoxLayout(content);
     m_scrollAreaLayout->setContentsMargins(0, 0, 20, 0);
+    m_scrollAreaLayout->setSpacing(10);
+}
+
+QVBoxLayout* GeneralConf::pushGroupBox(const QString& title)
+{
+    auto* box = new QGroupBox(title);
+    box->setFlat(true);
+    auto* layout = new QVBoxLayout();
+    layout->setSpacing(8);
+    box->setLayout(layout);
+    m_scrollAreaLayout->addWidget(box);
+    return layout;
+}
+
+QSpinBox* GeneralConf::pushCompactSpinBox(QHBoxLayout* row,
+                                         const QString& title,
+                                         int max)
+{
+    auto* box = new QGroupBox(title);
+    box->setFlat(true);
+    box->setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Preferred);
+    auto* vboxLayout = new QVBoxLayout();
+    box->setLayout(vboxLayout);
+
+    auto* spin = new QSpinBox(this);
+    spin->setMaximum(max);
+    QString foreground = this->palette().windowText().color().name();
+    spin->setStyleSheet(QStringLiteral("color: %1").arg(foreground));
+    vboxLayout->addWidget(spin);
+
+    row->addWidget(box);
+    return spin;
 }
 
 void GeneralConf::initShowHelp()
@@ -365,7 +420,7 @@ void GeneralConf::initConfigButtons()
     auto* box = new QGroupBox(tr("Configuration File"));
     box->setFlat(true);
     box->setLayout(buttonLayout);
-    m_layout->addWidget(box);
+    m_scrollAreaLayout->addWidget(box);
 
     m_exportButton = new QPushButton(tr("Export"));
     buttonLayout->addWidget(m_exportButton);
@@ -518,7 +573,7 @@ void GeneralConf::initSaveAfterCopy()
 
     auto* box = new QGroupBox(tr("Save Path"));
     box->setFlat(true);
-    m_layout->addWidget(box);
+    m_scrollAreaLayout->addWidget(box);
 
     auto* vboxLayout = new QVBoxLayout();
     box->setLayout(vboxLayout);
@@ -579,33 +634,11 @@ void GeneralConf::historyConfirmationToDelete(bool checked)
     ConfigHandler().setHistoryConfirmationToDelete(checked);
 }
 
-void GeneralConf::initUploadHistoryMax()
-{
-    auto* box = new QGroupBox(tr("Latest Uploads Max Size"));
-    box->setFlat(true);
-    m_layout->addWidget(box);
-
-    auto* vboxLayout = new QVBoxLayout();
-    box->setLayout(vboxLayout);
-
-    m_uploadHistoryMax = new QSpinBox(this);
-    m_uploadHistoryMax->setMaximum(50);
-    QString foreground = this->palette().windowText().color().name();
-    m_uploadHistoryMax->setStyleSheet(
-      QStringLiteral("color: %1").arg(foreground));
-
-    connect(m_uploadHistoryMax,
-            static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged),
-            this,
-            &GeneralConf::uploadHistoryMaxChanged);
-    vboxLayout->addWidget(m_uploadHistoryMax);
-}
-
 void GeneralConf::initUploadClientSecret()
 {
     auto* box = new QGroupBox(tr("Imgur Application Client ID"));
     box->setFlat(true);
-    m_layout->addWidget(box);
+    m_scrollAreaLayout->addWidget(box);
 
     auto* vboxLayout = new QVBoxLayout();
     box->setLayout(vboxLayout);
@@ -634,25 +667,29 @@ void GeneralConf::uploadHistoryMaxChanged(int max)
 
 void GeneralConf::initUndoLimit()
 {
-    auto* box = new QGroupBox(tr("Undo limit"));
-    box->setFlat(true);
-    m_layout->addWidget(box);
+    // Undo limit and (when built with Imgur) Latest Uploads Max Size are
+    // both a title + a single spinbox - lined up in one row via
+    // pushCompactSpinBox instead of each claiming a full-width section
+    // for one number field.
+    auto* row = new QHBoxLayout();
+    m_scrollAreaLayout->addLayout(row);
 
-    auto* vboxLayout = new QVBoxLayout();
-    box->setLayout(vboxLayout);
-
-    m_undoLimit = new QSpinBox(this);
+    m_undoLimit = pushCompactSpinBox(row, tr("Undo limit"), 999);
     m_undoLimit->setMinimum(1);
-    m_undoLimit->setMaximum(999);
-    QString foreground = this->palette().windowText().color().name();
-    m_undoLimit->setStyleSheet(QStringLiteral("color: %1").arg(foreground));
-
     connect(m_undoLimit,
             static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged),
             this,
             &GeneralConf::undoLimit);
 
-    vboxLayout->addWidget(m_undoLimit);
+#ifdef ENABLE_IMGUR
+    m_uploadHistoryMax = pushCompactSpinBox(row, tr("Latest Uploads Max Size"), 50);
+    connect(m_uploadHistoryMax,
+            static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged),
+            this,
+            &GeneralConf::uploadHistoryMaxChanged);
+#endif
+
+    row->addStretch();
 }
 
 void GeneralConf::undoLimit(int limit)
@@ -800,7 +837,7 @@ void GeneralConf::initShowSelectionGeometry()
 
     auto* box = new QGroupBox(tr("Selection Geometry Display"));
     box->setFlat(true);
-    m_layout->addWidget(box);
+    m_scrollAreaLayout->addWidget(box);
 
     auto* vboxLayout = new QVBoxLayout();
     box->setLayout(vboxLayout);

--- a/src/config/generalconf.h
+++ b/src/config/generalconf.h
@@ -7,6 +7,7 @@
 #include <QWidget>
 
 class QVBoxLayout;
+class QHBoxLayout;
 class QCheckBox;
 class QPushButton;
 class QLabel;
@@ -74,6 +75,20 @@ private slots:
 private:
     const QString chooseFolder(const QString& currentPath = "");
 
+    // Adds a titled, bordered QGroupBox to m_scrollAreaLayout and returns
+    // its inner layout. Callers temporarily reassign m_scrollAreaLayout to
+    // the result so existing initX() functions - which only ever call
+    // m_scrollAreaLayout->addWidget(...) - nest into the section without
+    // needing any changes themselves.
+    QVBoxLayout* pushGroupBox(const QString& title);
+    // A small titled QGroupBox holding one QSpinBox, sized to its content
+    // (not full-width) and appended into `row` - used to line up Undo
+    // limit and Latest Uploads Max Size side by side instead of each
+    // eating a full-width row for a single number field.
+    QSpinBox* pushCompactSpinBox(QHBoxLayout* row,
+                                 const QString& title,
+                                 int max);
+
     void initAllowMultipleGuiInstances();
     void initAntialiasingPinZoom();
     void initAutoCloseIdleDaemon();
@@ -101,7 +116,6 @@ private:
     void initUndoLimit();
     void initUploadWithoutConfirmation();
     void initUseJpgForClipboard();
-    void initUploadHistoryMax();
     void initUploadClientSecret();
     void initSaveLastRegion();
     void initShowSelectionGeometry();


### PR DESCRIPTION
## Fixed
- **General tab was cramped and clipped** — loose checkboxes had no visual grouping, and a `QGroupBox` populated via a redirected layout pointer rendered clipped to its first child once nested inside the resizable `QScrollArea`'s content layout.

Restructured into bordered, titled `QGroupBox` sections (Startup, Notifications & Behavior, Save Path, Selection Geometry Display, etc), with the whole tab living inside one scroll area instead of partially outside it. Also paired "Undo limit" with "Latest Uploads Max Size" as a compact two-column row instead of each taking the full tab width.

## Screenshot
<img width="640" height="695" alt="image" src="https://github.com/user-attachments/assets/f63b1562-c482-49ad-92f5-3a5d5f161b02" />




**Before: (took entire screen height)**

<img width="640" height="1080" alt="image" src="https://github.com/user-attachments/assets/70a0d2f7-c2d7-4bae-92ff-f6cb9cd279f2" />


**After:**

<img width="640" height="694" alt="image" src="https://github.com/user-attachments/assets/5bf42e91-04b6-4d47-81ed-5ee9d6b1a8e0" />
