### PR TITLE
Fix clipboard copy on COSMIC Wayland

### DIFF
--- a/src/utils/screenshotsaver.cpp
+++ b/src/utils/screenshotsaver.cpp
@@ -238,11 +238,6 @@ private:
             return;
         m_notified = true;
         AbstractLogger::info() << QObject::tr("Capture saved to clipboard.");
-        QPointer<QWidget> guard = m_owner;
-        QTimer::singleShot(0, [guard]() {
-            if (guard)
-                guard->close();
-        });
     }
 
     QImage m_image;
@@ -258,10 +253,31 @@ bool saveToClipboardGnomeWorkaround(const QPixmap& pixmap, QWidget* keepAlive)
 
     keepAlive->hide();
 
-    // Safety net: force close after 500ms if compositor never fetches
-    QTimer::singleShot(500, keepAlive, [keepAlive]() {
-        qWarning() << "GNOME workaround timed out, compositor did not request "
-                      "clipboard data within 500ms. Force closing.";
+    // Close once something else takes clipboard ownership, rather than
+    // after the first read: some paste consumers probe the clipboard
+    // (e.g. checking available types) before issuing the real fetch, and
+    // closing on that first read would cut them off before it arrives.
+    // dataChanged also fires for our own setMimeData() call above (the
+    // Wayland clipboard claim is confirmed asynchronously by the
+    // compositor), so we only close once the clipboard's current data is
+    // no longer ours, rather than closing on the first emission.
+    QObject::connect(clipboard,
+                     &QClipboard::dataChanged,
+                     keepAlive,
+                     [clipboard, mimeData, keepAlive]() {
+                         if (clipboard->mimeData() == mimeData)
+                             return;
+                         if (keepAlive)
+                             keepAlive->close();
+                     });
+
+    // Safety net: force close if nothing ever fetches the data. GNOME's
+    // mutter grabs clipboard offers eagerly on copy, so 500ms was enough
+    // there, but compositors that fetch lazily (e.g. COSMIC) only request
+    // the data once the user actually pastes, which can take much longer.
+    QTimer::singleShot(30000, keepAlive, [keepAlive]() {
+        qWarning() << "Clipboard workaround timed out, compositor did not "
+                      "request clipboard data within 30s. Force closing.";
         if (keepAlive)
             keepAlive->close();
     });

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -625,10 +625,10 @@ void CaptureWidget::uncheckActiveTool()
 void CaptureWidget::closeEvent(QCloseEvent* event)
 {
 #if !(defined(Q_OS_MACOS) || defined(Q_OS_WIN))
-    /* GNOME copy problem workaround, copy
+    /* Wayland copy problem workaround: the copy
        operation seems to work only when there
        is a visible window to retrieve the
-       data from. On GNOME, the GUI should
+       data from. On GNOME and COSMIC, the GUI should
        handle the copy operation, not the
        daemon.
     */
@@ -637,17 +637,18 @@ void CaptureWidget::closeEvent(QCloseEvent* event)
 
     if (m_captureDone && copyRequested) {
         DesktopInfo desktopInfo;
-        const bool needGnomeWorkaround =
+        const bool needClipboardWorkaround =
           desktopInfo.waylandDetected() &&
-          desktopInfo.windowManager() == DesktopInfo::GNOME;
+          (desktopInfo.windowManager() == DesktopInfo::GNOME ||
+           desktopInfo.windowManager() == DesktopInfo::COSMIC);
 
-        if (needGnomeWorkaround && !m_clipboardWorkaroundDone) {
+        if (needClipboardWorkaround && !m_clipboardWorkaroundDone) {
             event->ignore();
             m_clipboardWorkaroundDone = true;
             m_context.request.removeTask(CaptureRequest::COPY);
             AbstractLogger::info()
-              << "GNOME Wayland detected; keeping capture window alive until "
-                 "clipboard data is fetched.";
+              << "GNOME/COSMIC Wayland detected; keeping capture window "
+                 "alive until clipboard data is fetched.";
             saveToClipboardGnomeWorkaround(pixmap(), this);
             return;
         }


### PR DESCRIPTION
Closes #4823.

## Problem

The clipboard-persistence workaround (keeping the capture window alive so Wayland can serve clipboard data after the window would otherwise close) is gated to GNOME only:

```cpp
const bool needGnomeWorkaround =
  desktopInfo.waylandDetected() &&
  desktopInfo.windowManager() == DesktopInfo::GNOME;
```

COSMIC hits the exact same underlying Wayland limitation (a client can only serve clipboard data while it's alive to answer paste requests), but never triggers this workaround, so copy-to-clipboard (toolbar button or Ctrl+C) silently does nothing on COSMIC — matching the symptom in #4823 exactly. The right-click "Copy to clipboard" workaround mentioned there happens to work because it doesn't immediately close the window afterward, incidentally keeping the process alive long enough.

## Fix

- Extend the check to also cover `DesktopInfo::COSMIC`.
- Fix a race in the workaround itself, uncovered while testing this on COSMIC: it previously closed the window on the *first* clipboard read of any kind. If a paste consumer probes available clipboard types before issuing the real data fetch, that first read would close the window before the real fetch arrives. It now closes only once the clipboard's current data is no longer ours (compares against the live `QClipboard::mimeData()` pointer rather than assuming the first read is the real one).
- Raise the safety-net timeout from 500ms to 30s. GNOME's mutter grabs clipboard offers eagerly on copy, so 500ms was enough there, but COSMIC's compositor fetches lazily — only once the user actually pastes — which can reasonably take longer than half a second.

## Testing

Verified on Pop!_OS 24.04 with COSMIC 1.0.0 (`cosmic-comp 1.0.0`), built from current `master`: capture → copy → paste now works reliably across multiple runs, into both GUI apps and `wl-paste`-based tooling.