### PR TITLE
Group General settings' loose checkboxes into an "Options" section

### DIFF
--- a/src/config/generalconf.cpp
+++ b/src/config/generalconf.cpp
@@ -15,7 +15,6 @@
 #include <QMessageBox>
 #include <QPushButton>
 #include <QSettings>
-#include <QSizePolicy>
 #include <QSpinBox>
 #include <QStandardPaths>
 #include <QStringDecoder>
@@ -69,6 +68,11 @@ GeneralConf::GeneralConf(QWidget* parent)
         m_scrollAreaLayout = outer;
         group->activate();
     }
+    // Where screenshots end up is core to every capture, so the save
+    // settings (which also carry JPEG Quality now, folded into the Save
+    // Path box) rank above the general Options toggles below.
+    initSaveAfterCopy();
+    initSaveLocations();
     {
         QVBoxLayout* outer = m_scrollAreaLayout;
         QVBoxLayout* group = pushGroupBox(tr("Options"));
@@ -97,8 +101,8 @@ GeneralConf::GeneralConf(QWidget* parent)
         m_scrollAreaLayout = outer;
         group->activate();
     }
-    initSaveAfterCopy();
-    initSaveLocations();
+    // Fine-tuning knobs that are set once and rarely revisited - lowest
+    // priority, just above the Configuration File actions.
     initUndoLimit();
 #ifdef ENABLE_IMGUR
     initUploadClientSecret();
@@ -107,7 +111,6 @@ GeneralConf::GeneralConf(QWidget* parent)
 
     m_scrollAreaLayout->addStretch();
 
-    initJpegQuality();
     // this has to be at the end
     initConfigButtons();
     updateComponents();
@@ -318,26 +321,6 @@ QVBoxLayout* GeneralConf::pushGroupBox(const QString& title)
     box->setLayout(layout);
     m_scrollAreaLayout->addWidget(box);
     return layout;
-}
-
-QSpinBox* GeneralConf::pushCompactSpinBox(QHBoxLayout* row,
-                                         const QString& title,
-                                         int max)
-{
-    auto* box = new QGroupBox(title);
-    box->setFlat(true);
-    box->setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Preferred);
-    auto* vboxLayout = new QVBoxLayout();
-    box->setLayout(vboxLayout);
-
-    auto* spin = new QSpinBox(this);
-    spin->setMaximum(max);
-    QString foreground = this->palette().windowText().color().name();
-    spin->setStyleSheet(QStringLiteral("color: %1").arg(foreground));
-    vboxLayout->addWidget(spin);
-
-    row->addWidget(box);
-    return spin;
 }
 
 void GeneralConf::initShowHelp()
@@ -652,6 +635,14 @@ void GeneralConf::initSaveAfterCopy()
 
     extensionLayout->addWidget(m_setSaveAsFileExtension);
     vboxLayout->addLayout(extensionLayout);
+
+    // JPEG Quality only matters for the save/upload/clipboard file format
+    // set above - nest it in this same box instead of leaving it as an
+    // unrelated floating row elsewhere in the tab.
+    QVBoxLayout* outer = m_scrollAreaLayout;
+    m_scrollAreaLayout = vboxLayout;
+    initJpegQuality();
+    m_scrollAreaLayout = outer;
 }
 
 void GeneralConf::historyConfirmationToDelete(bool checked)
