### PR TITLE
Ignore mouse-wheel scroll on unfocused comboboxes/spinboxes in Configuration

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,6 +20,7 @@
 #include "utils/filenamehandler.h"
 #include "utils/pathinfo.h"
 #include "utils/valuehandler.h"
+#include "utils/wheelfocusguard.h"
 
 #if !(defined(Q_OS_MACOS) || defined(Q_OS_WIN))
 #include "core/flameshotdbusadapter.h"
@@ -180,6 +181,7 @@ void configureApp(bool gui, QTranslator& translator, QTranslator& qtTranslator)
 #else
         QApplication::setStyle(new StyleOverride);
 #endif
+        qApp->installEventFilter(new WheelFocusGuard(qApp));
     }
 
     auto app = QCoreApplication::instance();

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -7,6 +7,7 @@ target_sources(
           systemnotification.h
           valuehandler.h
           strfparse.h
+          wheelfocusguard.h
 )
 
 target_sources(
@@ -26,6 +27,7 @@ target_sources(
           colorutils.cpp
           history.cpp
           strfparse.cpp
+          wheelfocusguard.cpp
 )
 
 IF (UNIX AND NOT APPLE)

--- a/src/utils/wheelfocusguard.cpp
+++ b/src/utils/wheelfocusguard.cpp
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2017-2019 Alejandro Sirgo Rica & Contributors
+
+#include "wheelfocusguard.h"
+
+#include <QAbstractSpinBox>
+#include <QComboBox>
+#include <QEvent>
+#include <QWidget>
+
+bool WheelFocusGuard::eventFilter(QObject* watched, QEvent* event)
+{
+    if (event->type() == QEvent::Wheel) {
+        auto* widget = qobject_cast<QWidget*>(watched);
+        bool isScrollSensitive =
+          qobject_cast<QComboBox*>(widget) ||
+          qobject_cast<QAbstractSpinBox*>(widget);
+        if (isScrollSensitive && !widget->hasFocus()) {
+            event->ignore();
+            return true;
+        }
+    }
+    return QObject::eventFilter(watched, event);
+}

--- a/src/utils/wheelfocusguard.h
+++ b/src/utils/wheelfocusguard.h
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2017-2019 Alejandro Sirgo Rica & Contributors
+
+#pragma once
+
+#include <QObject>
+
+// QComboBox and QAbstractSpinBox react to the mouse wheel by default even
+// when they don't have focus, which hijacks scrolling anywhere these
+// widgets sit inside a QScrollArea (e.g. Configuration's General tab) -
+// the user ends up silently changing a setting instead of scrolling past
+// it. Installed once app-wide, this ignores wheel events on such widgets
+// while they're unfocused so the event bubbles up to the parent scroll
+// area instead; clicking into the widget first still allows scrolling to
+// change its value as usual.
+class WheelFocusGuard : public QObject
+{
+    Q_OBJECT
+public:
+    using QObject::QObject;
+
+protected:
+    bool eventFilter(QObject* watched, QEvent* event) override;
+};


### PR DESCRIPTION
## Fixed
- **Scrolling past a dropdown/spin box in Configuration could silently change its value** instead of scrolling the page. `QComboBox` and `QAbstractSpinBox` react to the mouse wheel by default even without focus, so any scroll gesture that passed over one inside a `QScrollArea` (e.g. the General tab) risked editing it.

Added `WheelFocusGuard`, a small app-wide event filter (installed once in `main.cpp`) that ignores wheel events on these widget types while they're unfocused. Clicking into a field first still lets the wheel change its value as before.

## Known limitation
This doesn't catch every case — a field that already holds keyboard focus from earlier interaction (e.g. tab order, a previous click elsewhere) can still respond to a wheel scroll. An attempt to also forward the blocked event so the page kept scrolling past the widget caused unreliable event redelivery and was reverted; happy to discuss further approaches.