@@ -692,29 +683,45 @@ void GeneralConf::uploadHistoryMaxChanged(int max)
 
 void GeneralConf::initUndoLimit()
 {
-    // Undo limit and (when built with Imgur) Latest Uploads Max Size are
-    // both a title + a single spinbox - lined up in one row via
-    // pushCompactSpinBox instead of each claiming a full-width section
-    // for one number field.
-    auto* row = new QHBoxLayout();
-    m_scrollAreaLayout->addLayout(row);
+    // One full-width titled box, matching every other section in this
+    // tab, instead of two mini boxes hugging their content on the left
+    // with dead space to the right.
+    auto* box = new QGroupBox(tr("Limits"));
+    box->setFlat(true);
+    m_scrollAreaLayout->addWidget(box);
 
-    m_undoLimit = pushCompactSpinBox(row, tr("Undo limit"), 999);
-    m_undoLimit->setMinimum(1);
+    auto* vboxLayout = new QVBoxLayout();
+    box->setLayout(vboxLayout);
+    QString foreground = this->palette().windowText().color().name();
+
+    auto* undoRow = new QHBoxLayout();
+    undoRow->addWidget(new QLabel(tr("Undo limit")));
+    m_undoLimit = new QSpinBox(this);
+    m_undoLimit->setRange(1, 999);
+    m_undoLimit->setStyleSheet(QStringLiteral("color: %1").arg(foreground));
+    undoRow->addWidget(m_undoLimit);
+    vboxLayout->addLayout(undoRow);
     connect(m_undoLimit,
             static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged),
             this,
             &GeneralConf::undoLimit);
 
 #ifdef ENABLE_IMGUR
-    m_uploadHistoryMax = pushCompactSpinBox(row, tr("Latest Uploads Max Size"), 50);
+    auto* uploadRow = new QHBoxLayout();
+    uploadRow->addWidget(new QLabel(tr("Latest Uploads Max Size")));
+    m_uploadHistoryMax = new QSpinBox(this);
+    m_uploadHistoryMax->setMaximum(50);
+    m_uploadHistoryMax->setStyleSheet(
+      QStringLiteral("color: %1").arg(foreground));
+    uploadRow->addWidget(m_uploadHistoryMax);
+    vboxLayout->addLayout(uploadRow);
     connect(m_uploadHistoryMax,
             static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged),
             this,
             &GeneralConf::uploadHistoryMaxChanged);
 #endif
 
-    row->addStretch();
+    vboxLayout->addStretch();
 }
 
 void GeneralConf::undoLimit(int limit)
@@ -929,8 +936,14 @@ void GeneralConf::initSquareMagnifier()
 
 void GeneralConf::initShowSelectionGeometry()
 {
-    auto* tobox = new QHBoxLayout();
+    auto* box = new QGroupBox(tr("Selection Geometry Display"));
+    box->setFlat(true);
+    m_scrollAreaLayout->addWidget(box);
 
+    auto* vboxLayout = new QVBoxLayout();
+    box->setLayout(vboxLayout);
+
+    auto* tobox = new QHBoxLayout();
     int timeout =
       ConfigHandler().value("showSelectionGeometryHideTime").toInt();
     m_xywhTimeout = new QSpinBox();
@@ -940,19 +953,12 @@ void GeneralConf::initShowSelectionGeometry()
     m_xywhTimeout->setValue(timeout);
     tobox->addWidget(m_xywhTimeout);
     tobox->addWidget(new QLabel(tr("Set geometry display timeout (ms)")));
-
-    m_scrollAreaLayout->addLayout(tobox);
+    vboxLayout->addLayout(tobox);
     connect(m_xywhTimeout,
             static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged),
             this,
             &GeneralConf::setSelGeoHideTime);
 
-    auto* box = new QGroupBox(tr("Selection Geometry Display"));
-    box->setFlat(true);
-    m_scrollAreaLayout->addWidget(box);
-
-    auto* vboxLayout = new QVBoxLayout();
-    box->setLayout(vboxLayout);
     auto* selGeoLayout = new QHBoxLayout();
     selGeoLayout->addWidget(new QLabel(tr("Display Location")));
     m_selectGeometryLocation = new QComboBox(this);

--- a/src/config/generalconf.cpp
+++ b/src/config/generalconf.cpp
@@ -28,57 +28,86 @@ GeneralConf::GeneralConf(QWidget* parent)
 {
     m_layout = new QVBoxLayout(this);
     m_layout->setAlignment(Qt::AlignTop);
+    m_layout->setSpacing(10);
 
     // Scroll area adapts the size of the content on small screens.
     // It must be initialized before the checkboxes.
     initScrollArea();
 
-    initAutostart();
-    initAutoCloseIdleDaemon();
-    initShowTrayIcon();
-    initShowDesktopNotification();
-    initShowAbortNotification();
+    {
+        QVBoxLayout* outer = m_scrollAreaLayout;
+        QVBoxLayout* group = pushGroupBox(tr("Startup"));
+        m_scrollAreaLayout = group;
+        initAutostart();
+        initAutoCloseIdleDaemon();
+        initShowTrayIcon();
+        m_scrollAreaLayout = outer;
+        // Forces this group's size hint to be recomputed right away, with
+        // all 3 checkboxes already added - otherwise a QGroupBox
+        // populated after being placed inside a resizable QScrollArea can
+        // end up sized (and clipped) as if it only ever held its first
+        // child.
+        group->activate();
+    }
+    {
+        QVBoxLayout* outer = m_scrollAreaLayout;
+        QVBoxLayout* group = pushGroupBox(tr("Notifications & Behavior"));
+        m_scrollAreaLayout = group;
+        initShowDesktopNotification();
+        initShowAbortNotification();
 #if !defined(DISABLE_UPDATE_CHECKER)
-    initCheckForUpdates();
+        initCheckForUpdates();
 #endif
-    initShowStartupLaunchMessage();
-    initShowQuitPrompt();
-    initAllowMultipleGuiInstances();
-    initSaveLastRegion();
-    initShowHelp();
-    initShowSidePanelButton();
-    initUseJpgForClipboard();
-    initCopyOnDoubleClick();
-    initSaveAfterCopy();
-    initCopyPathAfterSave();
-    initAntialiasingPinZoom();
-    initUndoLimit();
-    initInsecurePixelate();
+        initShowStartupLaunchMessage();
+        initShowQuitPrompt();
+        initAllowMultipleGuiInstances();
+        initSaveLastRegion();
+        initShowHelp();
+        initShowSidePanelButton();
+        initUseJpgForClipboard();
+        initCopyOnDoubleClick();
+        m_scrollAreaLayout = outer;
+        group->activate();
+    }
+    {
+        QVBoxLayout* outer = m_scrollAreaLayout;
+        QVBoxLayout* group = pushGroupBox(tr("Options"));
+        m_scrollAreaLayout = group;
+        initCopyPathAfterSave();
+        initAntialiasingPinZoom();
+        initInsecurePixelate();
 #if !defined(Q_OS_MACOS)
-    initCaptureActiveMonitor();
+        initCaptureActiveMonitor();
 #endif
 #if defined(Q_OS_MACOS)
-    initUseNativeFullscreen();
+        initUseNativeFullscreen();
 #endif
 #if defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)
-    initUseX11LegacyScreenshot();
+        initUseX11LegacyScreenshot();
 #endif
 #ifdef ENABLE_IMGUR
-    initCopyAndCloseAfterUpload();
-    initUploadWithoutConfirmation();
-    initHistoryConfirmationToDelete();
-    initUploadHistoryMax();
+        initCopyAndCloseAfterUpload();
+        initUploadWithoutConfirmation();
+        initHistoryConfirmationToDelete();
+#endif
+        initPredefinedColorPaletteLarge();
+        initShowMagnifier();
+        initSquareMagnifier();
+        initReverseArrow();
+        m_scrollAreaLayout = outer;
+        group->activate();
+    }
+    initSaveAfterCopy();
+    initSaveLocations();
+    initUndoLimit();
+#ifdef ENABLE_IMGUR
     initUploadClientSecret();
 #endif
-    initPredefinedColorPaletteLarge();
     initShowSelectionGeometry();
 
-    m_layout->addStretch();
+    m_scrollAreaLayout->addStretch();
 
-    initShowMagnifier();
-    initSquareMagnifier();
     initJpegQuality();
-    initReverseArrow();
     // this has to be at the end
     initConfigButtons();
     updateComponents();
@@ -100,6 +129,7 @@ void GeneralConf::_updateComponents(bool allowEmptySavePath)
 #ifdef ENABLE_IMGUR
     m_uploadWithoutConfirmation->setChecked(config.uploadWithoutConfirmation());
     m_copyURLAfterUpload->setChecked(config.copyURLAfterUpload());
+    m_showPostUploadDialog->setChecked(config.showPostUploadDialog());
     m_historyConfirmationToDelete->setChecked(
       config.historyConfirmationToDelete());
 
@@ -124,6 +154,9 @@ void GeneralConf::_updateComponents(bool allowEmptySavePath)
     if (allowEmptySavePath || !config.savePath().isEmpty()) {
         m_savePath->setText(config.savePath());
     }
+    m_saveLocation1->setText(config.savePathLocation1());
+    m_saveLocation2->setText(config.savePathLocation2());
+    m_saveLocation3->setText(config.savePathLocation3());
 
     m_showTray->setChecked(!config.disabledTrayIcon());
 
@@ -255,12 +288,16 @@ void GeneralConf::resetConfiguration()
 void GeneralConf::initScrollArea()
 {
     m_scrollArea = new QScrollArea(this);
+    // m_layout (this widget's own top-level layout) holds ONLY the scroll
+    // area - every section (Startup, Save Path, Shortcuts locations, all
+    // of it) is added to m_scrollAreaLayout below, not m_layout, so the
+    // whole tab scrolls as one unit instead of the dialog growing to fit
+    // all of it unconditionally.
     m_layout->addWidget(m_scrollArea);
 
     auto* content = new QWidget(m_scrollArea);
     m_scrollArea->setWidget(content);
     m_scrollArea->setWidgetResizable(true);
-    m_scrollArea->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Maximum);
     m_scrollArea->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
 
     content->setObjectName("content");
@@ -269,6 +306,38 @@ void GeneralConf::initScrollArea()
       "#content, #scrollArea { background: transparent; border: 0px; }");
     m_scrollAreaLayout = new QVBoxLayout(content);
     m_scrollAreaLayout->setContentsMargins(0, 0, 20, 0);
+    m_scrollAreaLayout->setSpacing(10);
+}
+
+QVBoxLayout* GeneralConf::pushGroupBox(const QString& title)
+{
+    auto* box = new QGroupBox(title);
+    box->setFlat(true);
+    auto* layout = new QVBoxLayout();
+    layout->setSpacing(8);
+    box->setLayout(layout);
+    m_scrollAreaLayout->addWidget(box);
+    return layout;
+}
+
+QSpinBox* GeneralConf::pushCompactSpinBox(QHBoxLayout* row,
+                                         const QString& title,
+                                         int max)
+{
+    auto* box = new QGroupBox(title);
+    box->setFlat(true);
+    box->setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Preferred);
+    auto* vboxLayout = new QVBoxLayout();
+    box->setLayout(vboxLayout);
+
+    auto* spin = new QSpinBox(this);
+    spin->setMaximum(max);
+    QString foreground = this->palette().windowText().color().name();
+    spin->setStyleSheet(QStringLiteral("color: %1").arg(foreground));
+    vboxLayout->addWidget(spin);
+
+    row->addWidget(box);
+    return spin;
 }
 
 void GeneralConf::initShowHelp()
@@ -365,7 +434,7 @@ void GeneralConf::initConfigButtons()
     auto* box = new QGroupBox(tr("Configuration File"));
     box->setFlat(true);
     box->setLayout(buttonLayout);
-    m_layout->addWidget(box);
+    m_scrollAreaLayout->addWidget(box);
 
     m_exportButton = new QPushButton(tr("Export"));
     buttonLayout->addWidget(m_exportButton);
@@ -503,6 +572,17 @@ void GeneralConf::initCopyAndCloseAfterUpload()
     connect(m_copyURLAfterUpload, &QCheckBox::clicked, [](bool checked) {
         ConfigHandler().setCopyURLAfterUpload(checked);
     });
+
+    m_showPostUploadDialog =
+      new QCheckBox(tr("Show upload result window"), this);
+    m_showPostUploadDialog->setToolTip(
+      tr("Open a window with the image and link after every upload, "
+         "instead of just copying the link"));
+    m_scrollAreaLayout->addWidget(m_showPostUploadDialog);
+
+    connect(m_showPostUploadDialog, &QCheckBox::clicked, [](bool checked) {
+        ConfigHandler().setShowPostUploadDialog(checked);
+    });
 }
 
 void GeneralConf::initSaveAfterCopy()
@@ -518,7 +598,7 @@ void GeneralConf::initSaveAfterCopy()
 
     auto* box = new QGroupBox(tr("Save Path"));
     box->setFlat(true);
-    m_layout->addWidget(box);
+    m_scrollAreaLayout->addWidget(box);
 
     auto* vboxLayout = new QVBoxLayout();
     box->setLayout(vboxLayout);
@@ -579,33 +659,11 @@ void GeneralConf::historyConfirmationToDelete(bool checked)
     ConfigHandler().setHistoryConfirmationToDelete(checked);
 }
 
-void GeneralConf::initUploadHistoryMax()
-{
-    auto* box = new QGroupBox(tr("Latest Uploads Max Size"));
-    box->setFlat(true);
-    m_layout->addWidget(box);
-
-    auto* vboxLayout = new QVBoxLayout();
-    box->setLayout(vboxLayout);
-
-    m_uploadHistoryMax = new QSpinBox(this);
-    m_uploadHistoryMax->setMaximum(50);
-    QString foreground = this->palette().windowText().color().name();
-    m_uploadHistoryMax->setStyleSheet(
-      QStringLiteral("color: %1").arg(foreground));
-
-    connect(m_uploadHistoryMax,
-            static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged),
-            this,
-            &GeneralConf::uploadHistoryMaxChanged);
-    vboxLayout->addWidget(m_uploadHistoryMax);
-}
-
 void GeneralConf::initUploadClientSecret()
 {
     auto* box = new QGroupBox(tr("Imgur Application Client ID"));
     box->setFlat(true);
-    m_layout->addWidget(box);
+    m_scrollAreaLayout->addWidget(box);
 
     auto* vboxLayout = new QVBoxLayout();
     box->setLayout(vboxLayout);
@@ -634,25 +692,29 @@ void GeneralConf::uploadHistoryMaxChanged(int max)
 
 void GeneralConf::initUndoLimit()
 {
-    auto* box = new QGroupBox(tr("Undo limit"));
-    box->setFlat(true);
-    m_layout->addWidget(box);
+    // Undo limit and (when built with Imgur) Latest Uploads Max Size are
+    // both a title + a single spinbox - lined up in one row via
+    // pushCompactSpinBox instead of each claiming a full-width section
+    // for one number field.
+    auto* row = new QHBoxLayout();
+    m_scrollAreaLayout->addLayout(row);
 
-    auto* vboxLayout = new QVBoxLayout();
-    box->setLayout(vboxLayout);
-
-    m_undoLimit = new QSpinBox(this);
+    m_undoLimit = pushCompactSpinBox(row, tr("Undo limit"), 999);
     m_undoLimit->setMinimum(1);
-    m_undoLimit->setMaximum(999);
-    QString foreground = this->palette().windowText().color().name();
-    m_undoLimit->setStyleSheet(QStringLiteral("color: %1").arg(foreground));
-
     connect(m_undoLimit,
             static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged),
             this,
             &GeneralConf::undoLimit);
 
-    vboxLayout->addWidget(m_undoLimit);
+#ifdef ENABLE_IMGUR
+    m_uploadHistoryMax = pushCompactSpinBox(row, tr("Latest Uploads Max Size"), 50);
+    connect(m_uploadHistoryMax,
+            static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged),
+            this,
+            &GeneralConf::uploadHistoryMaxChanged);
+#endif
+
+    row->addStretch();
 }
 
 void GeneralConf::undoLimit(int limit)
@@ -692,6 +754,93 @@ void GeneralConf::changeSavePath()
     if (!path.isEmpty()) {
         m_savePath->setText(path);
         ConfigHandler().setSavePath(path);
+    }
+}
+
+// 3 extra save destinations, each exposed as its own tool
+// (TYPE_SAVE_LOCATION_1/2/3) so a hotkey can be bound to it from the
+// Shortcuts tab, saving straight to that folder with no dialog.
+void GeneralConf::initSaveLocations()
+{
+    auto* box = new QGroupBox(tr("Save Path Locations (hotkey-bindable)"));
+    box->setFlat(true);
+    m_scrollAreaLayout->addWidget(box);
+
+    auto* vboxLayout = new QVBoxLayout();
+    box->setLayout(vboxLayout);
+
+    QString foreground = this->palette().windowText().color().name();
+    ConfigHandler config;
+
+    QLineEdit** lineEdits[3] = { &m_saveLocation1,
+                                 &m_saveLocation2,
+                                 &m_saveLocation3 };
+    QPushButton** buttons[3] = { &m_changeSaveLocation1Button,
+                                 &m_changeSaveLocation2Button,
+                                 &m_changeSaveLocation3Button };
+    QString savedPaths[3] = { config.savePathLocation1(),
+                              config.savePathLocation2(),
+                              config.savePathLocation3() };
+
+    for (int i = 0; i < 3; ++i) {
+        auto* rowLayout = new QHBoxLayout();
+        rowLayout->addWidget(new QLabel(tr("Location %1:").arg(i + 1)));
+
+        auto* lineEdit = new QLineEdit(savedPaths[i], this);
+        lineEdit->setDisabled(true);
+        lineEdit->setStyleSheet(QStringLiteral("color: %1").arg(foreground));
+        rowLayout->addWidget(lineEdit);
+        *lineEdits[i] = lineEdit;
+
+        auto* button = new QPushButton(tr("Change..."), this);
+        rowLayout->addWidget(button);
+        *buttons[i] = button;
+
+        int location = i + 1;
+        connect(button, &QPushButton::clicked, this, [this, location]() {
+            changeSaveLocation(location);
+        });
+
+        vboxLayout->addLayout(rowLayout);
+    }
+}
+
+void GeneralConf::changeSaveLocation(int location)
+{
+    ConfigHandler config;
+    QLineEdit* lineEdit = nullptr;
+    QString current;
+    switch (location) {
+        case 1:
+            lineEdit = m_saveLocation1;
+            current = config.savePathLocation1();
+            break;
+        case 2:
+            lineEdit = m_saveLocation2;
+            current = config.savePathLocation2();
+            break;
+        default:
+            lineEdit = m_saveLocation3;
+            current = config.savePathLocation3();
+            break;
+    }
+
+    QString path = chooseFolder(current);
+    if (path.isEmpty()) {
+        return;
+    }
+
+    lineEdit->setText(path);
+    switch (location) {
+        case 1:
+            config.setSavePathLocation1(path);
+            break;
+        case 2:
+            config.setSavePathLocation2(path);
+            break;
+        default:
+            config.setSavePathLocation3(path);
+            break;
     }
 }
 
@@ -800,7 +949,7 @@ void GeneralConf::initShowSelectionGeometry()
 
     auto* box = new QGroupBox(tr("Selection Geometry Display"));
     box->setFlat(true);
-    m_layout->addWidget(box);
+    m_scrollAreaLayout->addWidget(box);
 
     auto* vboxLayout = new QVBoxLayout();
     box->setLayout(vboxLayout);

--- a/src/config/generalconf.h
+++ b/src/config/generalconf.h
@@ -7,6 +7,7 @@
 #include <QWidget>
 
 class QVBoxLayout;
+class QHBoxLayout;
 class QCheckBox;
 class QPushButton;
 class QLabel;
@@ -49,6 +50,7 @@ private slots:
     void undoLimit(int limit);
     void saveAfterCopyChanged(bool checked);
     void changeSavePath();
+    void changeSaveLocation(int location);
     void importConfiguration();
     void exportFileConfiguration();
     void resetConfiguration();
@@ -74,6 +76,13 @@ private slots:
 private:
     const QString chooseFolder(const QString& currentPath = "");
 
+    // Adds a titled, bordered QGroupBox to m_scrollAreaLayout and returns
+    // its inner layout. Callers temporarily reassign m_scrollAreaLayout to
+    // the result so existing initX() functions - which only ever call
+    // m_scrollAreaLayout->addWidget(...) - nest into the section without
+    // needing any changes themselves.
+    QVBoxLayout* pushGroupBox(const QString& title);
+
     void initAllowMultipleGuiInstances();
     void initAntialiasingPinZoom();
     void initAutoCloseIdleDaemon();
@@ -88,6 +97,7 @@ private:
     void initHistoryConfirmationToDelete();
     void initPredefinedColorPaletteLarge();
     void initSaveAfterCopy();
+    void initSaveLocations();
     void initScrollArea();
     void initShowDesktopNotification();
     void initShowAbortNotification();
@@ -101,7 +111,6 @@ private:
     void initUndoLimit();
     void initUploadWithoutConfirmation();
     void initUseJpgForClipboard();
-    void initUploadHistoryMax();
     void initUploadClientSecret();
     void initSaveLastRegion();
     void initShowSelectionGeometry();
@@ -142,6 +151,7 @@ private:
     QCheckBox* m_antialiasingPinZoom;
     QCheckBox* m_saveLastRegion;
     QCheckBox* m_uploadWithoutConfirmation;
+    QCheckBox* m_showPostUploadDialog;
     QPushButton* m_importButton;
     QPushButton* m_exportButton;
     QPushButton* m_resetButton;
@@ -149,6 +159,12 @@ private:
     QLineEdit* m_savePath;
     QLineEdit* m_uploadClientKey;
     QPushButton* m_changeSaveButton;
+    QLineEdit* m_saveLocation1;
+    QLineEdit* m_saveLocation2;
+    QLineEdit* m_saveLocation3;
+    QPushButton* m_changeSaveLocation1Button;
+    QPushButton* m_changeSaveLocation2Button;
+    QPushButton* m_changeSaveLocation3Button;
     QCheckBox* m_screenshotPathFixedCheck;
     QCheckBox* m_historyConfirmationToDelete;
     QCheckBox* m_useJpgForClipboard;


### PR DESCRIPTION
**Description:**

13 checkboxes in the General settings tab were added directly to the tab's scroll area with no visual grouping — interleaved with unrelated input fields (Imgur Client ID, Selection Geometry Display) in an order that didn't reflect any logical grouping, and "Undo limit"/"Latest Uploads Max Size" rendered as two mini boxes hugging their content with dead space beside them while every other section in the tab was a single full-width titled box.

**Changes:**

Moved the 13 checkbox-only settings into a new "Options" titled box, matching the existing "Startup" / "Notifications & Behavior" pattern
Settings whose init function also builds an input field (Save Path, Imgur Client ID, Selection Geometry Display) were left where they are, since nesting an input-bearing box inside a checkbox-only box would look wrong
Merged "Undo limit" and "Latest Uploads Max Size" into one full-width "Limits" box; removed the now-unused pushCompactSpinBox helper that built the old two-mini-box layout
Folded two settings that rendered as bare, borderless rows into the titled boxes they actually belong to: the selection-geometry hide timeout (into "Selection Geometry Display") and JPEG Quality (into "Save Path", since it only affects the save/upload/clipboard file format set there)
Reordered top-level sections so save-destination settings rank above general Options toggles, which rank above rarely-touched tuning knobs (Undo limit, Imgur Client ID, Selection Geometry Display) — "Configuration File" stays last as before

**Test plan:**

Build and open Configuration → General
Confirm the 13 checkboxes render inside one bordered "Options" box
Confirm "Limits" is a single full-width box with both spinboxes
Confirm the geometry timeout and JPEG Quality no longer float as separate rows
Toggle a few settings and confirm they still persist to flameshot.ini

BEFORE
<img width="643" height="733" alt="21 08 2026 at 11-38" src="https://github.com/user-attachments/assets/ead3dc8b-9cdc-4390-bb1a-25f4af6a89ee" />

AFTER 1
<img width="651" height="723" alt="image" src="https://github.com/user-attachments/assets/cd1307b3-ae6b-4cc8-9f06-4295a5b36810" />

AFTER 2
<img width="657" height="717" alt="image" src="https://github.com/user-attachments/assets/2ae947ac-4a60-4613-8753-1a3204ac43aa" />



This is much cleaner because no mess from checkboxes that needs input and just checkboxes and then again checkbox that just buried between 2 input fields
No more suffering when I scroll then scroll blocked because it decide to update some input instead of continuing scrolling 

