### PR TITLE
feat: add external action plugin platform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,8 @@ CMakeLists.txt.user
 
 # python
 venv/*
+__pycache__/
+*.py[cod]
 
 # Created by https://www.gitignore.io/api/snapcraft
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,8 @@ project(
   flameshot
   VERSION ${FLAMESHOT_VERSION}
   LANGUAGES CXX)
+include(CTest)
+include(GNUInstallDirs)
 set(PROJECT_NAME_CAPITALIZED "Flameshot")
 
 include(FetchContent)
@@ -150,6 +152,21 @@ if(WIN32 OR APPLE)
 endif()
 
 add_subdirectory(src)
+if(BUILD_TESTING)
+  add_subdirectory(tests)
+endif()
+
+install(
+  PROGRAMS ${CMAKE_SOURCE_DIR}/sdk/flameshot-plugin
+  DESTINATION ${CMAKE_INSTALL_BINDIR})
+install(
+  DIRECTORY ${CMAKE_SOURCE_DIR}/sdk/schemas
+            ${CMAKE_SOURCE_DIR}/sdk/templates
+  DESTINATION ${CMAKE_INSTALL_DATADIR}/flameshot/sdk)
+install(
+  FILES ${CMAKE_SOURCE_DIR}/sdk/README.md
+  DESTINATION ${CMAKE_INSTALL_DATADIR}/doc/flameshot
+  RENAME plugin-sdk.md)
 
 # CPack
 set(CPACK_PACKAGE_VENDOR "flameshot-org")

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@
     - [Arch](#arch)
   - [Build](#build)
   - [Install](#install)
+- [Action Plugin SDK (experimental)](#action-plugin-sdk-experimental)
 - [License](#license)
 - [Privacy Policy](#privacy-policy)
 - [Code Signing Policy](#code-signing-policy)
@@ -567,6 +568,13 @@ cmake --install "$BUILD_DIR"
 ### FAQ
 
 <https://flameshot.org/docs/guide/faq/>
+
+## Action Plugin SDK (experimental)
+
+The experimental action-plugin platform lets external programs process a
+selected screenshot and return clipboard text or a desktop notification. Start
+with the beginner-friendly [SDK tutorial](sdk/README.md), or read the complete
+[action-plugin API reference](docs/action-plugins.md).
 
 ## License
 

--- a/data/shell-completion/flameshot.bash
+++ b/data/shell-completion/flameshot.bash
@@ -6,18 +6,31 @@
 
 
 _flameshot() {
-	local prev cur cmd gui_opts full_opts config_opts
+	local prev cur cmd gui_opts full_opts config_opts screen_opts plugin_opts
 	COMPREPLY=()
 
 	prev="${COMP_WORDS[COMP_CWORD-1]}"
 	cur="${COMP_WORDS[COMP_CWORD]}"
-	cmd="gui full config launcher screen"
+	cmd="gui full config launcher screen plugins"
+	plugin_opts="list install enable disable remove doctor roots"
 	screen_opts="--number -n --edit -e --path -p --clipboard -c --delay -d --region --raw -r --pin --help"
 	gui_opts="--path -p --clipboard -c --delay -d --region --last-region --raw -r --print-geometry -g --pin --accept-on-select -s --help"
 	full_opts="--path -p --clipboard -c --delay -d --raw -r --help"
 	config_opts="--autostart -a --filename -f --notifications -n --trayicon -t --showhelp -s --maincolor -m --contrastcolor -k --check"
 
 	case "${prev}" in
+		plugins)
+			COMPREPLY=( $(compgen -W "$plugin_opts" -- "${cur}") )
+			return 0
+			;;
+		install)
+			_filedir 'flameshot-plugin'
+			return 0
+			;;
+		enable|disable|remove)
+			COMPREPLY=( $(compgen -W "$(flameshot plugins list 2>/dev/null | awk '{print $2}')" -- "${cur}") )
+			return 0
+			;;
 		launcher)
 			return 0
 			;;

--- a/data/shell-completion/flameshot.fish
+++ b/data/shell-completion/flameshot.fish
@@ -67,7 +67,7 @@ end
 ###############
 
 # define the subcommands
-set -l SUBCOMMANDS gui screen full launcher config
+set -l SUBCOMMANDS gui screen full launcher config plugins
 
 # No subcommand
 complete -c flameshot                                                                                        --no-files --arguments "$SUBCOMMANDS" --condition __flameshot_no_positional_args 
@@ -121,3 +121,8 @@ __flameshot_complete config --long-option "maincolor"      --short-option "m" --
 __flameshot_complete config --long-option "contrastcolor"  --short-option "k" --description "Define the contrast UI color (hexadecimal)" --require-parameter --no-files 
 __flameshot_complete config --long-option "check"                             --description "Check the configuration for errors"                             --no-files
 __flameshot_complete config --long-option "help"           --short-option "h" --description "Show the available arguments"                                   --no-files
+
+# PLUGINS command
+__flameshot_complete plugins --no-files --arguments "list install enable disable remove doctor roots"
+complete -c flameshot -n '__fish_seen_subcommand_from plugins; and __fish_seen_subcommand_from install' --force-files
+complete -c flameshot -n '__fish_seen_subcommand_from plugins; and __fish_seen_subcommand_from enable disable remove' --no-files --arguments '(flameshot plugins list 2>/dev/null | string replace -r "^(enabled|disabled) +([^[:space:]]+).*$" "$2")'

--- a/data/shell-completion/flameshot.zsh
+++ b/data/shell-completion/flameshot.zsh
@@ -91,6 +91,37 @@ _flameshot_config() {
 }
 
 
+# plugins
+
+_flameshot_plugins() {
+    local -a plugin_commands
+    plugin_commands=(
+        'list:List discovered plugins'
+        'install:Install a plugin package'
+        'enable:Enable a plugin'
+        'disable:Disable a plugin'
+        'remove:Remove a user plugin'
+        'doctor:Validate plugin discovery'
+        'roots:Print plugin search roots'
+    )
+    _arguments '1:plugin command:->plugin-command' '*:argument:->plugin-argument'
+    case "$state" in
+        (plugin-command)
+            _describe -t commands 'plugin commands' plugin_commands
+        ;;
+        (plugin-argument)
+            if [[ $words[2] == install ]]; then
+                _files -g '*.flameshot-plugin'
+            elif [[ $words[2] == enable || $words[2] == disable || $words[2] == remove ]]; then
+                local -a plugins
+                plugins=(${(f)"$(flameshot plugins list 2>/dev/null | awk '{print $2}')"})
+                _describe -t plugins 'plugins' plugins
+            fi
+        ;;
+    esac
+}
+
+
 # Main handle
 _flameshot() {
     local curcontext="$curcontext" ret=1
@@ -102,6 +133,7 @@ _flameshot() {
         "full:Capture the entire desktop (all monitors)"
         "launcher:Open the capture launcher"
         "config:Configure Flameshot"
+        "plugins:Manage action plugins"
     )
 
     _arguments -C -s -S -n \
@@ -129,6 +161,9 @@ _flameshot() {
             ;;
             (config)
                 _flameshot_config && ret=0
+            ;;
+            (plugins)
+                _flameshot_plugins && ret=0
             ;;
             (*)
                 _default && ret=0

--- a/docs/action-plugins.md
+++ b/docs/action-plugins.md
@@ -1,0 +1,114 @@
+# Action plugins (experimental)
+
+Action plugins add a button directly to the Flameshot capture toolbar. When the
+button is selected, Flameshot starts the plugin asynchronously, sends the
+selected image as PNG on standard input, and applies the plugin's structured
+result through core services such as the clipboard and desktop notifications.
+
+This API does not load third-party code into the Flameshot process and does not
+yet provide interactive annotation tools.
+
+## Install and manage plugins
+
+The configuration window has **Install Plugin…** and **Remove Plugin** buttons.
+The same operations are available from the command line:
+
+```sh
+flameshot plugins install org.example.tool.flameshot-plugin
+flameshot plugins list
+flameshot plugins disable org.example.tool
+flameshot plugins enable org.example.tool
+flameshot plugins doctor
+flameshot plugins remove org.example.tool
+```
+
+User plugins follow the XDG Base Directory specification and are installed in
+`${XDG_DATA_HOME:-~/.local/share}/flameshot/plugins/<plugin-id>`. Flameshot also
+searches each XDG system data directory. The prototype location
+`~/.config/flameshot/plugins` remains a compatibility search root.
+
+A `.flameshot-plugin` package is a gzip-compressed TAR archive whose
+`metadata.json` is at the archive root. The installer rejects absolute and
+parent paths, links, special files, packages over 32 MiB, extracted content over
+64 MiB, and archives containing over 1000 files. Plugins are installed through
+a staging directory and activated with an atomic rename.
+
+## Create a plugin
+
+The installed SDK provides templates for Python, POSIX shell, Rust, and C++:
+
+```sh
+flameshot-plugin create org.example.my-tool --language python
+flameshot-plugin test org.example.my-tool --image screenshot.png
+flameshot-plugin validate org.example.my-tool
+flameshot-plugin pack org.example.my-tool
+flameshot plugins install org.example.my-tool.flameshot-plugin
+```
+
+JSON schemas for the manifest and result protocol are installed in
+`share/flameshot/sdk/schemas`.
+
+## Manifest API 1
+
+```json
+{
+  "api_version": 1,
+  "type": "action",
+  "id": "org.example.ocr",
+  "name": "Local OCR",
+  "description": "Recognize text and copy it to the clipboard",
+  "icon": "ocr.svg",
+  "toolbar": {
+    "visible": true,
+    "order": 175,
+    "shortcut": "Ctrl+Shift+O"
+  },
+  "command": {
+    "executable": "./bin/run",
+    "arguments": [],
+    "input": "png-stdin",
+    "output": "json",
+    "timeout_ms": 30000
+  }
+}
+```
+
+Required fields are `api_version`, `type`, `id`, `name`, and
+`command.executable`. API 1 accepts only `type: action` and `png-stdin` input.
+The toolbar fields control direct visibility, relative order, and shortcut.
+
+The recommended `json` output is a single UTF-8 object:
+
+```json
+{
+  "protocol_version": 1,
+  "status": "success",
+  "result": {
+    "type": "clipboard-text",
+    "text": "recognized text"
+  }
+}
+```
+
+Success result types are `clipboard-text`, `notification` (with `text` and an
+optional `title`), and `none`. A controlled failure is returned as
+`{"protocol_version":1,"status":"error","message":"..."}`. The legacy
+output modes `clipboard-text` and `none` remain supported for API 1.
+
+Flameshot supplies these environment variables:
+
+- `FLAMESHOT_PLUGIN_API_VERSION`: currently `1`;
+- `FLAMESHOT_PLUGIN_ID`: the stable manifest ID;
+- `FLAMESHOT_PLUGIN_DIR`: the read-only installation directory;
+- `FLAMESHOT_PLUGIN_CONFIG_DIR`: a writable per-plugin XDG config directory.
+
+Standard error is used for diagnostics when a process fails. Flameshot enforces
+the configured timeout, 1 MiB standard-output limit, and 256 KiB standard-error
+limit.
+
+## Security and compatibility
+
+Plugins run with the same user privileges as Flameshot. Package validation and
+process isolation reduce accidental damage, but they are not a security
+sandbox. Install only plugins you trust. A subprocess protocol avoids a fragile
+C++/Qt ABI and keeps plugin crashes outside the main application.

--- a/docs/plugin-architecture.md
+++ b/docs/plugin-architecture.md
@@ -1,0 +1,80 @@
+# Plugin platform architecture
+
+Flameshot treats built-in tools and external plugins as tools with stable
+string identifiers. They share discovery, ordering, visibility, shortcuts, and
+toolbar presentation, while their execution remains deliberately separate.
+
+```text
+Capture UI
+    |
+    v
+ToolRegistry
+    |-- BuiltIn provider ------> ToolFactory ------> native CaptureTool
+    `-- ExternalAction provider -> PluginActionTool -> ActionPluginRunner
+                                                   -> Flameshot core services
+```
+
+## Core platform
+
+The core owns functionality that depends on the desktop session or Flameshot's
+editor state:
+
+- screen capture and selection;
+- the capture model and undo/redo;
+- clipboard access and desktop notifications;
+- tool ordering, visibility, and shortcuts;
+- plugin discovery, validation, process lifetime, and timeouts.
+- package installation, writable plugin configuration, and result validation.
+
+Plugins return data to the host instead of implementing desktop integration
+themselves. For example, an OCR plugin writes UTF-8 text to standard output and
+Flameshot copies it through its clipboard service. This keeps Wayland-specific
+behavior in one place.
+
+## Tool registry
+
+Every tool has a stable ID. Built-in tools use IDs such as
+`org.flameshot.pencil`; external tools use the ID from their manifest, such as
+`org.flameshot.tesseract-ocr`.
+
+The existing `CaptureTool::Type` values remain as a compatibility bridge for
+old integer-based settings and native editor logic. External tools are not
+assigned new enum values. This allows any number of plugins without changing
+or recompiling the enum.
+
+The toolbar consumes registry descriptors and does not need a separate plugin
+chooser. The configuration UI uses the same registry, so external actions can
+be enabled or disabled like built-in buttons. User overrides are stored below
+`Plugins/<plugin-id>` and are kept separate from the installed manifest.
+
+## External action provider
+
+Version 1 runs plugins as subprocesses. A selected capture is encoded as PNG
+and sent to standard input. The host waits asynchronously, enforces the
+manifest timeout, validates the versioned JSON result, and handles crashes and
+unsuccessful exit codes without loading plugin code into the Flameshot process.
+
+The capture window is hidden while an action runs and closes only after the
+child process finishes. This keeps the Qt event loop alive without showing an
+intermediate plugin window.
+
+## Distribution and SDK
+
+The core plugin manager owns XDG discovery, package validation, staged installs,
+enablement, removal, and diagnostics. A `.flameshot-plugin` is intentionally an
+opaque extension over a conventional compressed TAR archive, keeping packages
+easy to inspect and the runtime dependency surface small.
+
+The language-neutral SDK mirrors the host validator and includes manifest and
+result schemas. Plugin authors can start from Python, shell, Rust, or C++
+templates, test the standard-input/result contract, and create deterministic
+packages. The subprocess boundary means other languages require no Flameshot
+library or C ABI.
+
+## Future providers
+
+The registry is intentionally provider-based. Later versions can add image
+transform plugins (PNG input and PNG output), exporters (image to URL or file),
+and eventually interactive editor tools. Interactive plugins need a separate
+protocol for pointer events, preview rendering, and undo/redo and should not be
+added to the action protocol.

--- a/examples/plugins/tesseract-ocr/metadata.json
+++ b/examples/plugins/tesseract-ocr/metadata.json
@@ -1,0 +1,20 @@
+{
+  "api_version": 1,
+  "type": "action",
+  "id": "org.flameshot.tesseract-ocr",
+  "name": "Tesseract OCR",
+  "description": "Recognize German and English text and copy it to the clipboard",
+  "icon": "ocr.svg",
+  "toolbar": {
+    "visible": true,
+    "order": 175,
+    "shortcut": "Ctrl+Shift+O"
+  },
+  "command": {
+    "executable": "./run.py",
+    "arguments": ["-l", "deu+eng", "--psm", "6"],
+    "input": "png-stdin",
+    "output": "json",
+    "timeout_ms": 30000
+  }
+}

--- a/examples/plugins/tesseract-ocr/ocr.svg
+++ b/examples/plugins/tesseract-ocr/ocr.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <path fill="#fff" d="M3 3h6v2H5v4H3V3zm12 0h6v6h-2V5h-4V3zM3 15h2v4h4v2H3v-6zm16 0h2v6h-6v-2h4v-4zM7 8h10v2H7V8zm0 3h10v2H7v-2zm0 3h7v2H7v-2z"/>
+</svg>

--- a/examples/plugins/tesseract-ocr/run.py
+++ b/examples/plugins/tesseract-ocr/run.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Flameshot action plugin using the local Tesseract executable."""
+
+import json
+import subprocess
+import sys
+
+
+def result(value):
+    print(json.dumps(value, ensure_ascii=False))
+
+
+image = sys.stdin.buffer.read()
+try:
+    completed = subprocess.run(
+        ["tesseract", "stdin", "stdout", *sys.argv[1:]],
+        input=image,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=28,
+        check=False,
+    )
+except (OSError, subprocess.TimeoutExpired) as error:
+    result({"protocol_version": 1, "status": "error", "message": str(error)})
+    raise SystemExit(0)
+
+if completed.returncode != 0:
+    message = completed.stderr.decode("utf-8", errors="replace").strip()
+    result({
+        "protocol_version": 1,
+        "status": "error",
+        "message": message or f"Tesseract exited with {completed.returncode}",
+    })
+else:
+    text = completed.stdout.decode("utf-8", errors="replace").strip()
+    if text:
+        result({
+            "protocol_version": 1,
+            "status": "success",
+            "result": {"type": "clipboard-text", "text": text},
+        })
+    else:
+        result({
+            "protocol_version": 1,
+            "status": "error",
+            "message": "Tesseract did not recognize any text.",
+        })

--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -34,6 +34,8 @@ Depends:
  libqt6network6 (>= 6.2.4~),
  libqt6widgets6 (>= 6.2.4~),
  libqt6svg6 (>= 6.2.4~),
+ python3,
+ tar,
 Recommends:
  xdg-desktop-portal-gtk | xdg-desktop-portal-gnome | xdg-desktop-portal-kde | xdg-desktop-portal-wlr,
  grim,

--- a/packaging/rpm/flameshot.spec
+++ b/packaging/rpm/flameshot.spec
@@ -40,6 +40,8 @@ BuildRequires:  kf6-kguiaddons-devel >= 6.7.0
 %endif
 
 Requires: hicolor-icon-theme
+Requires: python3
+Requires: tar
 
 %if 0%{?suse_version}
 Requires: qt6-svg
@@ -132,6 +134,9 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/*.desktop
 %dir %{_datadir}/bash-completion/completions
 %dir %{_datadir}/zsh/site-functions
 %{_bindir}/%{name}
+%{_bindir}/%{name}-plugin
+%{_datadir}/%{name}/sdk
+%{_datadir}/doc/%{name}/plugin-sdk.md
 %{_datadir}/applications/org.flameshot.Flameshot.desktop
 %{_datadir}/metainfo/org.flameshot.Flameshot.metainfo.xml
 %{_datadir}/bash-completion/completions/%{name}

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -1,20 +1,418 @@
 # Flameshot action-plugin SDK
 
-The SDK builds and checks external action plugins without requiring a Flameshot
-development checkout. It needs Python 3.10 or newer.
+This guide starts with a working plugin and explains the protocol only after
+you have run it. No knowledge of the Flameshot C++ code is required.
 
-```sh
-flameshot-plugin create org.example.my-tool --language python
-flameshot-plugin test org.example.my-tool --image screenshot.png
-flameshot-plugin pack org.example.my-tool
-flameshot plugins install org.example.my-tool.flameshot-plugin
+The SDK needs Python 3.10 or newer. A plugin itself may be written in any
+language that can read bytes from standard input and print JSON.
+
+## The idea in one minute
+
+An action plugin is a small external program connected to a toolbar button:
+
+```text
+selected screenshot                         plugin result
+      PNG                                        JSON
+       |                                           |
+       v                                           v
+   Flameshot  -------- standard input -------->  plugin
+   Flameshot  <------- standard output --------  plugin
+       |
+       `---- copies text or displays a notification
 ```
 
-Templates are included for Python, POSIX shell, Rust, and C++. Rust and C++ use
-a small executable wrapper so their projects can be validated before the native
-binary has been built. The schemas in `schemas/` describe manifest API 1 and
-structured result protocol 1.
+Flameshot owns the screenshot UI, clipboard, notifications, plugin timeout,
+and error handling. The plugin receives one PNG image, performs one action,
+and returns one result.
 
-Plugins receive PNG data on standard input. The recommended `json` output mode
-returns exactly one UTF-8 JSON object on standard output. Diagnostics belong on
-standard error.
+For example, an OCR plugin does not access the clipboard. It returns recognized
+text and asks Flameshot to copy it.
+
+## Five-minute quick start
+
+### 1. Create a Python plugin
+
+Plugin IDs use reverse-domain notation so they do not collide with other
+plugins. Replace `example.org` with a domain or namespace you control when
+publishing a real plugin.
+
+```sh
+flameshot-plugin create org.example.hello-flameshot --language python
+cd org.example.hello-flameshot
+```
+
+The generated project contains only two required files:
+
+```text
+org.example.hello-flameshot/
+├── metadata.json   # tells Flameshot how the plugin should appear and run
+└── bin/
+    └── run.py      # receives the PNG and returns a JSON result
+```
+
+### 2. Test it without installing it
+
+```sh
+flameshot-plugin test .
+```
+
+The SDK sends a tiny built-in PNG to the plugin. The result should look like:
+
+```json
+{
+  "protocol_version": 1,
+  "status": "success",
+  "result": {
+    "type": "notification",
+    "title": "Hello Flameshot",
+    "text": "Received 68 PNG bytes"
+  }
+}
+```
+
+To test with a real screenshot:
+
+```sh
+flameshot-plugin test . --image /path/to/screenshot.png
+```
+
+### 3. Change what the plugin does
+
+Open `bin/run.py`. The important part is:
+
+```python
+import json
+import sys
+
+# Flameshot sends the selected screenshot here as exact PNG bytes.
+image = sys.stdin.buffer.read()
+
+# Replace this object with the result your plugin should return.
+response = {
+    "protocol_version": 1,
+    "status": "success",
+    "result": {
+        "type": "notification",
+        "title": "My plugin",
+        "text": f"The image contains {len(image)} bytes",
+    },
+}
+
+# Standard output is reserved for one JSON response.
+print(json.dumps(response))
+```
+
+Your image processing belongs between reading `image` and creating `response`.
+Write diagnostic messages to standard error, not standard output:
+
+```python
+print("Loading model...", file=sys.stderr)
+```
+
+### 4. Validate and package it
+
+```sh
+flameshot-plugin validate .
+flameshot-plugin pack .
+```
+
+This creates:
+
+```text
+../org.example.hello-flameshot.flameshot-plugin
+```
+
+By default, `pack` places the package next to the plugin project, never inside
+it. The package is a compressed archive containing the plugin files. It can be
+inspected with normal TAR tools, but users should install it through Flameshot
+so its structure and manifest are checked.
+
+### 5. Install and use it
+
+```sh
+cd ..
+flameshot plugins install org.example.hello-flameshot.flameshot-plugin
+flameshot plugins list
+flameshot plugins doctor
+```
+
+Start a normal capture. The plugin appears as its own toolbar button. Selecting
+the button runs the plugin with the currently selected screenshot area.
+
+The same package can be installed from **Configuration > Button Selection >
+Install Plugin...**.
+
+To disable or remove it:
+
+```sh
+flameshot plugins disable org.example.hello-flameshot
+flameshot plugins enable org.example.hello-flameshot
+flameshot plugins remove org.example.hello-flameshot
+```
+
+## Understanding `metadata.json`
+
+This file describes the plugin without executing it:
+
+```json
+{
+  "api_version": 1,
+  "type": "action",
+  "id": "org.example.hello-flameshot",
+  "name": "Hello Flameshot",
+  "description": "Show information about the selected screenshot",
+  "icon": "icon.svg",
+  "toolbar": {
+    "visible": true,
+    "order": 1000,
+    "shortcut": "Ctrl+Shift+H"
+  },
+  "command": {
+    "executable": "./bin/run.py",
+    "arguments": [],
+    "input": "png-stdin",
+    "output": "json",
+    "timeout_ms": 30000
+  }
+}
+```
+
+| Field | Meaning |
+| --- | --- |
+| `api_version` | Manifest version understood by Flameshot. API v1 uses `1`. |
+| `type` | Plugin category. API v1 supports only `action`. |
+| `id` | Permanent, globally unique plugin ID. Do not change it after release. |
+| `name` | Human-readable name shown in Flameshot. |
+| `description` | Tooltip and configuration description. |
+| `icon` | Optional relative path to an icon inside the plugin. |
+| `toolbar.visible` | Whether a new installation enables the button by default. |
+| `toolbar.order` | Relative position in the toolbar; lower numbers appear earlier. |
+| `toolbar.shortcut` | Optional default shortcut. Users may override it. |
+| `command.executable` | Program or plugin-relative executable to start. |
+| `command.arguments` | String arguments passed to the executable. |
+| `command.input` | API v1 supports `png-stdin`. |
+| `command.output` | Use `json` for structured results. |
+| `command.timeout_ms` | Maximum runtime from 1,000 to 300,000 milliseconds. |
+
+Required fields are `api_version`, `type`, `id`, `name`, and
+`command.executable`. The SDK validator and Flameshot loader apply the same
+core constraints.
+
+## Choosing a result
+
+Every structured response contains `protocol_version` and `status`.
+
+### Copy text to the clipboard
+
+```json
+{
+  "protocol_version": 1,
+  "status": "success",
+  "result": {
+    "type": "clipboard-text",
+    "text": "Text produced by the plugin"
+  }
+}
+```
+
+### Display a desktop notification
+
+```json
+{
+  "protocol_version": 1,
+  "status": "success",
+  "result": {
+    "type": "notification",
+    "title": "Plugin finished",
+    "text": "The image was processed successfully"
+  }
+}
+```
+
+The notification `title` is optional. Flameshot uses the plugin name when it
+is omitted.
+
+### Finish without a visible result
+
+```json
+{
+  "protocol_version": 1,
+  "status": "success",
+  "result": { "type": "none" }
+}
+```
+
+### Report an expected error
+
+```json
+{
+  "protocol_version": 1,
+  "status": "error",
+  "message": "No text was recognized"
+}
+```
+
+Print an error response and exit with status `0` when the plugin ran normally
+but could not produce a result. Flameshot can then display the useful message.
+Use a non-zero exit status for a process failure; Flameshot displays standard
+error in that case.
+
+## Environment supplied by Flameshot
+
+Flameshot starts the process in the plugin installation directory and provides:
+
+| Variable | Purpose |
+| --- | --- |
+| `FLAMESHOT_PLUGIN_API_VERSION` | API version selected by the host. |
+| `FLAMESHOT_PLUGIN_ID` | Stable plugin ID from the manifest. |
+| `FLAMESHOT_PLUGIN_DIR` | Installation directory for read-only plugin assets. |
+| `FLAMESHOT_PLUGIN_CONFIG_DIR` | Writable directory for this plugin's settings. |
+
+Store user configuration only below `FLAMESHOT_PLUGIN_CONFIG_DIR`. Do not write
+into `FLAMESHOT_PLUGIN_DIR`, because system packages may install it read-only.
+
+## SDK command reference
+
+```text
+flameshot-plugin create ID [DIRECTORY] [--language LANGUAGE] [--name NAME]
+flameshot-plugin validate DIRECTORY_OR_PACKAGE
+flameshot-plugin test DIRECTORY [--image PNG]
+flameshot-plugin pack DIRECTORY [-o PACKAGE] [--force]
+```
+
+### `create`
+
+Copies a starter project and replaces its ID and display-name placeholders.
+Available languages are `python`, `shell`, `rust`, and `cpp`.
+
+### `validate`
+
+Checks the file tree, executable permissions, manifest values, paths, size
+limits, and package structure without installing or running the plugin.
+
+### `test`
+
+Runs an unpacked plugin, sends PNG data, applies the manifest timeout, and
+validates structured JSON output. It prints the result instead of changing the
+real clipboard or showing a desktop notification.
+
+### `pack`
+
+Creates a deterministic `.flameshot-plugin` archive next to the plugin project.
+Use `-o` to select another location outside the project. Existing output is not
+overwritten unless `--force` is specified.
+
+## Other language templates
+
+The protocol is language-neutral:
+
+- `--language shell` creates a directly runnable POSIX shell example.
+- `--language rust` creates a Cargo project and a `bin/run` launcher. Build it
+  with `cargo build --release` before using `test` or packaging a working binary.
+- `--language cpp` creates a small CMake project and launcher. Build it with
+  `cmake -S . -B build && cmake --build build` before using `test`.
+
+Native plugins do not link to Flameshot. They only implement the same stdin and
+JSON contract, which avoids a C++ or Qt ABI dependency.
+
+## OCR example
+
+The repository includes `examples/plugins/tesseract-ocr`. It demonstrates how
+a plugin can call another local program and return its output to Flameshot.
+
+On Debian or Ubuntu, install the OCR engine and language data first:
+
+```sh
+sudo apt install tesseract-ocr tesseract-ocr-eng tesseract-ocr-deu
+```
+
+From a source checkout:
+
+```sh
+flameshot-plugin validate examples/plugins/tesseract-ocr
+flameshot-plugin test examples/plugins/tesseract-ocr --image screenshot.png
+flameshot-plugin pack examples/plugins/tesseract-ocr
+flameshot plugins install org.flameshot.tesseract-ocr.flameshot-plugin
+```
+
+The example performs these steps:
+
+1. Read the selected image from standard input.
+2. Start the local `tesseract` executable.
+3. Pass the image to Tesseract.
+4. Return recognized text as a `clipboard-text` result.
+5. Let Flameshot perform the actual clipboard operation.
+
+## Troubleshooting
+
+### `executable was not found` or `is not executable`
+
+Use a plugin-relative path such as `./bin/run.py` and set its executable bit:
+
+```sh
+chmod +x bin/run.py
+flameshot-plugin validate .
+```
+
+### `invalid result JSON`
+
+Standard output must contain exactly one JSON object. Send logs to standard
+error. A debug `print()` on standard output before the result will invalidate
+the response.
+
+### The plugin works in a terminal but not in Flameshot
+
+Run `flameshot plugins doctor`, then test with the exact executable and files
+that were packaged. Do not depend on the shell's current directory or aliases.
+Use `FLAMESHOT_PLUGIN_DIR` for bundled assets.
+
+### The plugin times out
+
+Increase `command.timeout_ms` only when the action genuinely needs more time.
+The allowed range is 1-300 seconds. Prefer loading models efficiently and
+returning a controlled error when an external dependency stalls.
+
+### The button is missing
+
+```sh
+flameshot plugins list
+flameshot plugins enable org.example.hello-flameshot
+flameshot plugins doctor
+```
+
+Restart Flameshot after installing a plugin if an already-open configuration or
+capture window has cached the previous toolbar state.
+
+### A package is rejected as unsafe
+
+Packages may contain only regular files and directories. Symlinks, absolute
+paths, parent traversal, special files, oversized content, and excessive file
+counts are rejected intentionally.
+
+## File locations
+
+User plugins follow the XDG Base Directory specification:
+
+```text
+${XDG_DATA_HOME:-~/.local/share}/flameshot/plugins/<plugin-id>
+```
+
+Per-plugin writable configuration is placed below:
+
+```text
+${XDG_CONFIG_HOME:-~/.config}/flameshot/plugins/<plugin-id>
+```
+
+The JSON schemas installed with the SDK are in
+`share/flameshot/sdk/schemas`. Source checkouts contain them in `sdk/schemas`.
+
+## Security model
+
+Plugins run as external processes, so a crash does not directly crash
+Flameshot. They still run with the same user privileges as Flameshot. Package
+validation and process isolation are not a security sandbox. Install only
+plugins and packages you trust.
+
+For the complete API and architecture reference, see
+[`docs/action-plugins.md`](../docs/action-plugins.md) and
+[`docs/plugin-architecture.md`](../docs/plugin-architecture.md).

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -1,0 +1,20 @@
+# Flameshot action-plugin SDK
+
+The SDK builds and checks external action plugins without requiring a Flameshot
+development checkout. It needs Python 3.10 or newer.
+
+```sh
+flameshot-plugin create org.example.my-tool --language python
+flameshot-plugin test org.example.my-tool --image screenshot.png
+flameshot-plugin pack org.example.my-tool
+flameshot plugins install org.example.my-tool.flameshot-plugin
+```
+
+Templates are included for Python, POSIX shell, Rust, and C++. Rust and C++ use
+a small executable wrapper so their projects can be validated before the native
+binary has been built. The schemas in `schemas/` describe manifest API 1 and
+structured result protocol 1.
+
+Plugins receive PNG data on standard input. The recommended `json` output mode
+returns exactly one UTF-8 JSON object on standard output. Diagnostics belong on
+standard error.

--- a/sdk/flameshot-plugin
+++ b/sdk/flameshot-plugin
@@ -1,0 +1,379 @@
+#!/usr/bin/env python3
+"""Developer tools for Flameshot action plugins (API version 1)."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import gzip
+import io
+import json
+import os
+from pathlib import Path, PurePosixPath
+import re
+import shutil
+import stat
+import subprocess
+import sys
+import tarfile
+import tempfile
+
+
+API_VERSION = 1
+MAX_PACKAGE_SIZE = 32 * 1024 * 1024
+MAX_INSTALLED_SIZE = 64 * 1024 * 1024
+MAX_FILES = 1000
+PLUGIN_ID = re.compile(r"^[a-z0-9]+(?:[._-][a-z0-9]+)+$")
+PNG_1X1 = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk"
+    "/w8AAusB9Y9Z4S0AAAAASUVORK5CYII="
+)
+
+
+class PluginError(Exception):
+    pass
+
+
+def read_json(path: Path) -> dict:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise PluginError(f"cannot read {path}: {error}") from error
+    if not isinstance(value, dict):
+        raise PluginError(f"{path}: JSON root must be an object")
+    return value
+
+
+def safe_relative(name: str) -> bool:
+    path = PurePosixPath(name)
+    return (
+        bool(name)
+        and not path.is_absolute()
+        and ".." not in path.parts
+        and "\0" not in name
+        and "\n" not in name
+        and "\r" not in name
+    )
+
+
+def validate_manifest(root: Path) -> dict:
+    manifest_path = root / "metadata.json"
+    manifest = read_json(manifest_path)
+    if manifest.get("api_version") != API_VERSION:
+        raise PluginError("metadata.json: api_version must be 1")
+    if manifest.get("type") != "action":
+        raise PluginError("metadata.json: type must be 'action'")
+    plugin_id = manifest.get("id")
+    if not isinstance(plugin_id, str) or not PLUGIN_ID.fullmatch(plugin_id):
+        raise PluginError("metadata.json: invalid plugin id")
+    if not isinstance(manifest.get("name"), str) or not manifest["name"].strip():
+        raise PluginError("metadata.json: name is required")
+
+    command = manifest.get("command")
+    if not isinstance(command, dict):
+        raise PluginError("metadata.json: command object is required")
+    executable = command.get("executable")
+    if not isinstance(executable, str) or not executable:
+        raise PluginError("metadata.json: command.executable is required")
+    executable_path = Path(executable)
+    if executable_path.is_absolute():
+        resolved_executable = executable_path
+    elif "/" in executable or "\\" in executable:
+        if not safe_relative(executable.replace("\\", "/")):
+            raise PluginError("metadata.json: unsafe executable path")
+        resolved_executable = root / executable
+    else:
+        local_executable = root / executable
+        resolved_executable = (
+            local_executable
+            if local_executable.exists()
+            else Path(shutil.which(executable) or "")
+        )
+    if not str(resolved_executable) or not resolved_executable.is_file():
+        raise PluginError(f"metadata.json: executable was not found: {executable}")
+    if not os.access(resolved_executable, os.X_OK):
+        raise PluginError(f"metadata.json: executable is not executable: {executable}")
+
+    arguments = command.get("arguments", [])
+    if not isinstance(arguments, list) or not all(
+        isinstance(value, str) for value in arguments
+    ):
+        raise PluginError("metadata.json: command.arguments must contain strings")
+    if command.get("input", "png-stdin") != "png-stdin":
+        raise PluginError("metadata.json: only png-stdin input is supported")
+    if command.get("output", "none") not in {"none", "clipboard-text", "json"}:
+        raise PluginError("metadata.json: unsupported command.output")
+    timeout = command.get("timeout_ms", 30000)
+    if not isinstance(timeout, int) or not 1000 <= timeout <= 300000:
+        raise PluginError("metadata.json: timeout_ms must be between 1000 and 300000")
+
+    toolbar = manifest.get("toolbar", {})
+    if not isinstance(toolbar, dict):
+        raise PluginError("metadata.json: toolbar must be an object")
+    order = toolbar.get("order", 1000)
+    if not isinstance(order, int) or not 0 <= order <= 100000:
+        raise PluginError("metadata.json: toolbar.order must be between 0 and 100000")
+    icon = manifest.get("icon")
+    if icon is not None:
+        if not isinstance(icon, str) or not safe_relative(icon.replace("\\", "/")):
+            raise PluginError("metadata.json: invalid icon path")
+        if not (root / icon).is_file():
+            raise PluginError(f"metadata.json: icon was not found: {icon}")
+    return manifest
+
+
+def inspect_tree(root: Path) -> None:
+    total_size = 0
+    file_count = 0
+    for path in sorted(root.rglob("*")):
+        relative = path.relative_to(root).as_posix()
+        if not safe_relative(relative) or path.is_symlink():
+            raise PluginError(f"unsafe plugin entry: {relative}")
+        if not path.is_file() and not path.is_dir():
+            raise PluginError(f"unsupported plugin entry: {relative}")
+        if path.is_file():
+            total_size += path.stat().st_size
+            file_count += 1
+            if total_size > MAX_INSTALLED_SIZE or file_count > MAX_FILES:
+                raise PluginError("plugin exceeds the file or size limit")
+
+
+def inspect_package(package: Path, extract_to: Path | None = None) -> None:
+    if not package.is_file() or package.stat().st_size > MAX_PACKAGE_SIZE:
+        raise PluginError("package is missing or exceeds 32 MiB")
+    total_size = 0
+    file_count = 0
+    try:
+        with tarfile.open(package, "r:*") as archive:
+            for member in archive.getmembers():
+                if not safe_relative(member.name):
+                    raise PluginError(f"unsafe package entry: {member.name}")
+                if not member.isfile() and not member.isdir():
+                    raise PluginError(f"unsupported package entry: {member.name}")
+                if member.isfile():
+                    total_size += member.size
+                    file_count += 1
+                if total_size > MAX_INSTALLED_SIZE or file_count > MAX_FILES:
+                    raise PluginError("package exceeds the file or size limit")
+                if extract_to is not None:
+                    destination = extract_to / member.name
+                    if member.isdir():
+                        destination.mkdir(parents=True, exist_ok=True)
+                    else:
+                        destination.parent.mkdir(parents=True, exist_ok=True)
+                        source = archive.extractfile(member)
+                        if source is None:
+                            raise PluginError(f"cannot read package entry: {member.name}")
+                        with source, destination.open("wb") as output:
+                            shutil.copyfileobj(source, output)
+                        destination.chmod(member.mode & 0o777)
+    except (OSError, tarfile.TarError) as error:
+        raise PluginError(f"cannot read package: {error}") from error
+
+
+def validate_result(value: object) -> None:
+    if not isinstance(value, dict):
+        raise PluginError("plugin result must be a JSON object")
+    if value.get("protocol_version") != API_VERSION:
+        raise PluginError("result.protocol_version must be 1")
+    status_value = value.get("status")
+    if status_value == "error":
+        if not isinstance(value.get("message"), str):
+            raise PluginError("error result requires a message")
+        return
+    if status_value != "success":
+        raise PluginError("result.status must be 'success' or 'error'")
+    result = value.get("result")
+    if not isinstance(result, dict) or result.get("type") not in {
+        "clipboard-text",
+        "notification",
+        "none",
+    }:
+        raise PluginError("unsupported or missing result.type")
+    result_type = result["type"]
+    if result_type == "clipboard-text" and not isinstance(result.get("text"), str):
+        raise PluginError("clipboard-text result requires text")
+    if result_type == "notification" and not isinstance(result.get("text"), str):
+        raise PluginError("notification result requires text")
+
+
+def resolve_plugin_root(path: Path) -> tuple[Path, tempfile.TemporaryDirectory | None]:
+    if path.is_dir():
+        return path.resolve(), None
+    temporary = tempfile.TemporaryDirectory(prefix="flameshot-plugin-")
+    root = Path(temporary.name)
+    inspect_package(path.resolve(), root)
+    return root, temporary
+
+
+def command_validate(arguments: argparse.Namespace) -> None:
+    root, temporary = resolve_plugin_root(Path(arguments.source))
+    try:
+        inspect_tree(root)
+        manifest = validate_manifest(root)
+    finally:
+        if temporary:
+            temporary.cleanup()
+    print(f"valid: {manifest['id']} (API {manifest['api_version']})")
+
+
+def template_root() -> Path:
+    script = Path(__file__).resolve()
+    candidates = [
+        script.parent / "templates",
+        script.parent.parent / "share" / "flameshot" / "sdk" / "templates",
+    ]
+    for candidate in candidates:
+        if candidate.is_dir():
+            return candidate
+    raise PluginError("SDK templates were not found")
+
+
+def command_create(arguments: argparse.Namespace) -> None:
+    if not PLUGIN_ID.fullmatch(arguments.plugin_id):
+        raise PluginError("plugin id must look like org.example.my-plugin")
+    destination = Path(arguments.directory or arguments.plugin_id)
+    if destination.exists():
+        raise PluginError(f"destination already exists: {destination}")
+    source = template_root() / arguments.language
+    if not source.is_dir():
+        raise PluginError(f"unknown template: {arguments.language}")
+    shutil.copytree(source, destination)
+    display_name = arguments.name or arguments.plugin_id.rsplit(".", 1)[-1].replace("-", " ").title()
+    for path in destination.rglob("*"):
+        if path.is_file():
+            content = path.read_text(encoding="utf-8")
+            content = content.replace("@PLUGIN_ID@", arguments.plugin_id)
+            content = content.replace("@PLUGIN_NAME@", display_name)
+            path.write_text(content, encoding="utf-8")
+        if path.parent.name == "bin" and path.is_file():
+            path.chmod(path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    validate_manifest(destination)
+    print(f"created {arguments.plugin_id} in {destination}")
+
+
+def command_pack(arguments: argparse.Namespace) -> None:
+    root = Path(arguments.directory).resolve()
+    inspect_tree(root)
+    manifest = validate_manifest(root)
+    output = Path(arguments.output or f"{manifest['id']}.flameshot-plugin").resolve()
+    if output.exists() and not arguments.force:
+        raise PluginError(f"output already exists: {output} (use --force)")
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with output.open("wb") as raw_output:
+        with gzip.GzipFile(filename="", mode="wb", fileobj=raw_output, mtime=0) as compressed:
+            with tarfile.open(fileobj=compressed, mode="w") as archive:
+                for path in [root, *sorted(root.rglob("*"))]:
+                    if path == root:
+                        continue
+                    relative = path.relative_to(root).as_posix()
+                    info = archive.gettarinfo(str(path), relative)
+                    info.uid = info.gid = 0
+                    info.uname = info.gname = ""
+                    info.mtime = 0
+                    if path.is_file():
+                        with path.open("rb") as source:
+                            archive.addfile(info, source)
+                    else:
+                        archive.addfile(info)
+    inspect_package(output)
+    print(f"packed {manifest['id']} -> {output}")
+
+
+def command_test(arguments: argparse.Namespace) -> None:
+    root = Path(arguments.directory).resolve()
+    inspect_tree(root)
+    manifest = validate_manifest(root)
+    command = manifest["command"]
+    executable_value = command["executable"]
+    executable = Path(executable_value)
+    if not executable.is_absolute() and ("/" in executable_value or "\\" in executable_value):
+        executable = root / executable
+    elif not executable.is_absolute():
+        local = root / executable
+        executable = local if local.exists() else Path(shutil.which(executable_value) or executable_value)
+    image = Path(arguments.image).read_bytes() if arguments.image else PNG_1X1
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "FLAMESHOT_PLUGIN_API_VERSION": "1",
+            "FLAMESHOT_PLUGIN_ID": manifest["id"],
+            "FLAMESHOT_PLUGIN_CONFIG_DIR": str(
+                Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config"))
+                / "flameshot"
+                / "plugins"
+                / manifest["id"]
+            ),
+        }
+    )
+    try:
+        completed = subprocess.run(
+            [str(executable), *command.get("arguments", [])],
+            cwd=root,
+            input=image,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=command.get("timeout_ms", 30000) / 1000,
+            env=environment,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as error:
+        raise PluginError(f"plugin execution failed: {error}") from error
+    if completed.returncode != 0:
+        detail = completed.stderr.decode("utf-8", errors="replace").strip()
+        raise PluginError(f"plugin exited with {completed.returncode}: {detail}")
+    output_mode = command.get("output", "none")
+    if output_mode == "json":
+        try:
+            result = json.loads(completed.stdout)
+        except json.JSONDecodeError as error:
+            raise PluginError(f"invalid result JSON: {error}") from error
+        validate_result(result)
+        print(json.dumps(result, ensure_ascii=False, indent=2))
+    elif output_mode == "clipboard-text":
+        print(completed.stdout.decode("utf-8", errors="replace"))
+    else:
+        print("plugin completed successfully")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="flameshot-plugin")
+    parser.add_argument("--version", action="version", version="%(prog)s 1")
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    create = commands.add_parser("create", help="create a plugin from a template")
+    create.add_argument("plugin_id")
+    create.add_argument("directory", nargs="?")
+    create.add_argument("--language", choices=("shell", "python", "rust", "cpp"), default="python")
+    create.add_argument("--name")
+    create.set_defaults(function=command_create)
+
+    validate = commands.add_parser("validate", help="validate a directory or package")
+    validate.add_argument("source")
+    validate.set_defaults(function=command_validate)
+
+    pack = commands.add_parser("pack", help="build a .flameshot-plugin package")
+    pack.add_argument("directory")
+    pack.add_argument("-o", "--output")
+    pack.add_argument("--force", action="store_true")
+    pack.set_defaults(function=command_pack)
+
+    test = commands.add_parser("test", help="run a plugin with PNG input")
+    test.add_argument("directory")
+    test.add_argument("--image")
+    test.set_defaults(function=command_test)
+    return parser
+
+
+def main() -> int:
+    try:
+        arguments = build_parser().parse_args()
+        arguments.function(arguments)
+        return 0
+    except PluginError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sdk/flameshot-plugin
+++ b/sdk/flameshot-plugin
@@ -256,7 +256,17 @@ def command_pack(arguments: argparse.Namespace) -> None:
     root = Path(arguments.directory).resolve()
     inspect_tree(root)
     manifest = validate_manifest(root)
-    output = Path(arguments.output or f"{manifest['id']}.flameshot-plugin").resolve()
+    output = (
+        Path(arguments.output).resolve()
+        if arguments.output
+        else root.parent / f"{manifest['id']}.flameshot-plugin"
+    )
+    try:
+        output.relative_to(root)
+    except ValueError:
+        pass
+    else:
+        raise PluginError("package output must be outside the plugin directory")
     if output.exists() and not arguments.force:
         raise PluginError(f"output already exists: {output} (use --force)")
     output.parent.mkdir(parents=True, exist_ok=True)

--- a/sdk/schemas/manifest-v1.schema.json
+++ b/sdk/schemas/manifest-v1.schema.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://flameshot.org/schemas/action-plugin-manifest-v1.json",
+  "title": "Flameshot action plugin manifest, API 1",
+  "type": "object",
+  "required": ["api_version", "type", "id", "name", "command"],
+  "properties": {
+    "api_version": { "const": 1 },
+    "type": { "const": "action" },
+    "id": {
+      "type": "string",
+      "pattern": "^[a-z0-9]+(?:[._-][a-z0-9]+)+$"
+    },
+    "name": { "type": "string", "minLength": 1 },
+    "description": { "type": "string" },
+    "icon": { "type": "string", "minLength": 1 },
+    "toolbar": {
+      "type": "object",
+      "properties": {
+        "visible": { "type": "boolean" },
+        "order": { "type": "integer", "minimum": 0, "maximum": 100000 },
+        "shortcut": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "command": {
+      "type": "object",
+      "required": ["executable"],
+      "properties": {
+        "executable": { "type": "string", "minLength": 1 },
+        "arguments": { "type": "array", "items": { "type": "string" } },
+        "input": { "const": "png-stdin" },
+        "output": { "enum": ["none", "clipboard-text", "json"] },
+        "timeout_ms": { "type": "integer", "minimum": 1000, "maximum": 300000 }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/sdk/templates/cpp/CMakeLists.txt
+++ b/sdk/templates/cpp/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 3.16)
+project(flameshot-action-plugin LANGUAGES CXX)
+add_executable(flameshot-plugin src/main.cpp)
+target_compile_features(flameshot-plugin PRIVATE cxx_std_17)

--- a/sdk/templates/cpp/bin/run
+++ b/sdk/templates/cpp/bin/run
@@ -1,0 +1,8 @@
+#!/bin/sh
+root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+binary="$root/build/flameshot-plugin"
+if [ ! -x "$binary" ]; then
+  printf 'Build this plugin first: cmake -S . -B build && cmake --build build\n' >&2
+  exit 127
+fi
+exec "$binary" "$@"

--- a/sdk/templates/cpp/metadata.json
+++ b/sdk/templates/cpp/metadata.json
@@ -1,0 +1,15 @@
+{
+  "api_version": 1,
+  "type": "action",
+  "id": "@PLUGIN_ID@",
+  "name": "@PLUGIN_NAME@",
+  "description": "A C++ action plugin",
+  "toolbar": { "visible": true, "order": 1000 },
+  "command": {
+    "executable": "./bin/run",
+    "arguments": [],
+    "input": "png-stdin",
+    "output": "json",
+    "timeout_ms": 30000
+  }
+}

--- a/sdk/templates/cpp/src/main.cpp
+++ b/sdk/templates/cpp/src/main.cpp
@@ -1,0 +1,12 @@
+#include <iostream>
+#include <iterator>
+#include <string>
+
+int main()
+{
+    const std::string image(std::istreambuf_iterator<char>(std::cin), {});
+    std::cout << "{\"protocol_version\":1,\"status\":\"success\","
+                 "\"result\":{\"type\":\"notification\","
+                 "\"title\":\"@PLUGIN_NAME@\",\"text\":\"Received "
+              << image.size() << " PNG bytes\"}}\n";
+}

--- a/sdk/templates/python/bin/run.py
+++ b/sdk/templates/python/bin/run.py
@@ -2,13 +2,21 @@
 import json
 import sys
 
+# Flameshot writes the selected screenshot to standard input as PNG bytes.
 image = sys.stdin.buffer.read()
-print(json.dumps({
+
+# Replace this response with the result produced by your plugin. Flameshot
+# currently supports "notification", "clipboard-text", and "none" results.
+response = {
     "protocol_version": 1,
     "status": "success",
     "result": {
         "type": "notification",
         "title": "@PLUGIN_NAME@",
-        "text": f"Received {len(image)} PNG bytes"
-    }
-}))
+        "text": f"Received {len(image)} PNG bytes",
+    },
+}
+
+# Standard output is reserved for exactly one JSON response. Write diagnostic
+# messages to standard error with: print("message", file=sys.stderr)
+print(json.dumps(response))

--- a/sdk/templates/python/bin/run.py
+++ b/sdk/templates/python/bin/run.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+import json
+import sys
+
+image = sys.stdin.buffer.read()
+print(json.dumps({
+    "protocol_version": 1,
+    "status": "success",
+    "result": {
+        "type": "notification",
+        "title": "@PLUGIN_NAME@",
+        "text": f"Received {len(image)} PNG bytes"
+    }
+}))

--- a/sdk/templates/python/metadata.json
+++ b/sdk/templates/python/metadata.json
@@ -1,0 +1,15 @@
+{
+  "api_version": 1,
+  "type": "action",
+  "id": "@PLUGIN_ID@",
+  "name": "@PLUGIN_NAME@",
+  "description": "A Python action plugin",
+  "toolbar": { "visible": true, "order": 1000 },
+  "command": {
+    "executable": "./bin/run.py",
+    "arguments": [],
+    "input": "png-stdin",
+    "output": "json",
+    "timeout_ms": 30000
+  }
+}

--- a/sdk/templates/rust/Cargo.toml
+++ b/sdk/templates/rust/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "flameshot-plugin"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/sdk/templates/rust/bin/run
+++ b/sdk/templates/rust/bin/run
@@ -1,0 +1,8 @@
+#!/bin/sh
+root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+binary="$root/target/release/flameshot-plugin"
+if [ ! -x "$binary" ]; then
+  printf 'Build this plugin first: cargo build --release\n' >&2
+  exit 127
+fi
+exec "$binary" "$@"

--- a/sdk/templates/rust/metadata.json
+++ b/sdk/templates/rust/metadata.json
@@ -1,0 +1,15 @@
+{
+  "api_version": 1,
+  "type": "action",
+  "id": "@PLUGIN_ID@",
+  "name": "@PLUGIN_NAME@",
+  "description": "A Rust action plugin",
+  "toolbar": { "visible": true, "order": 1000 },
+  "command": {
+    "executable": "./bin/run",
+    "arguments": [],
+    "input": "png-stdin",
+    "output": "json",
+    "timeout_ms": 30000
+  }
+}

--- a/sdk/templates/rust/src/main.rs
+++ b/sdk/templates/rust/src/main.rs
@@ -1,0 +1,10 @@
+use std::io::{self, Read};
+
+fn main() {
+    let mut image = Vec::new();
+    io::stdin().read_to_end(&mut image).expect("read PNG");
+    println!(
+        "{{\"protocol_version\":1,\"status\":\"success\",\"result\":{{\"type\":\"notification\",\"title\":\"@PLUGIN_NAME@\",\"text\":\"Received {} PNG bytes\"}}}}",
+        image.len()
+    );
+}

--- a/sdk/templates/shell/bin/run
+++ b/sdk/templates/shell/bin/run
@@ -1,0 +1,3 @@
+#!/bin/sh
+bytes=$(wc -c)
+printf '{"protocol_version":1,"status":"success","result":{"type":"notification","title":"@PLUGIN_NAME@","text":"Received %s PNG bytes"}}\n' "$bytes"

--- a/sdk/templates/shell/metadata.json
+++ b/sdk/templates/shell/metadata.json
@@ -1,0 +1,15 @@
+{
+  "api_version": 1,
+  "type": "action",
+  "id": "@PLUGIN_ID@",
+  "name": "@PLUGIN_NAME@",
+  "description": "A shell action plugin",
+  "toolbar": { "visible": true, "order": 1000 },
+  "command": {
+    "executable": "./bin/run",
+    "arguments": [],
+    "input": "png-stdin",
+    "output": "json",
+    "timeout_ms": 30000
+  }
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -111,6 +111,7 @@ add_subdirectory(config)
 add_subdirectory(core)
 add_subdirectory(utils)
 add_subdirectory(widgets)
+add_subdirectory(plugins)
 add_subdirectory(tools)
 
 

--- a/src/config/buttonlistview.cpp
+++ b/src/config/buttonlistview.cpp
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: 2017-2019 Alejandro Sirgo Rica & Contributors
 
 #include "buttonlistview.h"
-#include "tools/toolfactory.h"
+#include "tools/toolregistry.h"
 #include "utils/confighandler.h"
 
 #include <QListWidgetItem>
@@ -21,14 +21,13 @@ ButtonListView::ButtonListView(QWidget* parent)
 
 void ButtonListView::initButtonList()
 {
-    ToolFactory factory;
-    auto listTypes = CaptureToolButton::getIterableButtonTypes();
+    ToolRegistry registry;
 
-    for (const CaptureTool::Type t : listTypes) {
-        CaptureTool* tool = factory.CreateTool(t);
-
-        // add element to the local map
-        m_buttonTypeByName.insert(tool->name(), t);
+    for (const ToolDescriptor& descriptor : registry.tools()) {
+        CaptureTool* tool = ToolRegistry::createTool(descriptor);
+        if (!tool) {
+            continue;
+        }
 
         // init the menu option
         auto* m_buttonItem = new QListWidgetItem(this);
@@ -44,13 +43,27 @@ void ButtonListView::initButtonList()
 
         m_buttonItem->setText(tool->name());
         m_buttonItem->setToolTip(tool->description());
-        tool->deleteLater();
+        m_buttonItem->setData(Qt::UserRole, descriptor.id);
+        m_buttonItem->setData(Qt::UserRole + 1, descriptor.isExternal());
+        m_buttonItem->setData(Qt::UserRole + 2,
+                              static_cast<int>(descriptor.legacyType));
+        m_buttonItem->setData(Qt::UserRole + 3, descriptor.toolbarVisible);
+        delete tool;
     }
 }
 
 void ButtonListView::updateActiveButtons(QListWidgetItem* item)
 {
-    CaptureTool::Type bType = m_buttonTypeByName[item->text()];
+    const QString toolId = item->data(Qt::UserRole).toString();
+    const bool external = item->data(Qt::UserRole + 1).toBool();
+    if (external) {
+        ConfigHandler().setPluginEnabled(toolId,
+                                         item->checkState() == Qt::Checked);
+        return;
+    }
+
+    const auto bType =
+      static_cast<CaptureTool::Type>(item->data(Qt::UserRole + 2).toInt());
     if (item->checkState() == Qt::Checked) {
         // Refactored to avoid external sort: insert into the correct position
         using bt = CaptureTool::Type;
@@ -82,17 +95,45 @@ void ButtonListView::selectAll()
     for (int i = 0; i < this->count(); ++i) {
         QListWidgetItem* item = this->item(i);
         item->setCheckState(Qt::Checked);
+        if (item->data(Qt::UserRole + 1).toBool()) {
+            ConfigHandler().setPluginEnabled(
+              item->data(Qt::UserRole).toString(), true);
+        }
     }
+}
+
+void ButtonListView::reload()
+{
+    clear();
+    initButtonList();
+    updateComponents();
+}
+
+QString ButtonListView::selectedExternalPluginId() const
+{
+    const QListWidgetItem* selected = currentItem();
+    if (!selected || !selected->data(Qt::UserRole + 1).toBool()) {
+        return {};
+    }
+    return selected->data(Qt::UserRole).toString();
 }
 
 void ButtonListView::updateComponents()
 {
     m_listButtons = ConfigHandler().buttons();
-    auto listTypes = CaptureToolButton::getIterableButtonTypes();
     for (int i = 0; i < this->count(); ++i) {
         QListWidgetItem* item = this->item(i);
-        auto elem = static_cast<CaptureTool::Type>(listTypes.at(i));
-        if (m_listButtons.contains(elem)) {
+        bool enabled;
+        if (item->data(Qt::UserRole + 1).toBool()) {
+            enabled = ConfigHandler().pluginEnabled(
+              item->data(Qt::UserRole).toString(),
+              item->data(Qt::UserRole + 3).toBool());
+        } else {
+            const auto type = static_cast<CaptureTool::Type>(
+              item->data(Qt::UserRole + 2).toInt());
+            enabled = m_listButtons.contains(type);
+        }
+        if (enabled) {
             item->setCheckState(Qt::Checked);
         } else {
             item->setCheckState(Qt::Unchecked);

--- a/src/config/buttonlistview.h
+++ b/src/config/buttonlistview.h
@@ -12,8 +12,12 @@ public:
     explicit ButtonListView(QWidget* parent = nullptr);
 
 public slots:
+    void reload();
     void selectAll();
     void updateComponents();
+
+public:
+    QString selectedExternalPluginId() const;
 
 private slots:
     void reverseItemCheck(QListWidgetItem*);
@@ -23,7 +27,6 @@ protected:
 
 private:
     QList<CaptureTool::Type> m_listButtons;
-    QMap<QString, CaptureTool::Type> m_buttonTypeByName;
 
     void updateActiveButtons(QListWidgetItem*);
 };

--- a/src/config/shortcutswidget.cpp
+++ b/src/config/shortcutswidget.cpp
@@ -6,6 +6,7 @@
 #include "core/qguiappcurrentscreen.h"
 #include "tools/capturetool.h"
 #include "tools/toolfactory.h"
+#include "tools/toolregistry.h"
 #include "utils/globalvalues.h"
 
 #include <QCheckBox>
@@ -151,7 +152,16 @@ void ShortcutsWidget::onShortcutCellClicked(int row, int col)
                 shortcutValue = QKeySequence("");
             }
 #endif
-            if (m_config.setShortcut(shortcutName, shortcutValue.toString())) {
+            bool updated;
+            if (shortcutName.startsWith("PLUGIN:")) {
+                m_config.setPluginShortcut(shortcutName.mid(7),
+                                           shortcutValue.toString());
+                updated = true;
+            } else {
+                updated =
+                  m_config.setShortcut(shortcutName, shortcutValue.toString());
+            }
+            if (updated) {
                 populateInfoTable();
             }
         }
@@ -175,6 +185,21 @@ void ShortcutsWidget::loadShortcuts()
                                               << tr("Left Double-click"));
             }
         }
+        delete tool;
+    }
+
+    ToolRegistry registry;
+    for (const ToolDescriptor& descriptor : registry.tools()) {
+        if (!descriptor.isExternal()) {
+            continue;
+        }
+        CaptureTool* tool = ToolRegistry::createTool(descriptor);
+        if (!tool) {
+            continue;
+        }
+        m_shortcuts << (QStringList()
+                        << QStringLiteral("PLUGIN:") + descriptor.id
+                        << tool->description() << descriptor.shortcut);
         delete tool;
     }
 

--- a/src/config/visualseditor.cpp
+++ b/src/config/visualseditor.cpp
@@ -6,12 +6,16 @@
 #include "config/colorpickereditor.h"
 #include "config/extendedslider.h"
 #include "config/uicoloreditor.h"
+#include "plugins/pluginmanager.h"
 #include "utils/confighandler.h"
 
 #include <QDirIterator>
+#include <QFileDialog>
+#include <QGroupBox>
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QMessageBox>
+#include <QPushButton>
 
 VisualsEditor::VisualsEditor(QWidget* parent)
   : QWidget(parent)
@@ -87,12 +91,64 @@ void VisualsEditor::initWidgets()
     m_layout->addWidget(boxButtons);
     listLayout->addWidget(m_buttonList);
 
+    auto* buttonActions = new QHBoxLayout();
     auto* setAllButtons = new QPushButton(tr("Select All"));
     connect(setAllButtons,
             &QPushButton::clicked,
             m_buttonList,
             &ButtonListView::selectAll);
-    listLayout->addWidget(setAllButtons);
+    buttonActions->addWidget(setAllButtons);
+
+    auto* installPlugin = new QPushButton(tr("Install Plugin…"));
+    connect(installPlugin, &QPushButton::clicked, this, [this]() {
+        const QString package = QFileDialog::getOpenFileName(
+          this,
+          tr("Install Flameshot Plugin"),
+          {},
+          tr("Flameshot plugins (*.flameshot-plugin);;All files (*)"));
+        if (package.isEmpty()) {
+            return;
+        }
+        const PluginManagerResult result = PluginManager::install(package);
+        if (result.success) {
+            m_buttonList->reload();
+            QMessageBox::information(
+              this, tr("Plugin installed"), result.message);
+        } else {
+            QMessageBox::warning(
+              this, tr("Plugin installation failed"), result.message);
+        }
+    });
+    buttonActions->addWidget(installPlugin);
+
+    auto* removePlugin = new QPushButton(tr("Remove Plugin"));
+    connect(removePlugin, &QPushButton::clicked, this, [this]() {
+        const QString pluginId = m_buttonList->selectedExternalPluginId();
+        if (pluginId.isEmpty()) {
+            QMessageBox::information(
+              this,
+              tr("Remove Plugin"),
+              tr("Select an installed plugin first."));
+            return;
+        }
+        if (QMessageBox::question(
+              this,
+              tr("Remove Plugin"),
+              tr("Remove plugin %1?").arg(pluginId)) != QMessageBox::Yes) {
+            return;
+        }
+        const PluginManagerResult result = PluginManager::remove(pluginId);
+        if (result.success) {
+            m_buttonList->reload();
+            QMessageBox::information(
+              this, tr("Plugin removed"), result.message);
+        } else {
+            QMessageBox::warning(
+              this, tr("Plugin removal failed"), result.message);
+        }
+    });
+    buttonActions->addWidget(removePlugin);
+    listLayout->addLayout(buttonActions);
 }
 
 void VisualsEditor::initTranslations()

--- a/src/core/flameshotdaemon.cpp
+++ b/src/core/flameshotdaemon.cpp
@@ -12,7 +12,9 @@
 #include <QClipboard>
 #include <QIODevice>
 #include <QPixmap>
+#include <QProcess>
 #include <QRect>
+#include <QStandardPaths>
 
 #if !(defined(Q_OS_MACOS) || defined(Q_OS_WIN))
 #include <QDBusConnection>
@@ -351,6 +353,31 @@ void FlameshotDaemon::attachTextToClipboard(const QString& text,
     // Must send notification before clipboard modification on linux
     if (!notification.isEmpty()) {
         AbstractLogger::info() << notification;
+    }
+
+    // A background Wayland client has no recent input serial and therefore
+    // cannot reliably acquire clipboard ownership through QClipboard. Let the
+    // compositor-aware helper serve text when it is available.
+    if (QApplication::platformName() == QLatin1String("wayland")) {
+        const QString wlCopy =
+          QStandardPaths::findExecutable(QStringLiteral("wl-copy"));
+        if (!wlCopy.isEmpty()) {
+            QProcess process;
+            process.start(wlCopy,
+                          { QStringLiteral("--type"),
+                            QStringLiteral("text/plain;charset=utf-8") });
+            if (process.waitForStarted(1000)) {
+                process.write(text.toUtf8());
+                process.closeWriteChannel();
+                if (process.waitForFinished(3000) &&
+                    process.exitStatus() == QProcess::NormalExit &&
+                    process.exitCode() == 0) {
+                    return;
+                }
+            }
+            AbstractLogger::warning()
+              << tr("Could not copy text with wl-copy; falling back to Qt.");
+        }
     }
 
     m_hostingClipboard = true;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,6 +15,7 @@
 #include "core/capturerequest.h"
 #include "core/flameshot.h"
 #include "core/flameshotdaemon.h"
+#include "plugins/pluginmanager.h"
 #include "utils/abstractlogger.h"
 #include "utils/confighandler.h"
 #include "utils/filenamehandler.h"
@@ -265,6 +266,13 @@ int main(int argc, char* argv[])
     new QCoreApplication(argc, argv);
     configureApp(false, translator, qtTranslator);
 
+    if (qApp->arguments().size() > 1 &&
+        qApp->arguments().at(1) == QLatin1String("plugins")) {
+        const int result = PluginManagerCli::run(qApp->arguments().mid(2));
+        delete QCoreApplication::instance();
+        return result;
+    }
+
     CommandLineParser parser;
     // Add description
     parser.setDescription(
@@ -281,6 +289,8 @@ int main(int argc, char* argv[])
       QObject::tr("Start a manual capture in GUI mode."));
     CommandArgument configArgument(QStringLiteral("config"),
                                    QObject::tr("Configure") + " flameshot.");
+    CommandArgument pluginsArgument(
+      QStringLiteral("plugins"), QObject::tr("Manage action plugins."));
     CommandArgument screenArgument(
       QStringLiteral("screen"),
       QObject::tr("Capture a screenshot of the specified monitor."));
@@ -419,6 +429,7 @@ int main(int argc, char* argv[])
     parser.AddArgument(fullArgument);
     parser.AddArgument(launcherArgument);
     parser.AddArgument(configArgument);
+    parser.AddArgument(pluginsArgument);
     auto helpOption = parser.addHelpOption();
     auto versionOption = parser.addVersionOption();
     parser.AddOptions({ pathOption,

--- a/src/plugins/CMakeLists.txt
+++ b/src/plugins/CMakeLists.txt
@@ -1,0 +1,8 @@
+target_sources(
+  flameshot
+  PRIVATE actionplugin.h
+          actionplugin.cpp
+          actionpluginrunner.h
+          actionpluginrunner.cpp
+          pluginmanager.h
+          pluginmanager.cpp)

--- a/src/plugins/actionplugin.cpp
+++ b/src/plugins/actionplugin.cpp
@@ -1,0 +1,240 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "actionplugin.h"
+
+#include <QDir>
+#include <QDirIterator>
+#include <QFile>
+#include <QFileInfo>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QRegularExpression>
+#include <QSet>
+#include <QStandardPaths>
+
+#include <algorithm>
+
+namespace {
+
+bool fail(QString* error, const QString& message)
+{
+    if (error) {
+        *error = message;
+    }
+    return false;
+}
+
+QString resolveExecutable(const QString& value, const QString& pluginDir)
+{
+    if (value.isEmpty()) {
+        return {};
+    }
+
+    const QFileInfo executableInfo(value);
+    if (executableInfo.isAbsolute()) {
+        return executableInfo.absoluteFilePath();
+    }
+
+    if (value.contains(QLatin1Char('/')) || value.contains(QLatin1Char('\\'))) {
+        const QString normalized =
+          QString(value).replace(QLatin1Char('\\'), QLatin1Char('/'));
+        const QString clean = QDir::cleanPath(normalized);
+        if (clean == QLatin1String("..") ||
+            clean.startsWith(QLatin1String("../"))) {
+            return {};
+        }
+        return QDir(pluginDir).absoluteFilePath(clean);
+    }
+
+    QString executable = QStandardPaths::findExecutable(value, { pluginDir });
+    if (executable.isEmpty()) {
+        executable = QStandardPaths::findExecutable(value);
+    }
+    return executable;
+}
+
+} // namespace
+
+QString ActionPluginLoader::userPluginRoot()
+{
+    return QDir(QStandardPaths::writableLocation(
+                  QStandardPaths::GenericDataLocation))
+      .filePath(QStringLiteral("flameshot/plugins"));
+}
+
+QStringList ActionPluginLoader::pluginRoots()
+{
+    QStringList roots;
+    const QStringList dataLocations =
+      QStandardPaths::standardLocations(QStandardPaths::GenericDataLocation);
+    for (const QString& location : dataLocations) {
+        roots.append(
+          QDir(location).filePath(QStringLiteral("flameshot/plugins")));
+    }
+
+    // Compatibility with the first prototype and the path discussed in the
+    // original plugin RFC.
+    const QString legacyRoot = QDir(QStandardPaths::writableLocation(
+                                      QStandardPaths::GenericConfigLocation))
+                                 .filePath(QStringLiteral("flameshot/plugins"));
+    if (!roots.contains(legacyRoot)) {
+        roots.append(legacyRoot);
+    }
+    roots.removeDuplicates();
+    return roots;
+}
+
+QList<ActionPlugin> ActionPluginLoader::discover(const QStringList& pluginRoots,
+                                                 QStringList* errors)
+{
+    QList<ActionPlugin> plugins;
+    QSet<QString> knownIds;
+
+    for (const QString& pluginRoot : pluginRoots) {
+        QDirIterator manifests(pluginRoot,
+                               { QStringLiteral("metadata.json") },
+                               QDir::Files,
+                               QDirIterator::Subdirectories);
+        while (manifests.hasNext()) {
+            ActionPlugin plugin;
+            QString error;
+            const QString manifestPath = manifests.next();
+            if (!loadManifest(manifestPath, &plugin, &error)) {
+                if (errors) {
+                    errors->append(
+                      QStringLiteral("%1: %2").arg(manifestPath, error));
+                }
+                continue;
+            }
+            if (knownIds.contains(plugin.id)) {
+                if (errors) {
+                    errors->append(QStringLiteral("%1: duplicate plugin id %2")
+                                     .arg(manifestPath, plugin.id));
+                }
+                continue;
+            }
+            knownIds.insert(plugin.id);
+            plugins.append(plugin);
+        }
+    }
+
+    std::sort(
+      plugins.begin(), plugins.end(), [](const auto& left, const auto& right) {
+          return left.name.localeAwareCompare(right.name) < 0;
+      });
+    return plugins;
+}
+
+bool ActionPluginLoader::loadManifest(const QString& path,
+                                      ActionPlugin* plugin,
+                                      QString* error)
+{
+    if (!plugin) {
+        return fail(error, QStringLiteral("missing output object"));
+    }
+    *plugin = ActionPlugin{};
+
+    QFile file(path);
+    if (!file.open(QIODevice::ReadOnly)) {
+        return fail(error, file.errorString());
+    }
+
+    QJsonParseError parseError;
+    const QJsonDocument document =
+      QJsonDocument::fromJson(file.readAll(), &parseError);
+    if (parseError.error != QJsonParseError::NoError || !document.isObject()) {
+        return fail(
+          error,
+          QStringLiteral("invalid JSON: %1").arg(parseError.errorString()));
+    }
+
+    const QJsonObject root = document.object();
+    if (root.value("api_version").toInt(-1) != ApiVersion) {
+        return fail(error,
+                    QStringLiteral("unsupported api_version (expected %1)")
+                      .arg(ApiVersion));
+    }
+    if (root.value("type").toString() != QLatin1String("action")) {
+        return fail(error, QStringLiteral("type must be 'action'"));
+    }
+
+    static const QRegularExpression validId(
+      QStringLiteral("^[a-z0-9]+(?:[._-][a-z0-9]+)+$"));
+    plugin->id = root.value("id").toString();
+    if (!validId.match(plugin->id).hasMatch()) {
+        return fail(error, QStringLiteral("invalid plugin id"));
+    }
+
+    plugin->name = root.value("name").toString().trimmed();
+    if (plugin->name.isEmpty()) {
+        return fail(error, QStringLiteral("name is required"));
+    }
+    plugin->description = root.value("description").toString().trimmed();
+
+    const QJsonObject command = root.value("command").toObject();
+    const QString pluginDir = QFileInfo(path).absolutePath();
+    plugin->executable =
+      resolveExecutable(command.value("executable").toString(), pluginDir);
+    const QFileInfo resolvedExecutable(plugin->executable);
+    if (plugin->executable.isEmpty() || !resolvedExecutable.isExecutable()) {
+        return fail(error, QStringLiteral("executable was not found"));
+    }
+
+    const QJsonArray arguments = command.value("arguments").toArray();
+    for (const QJsonValue& argument : arguments) {
+        if (!argument.isString()) {
+            return fail(error,
+                        QStringLiteral("command arguments must be strings"));
+        }
+        plugin->arguments.append(argument.toString());
+    }
+
+    if (command.value("input").toString("png-stdin") !=
+        QLatin1String("png-stdin")) {
+        return fail(error, QStringLiteral("only png-stdin input is supported"));
+    }
+
+    const QString output = command.value("output").toString("none");
+    if (output == QLatin1String("clipboard-text")) {
+        plugin->outputMode = ActionPlugin::OutputMode::ClipboardText;
+    } else if (output == QLatin1String("json")) {
+        plugin->outputMode = ActionPlugin::OutputMode::Json;
+    } else if (output == QLatin1String("none")) {
+        plugin->outputMode = ActionPlugin::OutputMode::None;
+    } else {
+        return fail(error, QStringLiteral("unsupported command output"));
+    }
+
+    plugin->timeoutMs = command.value("timeout_ms").toInt(30000);
+    if (plugin->timeoutMs < 1000 || plugin->timeoutMs > 300000) {
+        return fail(
+          error, QStringLiteral("timeout_ms must be between 1000 and 300000"));
+    }
+
+    const QJsonObject toolbar = root.value("toolbar").toObject();
+    plugin->toolbarVisible = toolbar.value("visible").toBool(true);
+    plugin->toolbarOrder = toolbar.value("order").toInt(1000);
+    if (plugin->toolbarOrder < 0 || plugin->toolbarOrder > 100000) {
+        return fail(
+          error, QStringLiteral("toolbar.order must be between 0 and 100000"));
+    }
+    plugin->shortcut = toolbar.value("shortcut").toString();
+
+    const QString iconName = root.value("icon").toString();
+    if (!iconName.isEmpty()) {
+        const QString cleanIcon = QDir::cleanPath(
+          QString(iconName).replace(QLatin1Char('\\'), QLatin1Char('/')));
+        if (QDir::isAbsolutePath(cleanIcon) ||
+            cleanIcon == QLatin1String("..") ||
+            cleanIcon.startsWith(QLatin1String("../"))) {
+            return fail(error, QStringLiteral("invalid icon path"));
+        }
+        const QString iconPath = QDir(pluginDir).absoluteFilePath(cleanIcon);
+        if (QFileInfo::exists(iconPath)) {
+            plugin->icon = QIcon(iconPath);
+        }
+    }
+    plugin->manifestPath = QFileInfo(path).absoluteFilePath();
+    return true;
+}

--- a/src/plugins/actionplugin.h
+++ b/src/plugins/actionplugin.h
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <QIcon>
+#include <QList>
+#include <QString>
+#include <QStringList>
+
+struct ActionPlugin
+{
+    enum class OutputMode
+    {
+        None,
+        ClipboardText,
+        Json,
+    };
+
+    QString id;
+    QString name;
+    QString description;
+    QString executable;
+    QStringList arguments;
+    QString manifestPath;
+    QIcon icon;
+    OutputMode outputMode = OutputMode::None;
+    int timeoutMs = 30000;
+    int toolbarOrder = 1000;
+    bool toolbarVisible = true;
+    QString shortcut;
+};
+
+class ActionPluginLoader
+{
+public:
+    static constexpr int ApiVersion = 1;
+
+    static QString userPluginRoot();
+    static QStringList pluginRoots();
+    static QList<ActionPlugin> discover(const QStringList& pluginRoots,
+                                        QStringList* errors = nullptr);
+    static bool loadManifest(const QString& path,
+                             ActionPlugin* plugin,
+                             QString* error = nullptr);
+};

--- a/src/plugins/actionpluginrunner.cpp
+++ b/src/plugins/actionpluginrunner.cpp
@@ -1,0 +1,259 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "actionpluginrunner.h"
+
+#include "core/flameshotdaemon.h"
+#include "utils/systemnotification.h"
+
+#include <QApplication>
+#include <QBuffer>
+#include <QDir>
+#include <QFileInfo>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QPixmap>
+#include <QProcessEnvironment>
+#include <QStandardPaths>
+
+namespace {
+constexpr qsizetype MaxStandardOutputSize = 1024 * 1024;
+constexpr qsizetype MaxStandardErrorSize = 256 * 1024;
+}
+
+ActionPluginRunner* ActionPluginRunner::run(const ActionPlugin& plugin,
+                                            const QPixmap& capture)
+{
+    auto* runner = new ActionPluginRunner(plugin, capture);
+    QTimer::singleShot(0, runner, [runner]() { runner->start(); });
+    return runner;
+}
+
+ActionPluginRunner::ActionPluginRunner(const ActionPlugin& plugin,
+                                       const QPixmap& capture)
+  : QObject(qApp)
+  , m_plugin(plugin)
+{
+    QBuffer buffer(&m_png);
+    if (!buffer.open(QIODevice::WriteOnly) || !capture.save(&buffer, "PNG")) {
+        m_png.clear();
+    }
+
+    m_timeout.setSingleShot(true);
+    connect(
+      &m_timeout, &QTimer::timeout, this, &ActionPluginRunner::processTimedOut);
+    connect(&m_process, &QProcess::started, this, [this]() {
+        m_process.write(m_png);
+        m_process.closeWriteChannel();
+    });
+    connect(&m_process,
+            qOverload<int, QProcess::ExitStatus>(&QProcess::finished),
+            this,
+            &ActionPluginRunner::processFinished);
+    connect(&m_process,
+            &QProcess::errorOccurred,
+            this,
+            [this](QProcess::ProcessError) { processFailed(); });
+    connect(&m_process, &QProcess::readyReadStandardOutput, this, [this]() {
+        collectOutput();
+    });
+    connect(&m_process, &QProcess::readyReadStandardError, this, [this]() {
+        collectOutput();
+    });
+}
+
+void ActionPluginRunner::start()
+{
+    if (m_png.isEmpty()) {
+        finishWithError(tr("Could not encode the capture as PNG."));
+        return;
+    }
+
+    QProcessEnvironment environment = QProcessEnvironment::systemEnvironment();
+    environment.remove("LD_PRELOAD");
+    environment.insert("FLAMESHOT_PLUGIN_API_VERSION",
+                       QString::number(ActionPluginLoader::ApiVersion));
+    environment.insert("FLAMESHOT_PLUGIN_ID", m_plugin.id);
+    environment.insert("FLAMESHOT_PLUGIN_DIR",
+                       QFileInfo(m_plugin.manifestPath).absolutePath());
+    const QString configDirectory =
+      QDir(
+        QStandardPaths::writableLocation(QStandardPaths::GenericConfigLocation))
+        .filePath(QStringLiteral("flameshot/plugins/%1").arg(m_plugin.id));
+    QDir().mkpath(configDirectory);
+    environment.insert("FLAMESHOT_PLUGIN_CONFIG_DIR", configDirectory);
+    m_process.setProcessEnvironment(environment);
+    m_process.setWorkingDirectory(
+      QFileInfo(m_plugin.manifestPath).absolutePath());
+    m_process.setProgram(m_plugin.executable);
+    m_process.setArguments(m_plugin.arguments);
+    m_timeout.start(m_plugin.timeoutMs);
+    m_process.start();
+}
+
+void ActionPluginRunner::processFinished(int exitCode,
+                                         QProcess::ExitStatus exitStatus)
+{
+    if (m_finished) {
+        return;
+    }
+    m_timeout.stop();
+    if (!collectOutput()) {
+        return;
+    }
+
+    const QString standardError = QString::fromUtf8(m_standardError).trimmed();
+    if (exitStatus != QProcess::NormalExit || exitCode != 0) {
+        finishWithError(standardError.isEmpty()
+                          ? tr("Plugin %1 failed with exit code %2.")
+                              .arg(m_plugin.name)
+                              .arg(exitCode)
+                          : standardError);
+        return;
+    }
+    finishSuccessfully(m_standardOutput);
+}
+
+bool ActionPluginRunner::collectOutput()
+{
+    if (m_finished) {
+        return false;
+    }
+    m_standardOutput.append(m_process.readAllStandardOutput());
+    m_standardError.append(m_process.readAllStandardError());
+    if (m_standardOutput.size() > MaxStandardOutputSize ||
+        m_standardError.size() > MaxStandardErrorSize) {
+        m_process.kill();
+        finishWithError(
+          tr("Plugin %1 produced too much output.").arg(m_plugin.name));
+        return false;
+    }
+    return true;
+}
+
+void ActionPluginRunner::processFailed()
+{
+    if (!m_finished) {
+        finishWithError(m_process.errorString());
+    }
+}
+
+void ActionPluginRunner::processTimedOut()
+{
+    if (m_finished) {
+        return;
+    }
+    m_process.kill();
+    finishWithError(tr("Plugin %1 timed out.").arg(m_plugin.name));
+}
+
+void ActionPluginRunner::finishWithError(const QString& message)
+{
+    if (m_finished) {
+        return;
+    }
+    m_finished = true;
+    m_timeout.stop();
+    SystemNotification().sendMessage(message, tr("Action Plugin Error"), {});
+    emit finished(false);
+    deleteLater();
+}
+
+void ActionPluginRunner::finishSuccessfully(const QByteArray& standardOutput)
+{
+    if (m_finished) {
+        return;
+    }
+    m_timeout.stop();
+
+    if (m_plugin.outputMode == ActionPlugin::OutputMode::ClipboardText) {
+        const QString text = QString::fromUtf8(standardOutput).trimmed();
+        if (text.isEmpty()) {
+            finishWithError(
+              tr("Plugin %1 returned no text.").arg(m_plugin.name));
+            return;
+        }
+        FlameshotDaemon::copyToClipboard(
+          text, tr("%1 output copied to clipboard.").arg(m_plugin.name));
+    } else if (m_plugin.outputMode == ActionPlugin::OutputMode::Json) {
+        if (!handleJsonResult(standardOutput)) {
+            return;
+        }
+    } else {
+        SystemNotification().sendMessage(
+          tr("Plugin finished successfully."), m_plugin.name, {});
+    }
+    m_finished = true;
+    emit finished(true);
+    deleteLater();
+}
+
+bool ActionPluginRunner::handleJsonResult(const QByteArray& standardOutput)
+{
+    QJsonParseError parseError;
+    const QJsonDocument document =
+      QJsonDocument::fromJson(standardOutput, &parseError);
+    if (parseError.error != QJsonParseError::NoError || !document.isObject()) {
+        const QString detail = parseError.error == QJsonParseError::NoError
+                                 ? tr("the root value is not an object")
+                                 : parseError.errorString();
+        finishWithError(tr("Plugin %1 returned invalid result JSON: %2")
+                          .arg(m_plugin.name, detail));
+        return false;
+    }
+
+    const QJsonObject root = document.object();
+    if (root.value("protocol_version").toInt(-1) !=
+        ActionPluginLoader::ApiVersion) {
+        finishWithError(
+          tr("Plugin %1 returned an unsupported protocol version.")
+            .arg(m_plugin.name));
+        return false;
+    }
+
+    const QString status = root.value("status").toString();
+    if (status == QLatin1String("error")) {
+        const QString message = root.value("message").toString().trimmed();
+        finishWithError(
+          message.isEmpty()
+            ? tr("Plugin %1 reported an error.").arg(m_plugin.name)
+            : message);
+        return false;
+    }
+    if (status != QLatin1String("success")) {
+        finishWithError(tr("Plugin %1 returned an invalid result status.")
+                          .arg(m_plugin.name));
+        return false;
+    }
+
+    const QJsonObject result = root.value("result").toObject();
+    const QString type = result.value("type").toString();
+    if (type == QLatin1String("clipboard-text")) {
+        const QString text = result.value("text").toString();
+        if (text.isEmpty()) {
+            finishWithError(
+              tr("Plugin %1 returned no text.").arg(m_plugin.name));
+            return false;
+        }
+        FlameshotDaemon::copyToClipboard(
+          text, tr("%1 output copied to clipboard.").arg(m_plugin.name));
+        return true;
+    }
+    if (type == QLatin1String("notification")) {
+        const QString text = result.value("text").toString();
+        const QString title = result.value("title").toString(m_plugin.name);
+        if (text.isEmpty()) {
+            finishWithError(tr("Plugin %1 returned an empty notification.")
+                              .arg(m_plugin.name));
+            return false;
+        }
+        SystemNotification().sendMessage(text, title, {});
+        return true;
+    }
+    if (type == QLatin1String("none")) {
+        return true;
+    }
+
+    finishWithError(tr("Plugin %1 returned unsupported result type '%2'.")
+                      .arg(m_plugin.name, type));
+    return false;
+}

--- a/src/plugins/actionpluginrunner.h
+++ b/src/plugins/actionpluginrunner.h
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include "actionplugin.h"
+
+#include <QByteArray>
+#include <QObject>
+#include <QProcess>
+#include <QTimer>
+
+class QPixmap;
+
+class ActionPluginRunner : public QObject
+{
+    Q_OBJECT
+public:
+    static ActionPluginRunner* run(const ActionPlugin& plugin,
+                                   const QPixmap& capture);
+
+signals:
+    void finished(bool success);
+
+private slots:
+    void processFinished(int exitCode, QProcess::ExitStatus exitStatus);
+    void processFailed();
+    void processTimedOut();
+
+private:
+    explicit ActionPluginRunner(const ActionPlugin& plugin,
+                                const QPixmap& capture);
+
+    void start();
+    bool collectOutput();
+    void finishWithError(const QString& message);
+    void finishSuccessfully(const QByteArray& standardOutput);
+    bool handleJsonResult(const QByteArray& standardOutput);
+
+    ActionPlugin m_plugin;
+    QByteArray m_png;
+    QByteArray m_standardOutput;
+    QByteArray m_standardError;
+    QProcess m_process;
+    QTimer m_timeout;
+    bool m_finished = false;
+};

--- a/src/plugins/pluginmanager.cpp
+++ b/src/plugins/pluginmanager.cpp
@@ -1,0 +1,453 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "pluginmanager.h"
+
+#include "utils/confighandler.h"
+
+#include <QCoreApplication>
+#include <QDir>
+#include <QDirIterator>
+#include <QFile>
+#include <QFileInfo>
+#include <QProcess>
+#include <QProcessEnvironment>
+#include <QRegularExpression>
+#include <QStandardPaths>
+#include <QTemporaryDir>
+#include <QTextStream>
+
+namespace {
+constexpr qint64 MaxPackageSize = 32 * 1024 * 1024;
+constexpr qint64 MaxInstalledSize = 64 * 1024 * 1024;
+constexpr int MaxFileCount = 1000;
+
+PluginManagerResult failure(const QString& message)
+{
+    return { false, message };
+}
+
+PluginManagerResult success(const QString& message)
+{
+    return { true, message };
+}
+
+bool validateRelativePath(const QString& path)
+{
+    if (path.isEmpty() || QDir::isAbsolutePath(path) ||
+        path.contains(QLatin1Char('\0')) || path.contains(QLatin1Char('\n')) ||
+        path.contains(QLatin1Char('\r'))) {
+        return false;
+    }
+    const QString clean = QDir::cleanPath(path);
+    return clean != QLatin1String("..") &&
+           !clean.startsWith(QLatin1String("../"));
+}
+
+bool inspectTree(const QString& root, QString* error)
+{
+    QDir rootDirectory(root);
+    QDirIterator iterator(root,
+                          QDir::AllEntries | QDir::NoDotAndDotDot |
+                            QDir::Hidden | QDir::System,
+                          QDirIterator::Subdirectories);
+    qint64 totalSize = 0;
+    int fileCount = 0;
+    while (iterator.hasNext()) {
+        const QString path = iterator.next();
+        const QFileInfo info(path);
+        const QString relative = rootDirectory.relativeFilePath(path);
+        if (!validateRelativePath(relative) || info.isSymLink()) {
+            *error = QCoreApplication::translate("PluginManager",
+                                                 "Unsafe package entry: %1")
+                       .arg(relative);
+            return false;
+        }
+        if (!info.isDir() && !info.isFile()) {
+            *error = QCoreApplication::translate(
+                       "PluginManager", "Unsupported package entry: %1")
+                       .arg(relative);
+            return false;
+        }
+        if (info.isFile()) {
+            totalSize += info.size();
+            ++fileCount;
+            if (totalSize > MaxInstalledSize || fileCount > MaxFileCount) {
+                *error = QCoreApplication::translate(
+                  "PluginManager", "Plugin package exceeds the safety limits.");
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+bool copyTree(const QString& source, const QString& target, QString* error)
+{
+    if (!inspectTree(source, error)) {
+        return false;
+    }
+
+    QDir sourceDirectory(source);
+    QDirIterator iterator(source,
+                          QDir::AllEntries | QDir::NoDotAndDotDot |
+                            QDir::Hidden | QDir::System,
+                          QDirIterator::Subdirectories);
+    while (iterator.hasNext()) {
+        const QString sourcePath = iterator.next();
+        const QFileInfo info(sourcePath);
+        const QString relative = sourceDirectory.relativeFilePath(sourcePath);
+        const QString targetPath = QDir(target).filePath(relative);
+        if (info.isDir()) {
+            if (!QDir().mkpath(targetPath)) {
+                *error = QCoreApplication::translate("PluginManager",
+                                                     "Could not create %1")
+                           .arg(targetPath);
+                return false;
+            }
+        } else {
+            if (!QDir().mkpath(QFileInfo(targetPath).absolutePath()) ||
+                !QFile::copy(sourcePath, targetPath)) {
+                *error = QCoreApplication::translate("PluginManager",
+                                                     "Could not copy %1")
+                           .arg(relative);
+                return false;
+            }
+            QFile::setPermissions(targetPath, info.permissions());
+        }
+    }
+    return true;
+}
+
+bool runTar(const QStringList& arguments,
+            QByteArray* standardOutput,
+            QString* error)
+{
+    const QString tar = QStandardPaths::findExecutable(QStringLiteral("tar"));
+    if (tar.isEmpty()) {
+        *error = QCoreApplication::translate(
+          "PluginManager", "The tar command is required to install packages.");
+        return false;
+    }
+
+    QProcess process;
+    QProcessEnvironment environment = QProcessEnvironment::systemEnvironment();
+    environment.insert(QStringLiteral("LC_ALL"), QStringLiteral("C"));
+    process.setProcessEnvironment(environment);
+    process.start(tar, arguments);
+    if (!process.waitForFinished(30000) ||
+        process.exitStatus() != QProcess::NormalExit ||
+        process.exitCode() != 0) {
+        *error = QString::fromUtf8(process.readAllStandardError()).trimmed();
+        if (error->isEmpty()) {
+            *error = QCoreApplication::translate(
+              "PluginManager", "Could not read the plugin package.");
+        }
+        return false;
+    }
+    if (standardOutput) {
+        *standardOutput = process.readAllStandardOutput();
+    }
+    return true;
+}
+
+bool extractPackage(const QString& packagePath,
+                    const QString& target,
+                    QString* error)
+{
+    const QFileInfo packageInfo(packagePath);
+    if (!packageInfo.isFile() || packageInfo.size() > MaxPackageSize) {
+        *error = QCoreApplication::translate(
+          "PluginManager", "Plugin package is missing or too large.");
+        return false;
+    }
+
+    QByteArray listing;
+    if (!runTar({ QStringLiteral("--list"),
+                  QStringLiteral("--file"),
+                  packageInfo.absoluteFilePath() },
+                &listing,
+                error)) {
+        return false;
+    }
+    const QList<QByteArray> entries = listing.split('\n');
+    int entryCount = 0;
+    for (const QByteArray& rawEntry : entries) {
+        if (rawEntry.isEmpty()) {
+            continue;
+        }
+        ++entryCount;
+        const QString entry = QString::fromUtf8(rawEntry);
+        if (entryCount > MaxFileCount || !validateRelativePath(entry)) {
+            *error = QCoreApplication::translate("PluginManager",
+                                                 "Unsafe package entry: %1")
+                       .arg(entry);
+            return false;
+        }
+    }
+
+    QByteArray verboseListing;
+    if (!runTar({ QStringLiteral("--list"),
+                  QStringLiteral("--verbose"),
+                  QStringLiteral("--file"),
+                  packageInfo.absoluteFilePath() },
+                &verboseListing,
+                error)) {
+        return false;
+    }
+    for (const QByteArray& line : verboseListing.split('\n')) {
+        if (!line.isEmpty() && line.at(0) != '-' && line.at(0) != 'd') {
+            *error =
+              QCoreApplication::translate("PluginManager",
+                                          "Plugin packages may contain only "
+                                          "regular files and directories.");
+            return false;
+        }
+    }
+
+    if (!runTar({ QStringLiteral("--extract"),
+                  QStringLiteral("--file"),
+                  packageInfo.absoluteFilePath(),
+                  QStringLiteral("--directory"),
+                  target,
+                  QStringLiteral("--no-same-owner"),
+                  QStringLiteral("--no-same-permissions") },
+                nullptr,
+                error)) {
+        return false;
+    }
+    return inspectTree(target, error);
+}
+
+ActionPlugin findPlugin(const QString& pluginId, bool* found)
+{
+    const QList<ActionPlugin> plugins =
+      ActionPluginLoader::discover(ActionPluginLoader::pluginRoots());
+    for (const ActionPlugin& plugin : plugins) {
+        if (plugin.id == pluginId) {
+            *found = true;
+            return plugin;
+        }
+    }
+    *found = false;
+    return {};
+}
+
+void printPluginHelp(QTextStream& output)
+{
+    output
+      << "Usage:\n"
+         "  flameshot plugins list\n"
+         "  flameshot plugins install <directory|package.flameshot-plugin>\n"
+         "  flameshot plugins enable <plugin-id>\n"
+         "  flameshot plugins disable <plugin-id>\n"
+         "  flameshot plugins remove <plugin-id>\n"
+         "  flameshot plugins doctor\n"
+         "  flameshot plugins roots\n";
+}
+} // namespace
+
+PluginManagerResult PluginManager::install(const QString& sourcePath)
+{
+    const QFileInfo sourceInfo(sourcePath);
+    if (!sourceInfo.exists()) {
+        return failure(QCoreApplication::translate("PluginManager",
+                                                   "Source does not exist: %1")
+                         .arg(sourcePath));
+    }
+
+    const QString root = ActionPluginLoader::userPluginRoot();
+    if (!QDir().mkpath(root)) {
+        return failure(QCoreApplication::translate(
+                         "PluginManager", "Could not create plugin root: %1")
+                         .arg(root));
+    }
+
+    QTemporaryDir staging(
+      QDir(root).filePath(QStringLiteral(".install-XXXXXX")));
+    if (!staging.isValid()) {
+        return failure(QCoreApplication::translate(
+          "PluginManager", "Could not create a temporary install directory."));
+    }
+
+    QString error;
+    const bool prepared =
+      sourceInfo.isDir()
+        ? copyTree(sourceInfo.absoluteFilePath(), staging.path(), &error)
+        : extractPackage(sourceInfo.absoluteFilePath(), staging.path(), &error);
+    if (!prepared) {
+        return failure(error);
+    }
+
+    ActionPlugin plugin;
+    if (!ActionPluginLoader::loadManifest(
+          QDir(staging.path()).filePath(QStringLiteral("metadata.json")),
+          &plugin,
+          &error)) {
+        return failure(QCoreApplication::translate(
+                         "PluginManager", "Invalid plugin manifest: %1")
+                         .arg(error));
+    }
+
+    const QString target = QDir(root).filePath(plugin.id);
+    if (QFileInfo::exists(target)) {
+        return failure(
+          QCoreApplication::translate(
+            "PluginManager", "Plugin %1 is already installed for this user.")
+            .arg(plugin.id));
+    }
+    staging.setAutoRemove(false);
+    if (!QDir().rename(staging.path(), target)) {
+        staging.setAutoRemove(true);
+        return failure(QCoreApplication::translate(
+                         "PluginManager", "Could not activate plugin %1.")
+                         .arg(plugin.id));
+    }
+    ConfigHandler().setPluginEnabled(plugin.id, plugin.toolbarVisible);
+    return success(
+      QCoreApplication::translate("PluginManager", "Installed plugin %1 in %2")
+        .arg(plugin.id, target));
+}
+
+PluginManagerResult PluginManager::remove(const QString& pluginId)
+{
+    if (!validPluginId(pluginId)) {
+        return failure(
+          QCoreApplication::translate("PluginManager", "Invalid plugin id."));
+    }
+    const QString target =
+      QDir(ActionPluginLoader::userPluginRoot()).filePath(pluginId);
+    const QFileInfo info(target);
+    if (!info.isDir() || info.isSymLink()) {
+        return failure(QCoreApplication::translate(
+          "PluginManager", "Plugin is not installed in the user plugin root."));
+    }
+    if (!QDir(target).removeRecursively()) {
+        return failure(QCoreApplication::translate(
+                         "PluginManager", "Could not remove plugin %1.")
+                         .arg(pluginId));
+    }
+    return success(
+      QCoreApplication::translate("PluginManager", "Removed plugin %1.")
+        .arg(pluginId));
+}
+
+PluginManagerResult PluginManager::setEnabled(const QString& pluginId,
+                                              bool enabled)
+{
+    bool found = false;
+    findPlugin(pluginId, &found);
+    if (!found) {
+        return failure(QCoreApplication::translate("PluginManager",
+                                                   "Plugin %1 was not found.")
+                         .arg(pluginId));
+    }
+    ConfigHandler().setPluginEnabled(pluginId, enabled);
+    return success(
+      QCoreApplication::translate("PluginManager", "Plugin %1 is now %2.")
+        .arg(pluginId,
+             enabled ? QStringLiteral("enabled") : QStringLiteral("disabled")));
+}
+
+QList<ActionPlugin> PluginManager::list(QStringList* errors)
+{
+    return ActionPluginLoader::discover(ActionPluginLoader::pluginRoots(),
+                                        errors);
+}
+
+QStringList PluginManager::doctor(bool* healthy)
+{
+    QStringList messages;
+    QStringList errors;
+    const QList<ActionPlugin> plugins = list(&errors);
+    for (const QString& root : ActionPluginLoader::pluginRoots()) {
+        messages.append(
+          QCoreApplication::translate("PluginManager", "Search root: %1%2")
+            .arg(root,
+                 QDir(root).exists() ? QStringLiteral(" [present]")
+                                     : QStringLiteral(" [missing]")));
+    }
+    for (const ActionPlugin& plugin : plugins) {
+        messages.append(
+          QCoreApplication::translate("PluginManager", "OK: %1 -> %2")
+            .arg(plugin.id, plugin.executable));
+    }
+    for (const QString& error : errors) {
+        messages.append(
+          QCoreApplication::translate("PluginManager", "ERROR: %1").arg(error));
+    }
+    if (healthy) {
+        *healthy = errors.isEmpty();
+    }
+    return messages;
+}
+
+bool PluginManager::validPluginId(const QString& pluginId)
+{
+    static const QRegularExpression expression(
+      QStringLiteral("^[a-z0-9]+(?:[._-][a-z0-9]+)+$"));
+    return expression.match(pluginId).hasMatch();
+}
+
+int PluginManagerCli::run(const QStringList& arguments)
+{
+    QTextStream output(stdout);
+    QTextStream errorOutput(stderr);
+    if (arguments.isEmpty() || arguments.first() == QLatin1String("help") ||
+        arguments.first() == QLatin1String("--help") ||
+        arguments.first() == QLatin1String("-h")) {
+        printPluginHelp(output);
+        return 0;
+    }
+
+    const QString command = arguments.first();
+    if (command == QLatin1String("list")) {
+        QStringList errors;
+        const QList<ActionPlugin> plugins = PluginManager::list(&errors);
+        ConfigHandler config;
+        for (const ActionPlugin& plugin : plugins) {
+            output << (config.pluginEnabled(plugin.id, plugin.toolbarVisible)
+                         ? "enabled  "
+                         : "disabled ")
+                   << plugin.id << "\t" << plugin.name << "\n";
+        }
+        for (const QString& message : errors) {
+            errorOutput << "error: " << message << "\n";
+        }
+        return errors.isEmpty() ? 0 : 1;
+    }
+    if (command == QLatin1String("doctor")) {
+        bool healthy = false;
+        for (const QString& message : PluginManager::doctor(&healthy)) {
+            output << message << "\n";
+        }
+        return healthy ? 0 : 1;
+    }
+    if (command == QLatin1String("roots")) {
+        for (const QString& root : ActionPluginLoader::pluginRoots()) {
+            output << root << "\n";
+        }
+        return 0;
+    }
+
+    if (arguments.size() != 2) {
+        printPluginHelp(errorOutput);
+        return 2;
+    }
+    PluginManagerResult result;
+    if (command == QLatin1String("install")) {
+        result = PluginManager::install(arguments.at(1));
+    } else if (command == QLatin1String("enable")) {
+        result = PluginManager::setEnabled(arguments.at(1), true);
+    } else if (command == QLatin1String("disable")) {
+        result = PluginManager::setEnabled(arguments.at(1), false);
+    } else if (command == QLatin1String("remove")) {
+        result = PluginManager::remove(arguments.at(1));
+    } else {
+        errorOutput << "Unknown plugins command: " << command << "\n";
+        printPluginHelp(errorOutput);
+        return 2;
+    }
+
+    (result.success ? output : errorOutput) << result.message << "\n";
+    return result.success ? 0 : 1;
+}

--- a/src/plugins/pluginmanager.h
+++ b/src/plugins/pluginmanager.h
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include "actionplugin.h"
+
+#include <QString>
+#include <QStringList>
+
+struct PluginManagerResult
+{
+    bool success = false;
+    QString message;
+};
+
+class PluginManager
+{
+public:
+    static PluginManagerResult install(const QString& sourcePath);
+    static PluginManagerResult remove(const QString& pluginId);
+    static PluginManagerResult setEnabled(const QString& pluginId,
+                                          bool enabled);
+    static QList<ActionPlugin> list(QStringList* errors = nullptr);
+    static QStringList doctor(bool* healthy = nullptr);
+
+private:
+    static bool validPluginId(const QString& pluginId);
+};
+
+class PluginManagerCli
+{
+public:
+    static int run(const QStringList& arguments);
+};

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -56,6 +56,10 @@ target_sources(
           text/texttool.cpp
           text/textwidget.cpp)
 target_sources(flameshot PRIVATE undo/undotool.h undo/undotool.cpp)
+target_sources(
+  flameshot
+  PRIVATE plugin/plugintool.h
+          plugin/plugintool.cpp)
 
 target_sources(
   flameshot
@@ -63,9 +67,11 @@ target_sources(
           abstractpathtool.cpp
           abstracttwopointtool.cpp
           capturecontext.cpp
+          toolregistry.cpp
           toolfactory.cpp
           abstractactiontool.h
           abstractpathtool.h
           abstracttwopointtool.h
           capturetool.h
+          toolregistry.h
           toolfactory.h)

--- a/src/tools/capturetool.h
+++ b/src/tools/capturetool.h
@@ -51,6 +51,7 @@ public:
         TYPE_INVERT = 22,
         TYPE_ACCEPT = 23,
         TYPE_CANCEL = 24,
+        TYPE_PLUGIN = 25,
     };
     Q_ENUM(Type);
 

--- a/src/tools/plugin/plugintool.cpp
+++ b/src/tools/plugin/plugintool.cpp
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "plugintool.h"
+#include "plugins/actionpluginrunner.h"
+
+PluginActionTool::PluginActionTool(const ActionPlugin& plugin, QObject* parent)
+  : AbstractActionTool(parent)
+  , m_plugin(plugin)
+{}
+
+bool PluginActionTool::closeOnButtonPressed() const
+{
+    return true;
+}
+
+QIcon PluginActionTool::icon(const QColor& background, bool inEditor) const
+{
+    Q_UNUSED(inEditor)
+    if (!m_plugin.icon.isNull()) {
+        return m_plugin.icon;
+    }
+    return QIcon(iconPath(background) + "apps.svg");
+}
+
+QString PluginActionTool::name() const
+{
+    return m_plugin.name;
+}
+
+CaptureTool::Type PluginActionTool::type() const
+{
+    return CaptureTool::TYPE_PLUGIN;
+}
+
+QString PluginActionTool::description() const
+{
+    return m_plugin.description;
+}
+
+CaptureTool* PluginActionTool::copy(QObject* parent)
+{
+    return new PluginActionTool(m_plugin, parent);
+}
+
+void PluginActionTool::pressed(CaptureContext& context)
+{
+    ActionPluginRunner* runner =
+      ActionPluginRunner::run(m_plugin, context.selectedScreenshotArea());
+    connect(runner, &ActionPluginRunner::finished, this, [this](bool) {
+        emit requestAction(REQ_CLOSE_GUI);
+    });
+    emit requestAction(REQ_CAPTURE_DONE_OK);
+    emit requestAction(REQ_HIDE_GUI);
+}

--- a/src/tools/plugin/plugintool.h
+++ b/src/tools/plugin/plugintool.h
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include "plugins/actionplugin.h"
+#include "tools/abstractactiontool.h"
+
+class PluginActionTool : public AbstractActionTool
+{
+    Q_OBJECT
+public:
+    explicit PluginActionTool(const ActionPlugin& plugin,
+                              QObject* parent = nullptr);
+
+    bool closeOnButtonPressed() const override;
+    QIcon icon(const QColor& background, bool inEditor) const override;
+    QString name() const override;
+    CaptureTool::Type type() const override;
+    QString description() const override;
+    CaptureTool* copy(QObject* parent = nullptr) override;
+
+public slots:
+    void pressed(CaptureContext& context) override;
+
+private:
+    ActionPlugin m_plugin;
+};

--- a/src/tools/toolregistry.cpp
+++ b/src/tools/toolregistry.cpp
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "toolregistry.h"
+
+#include "tools/plugin/plugintool.h"
+#include "tools/toolfactory.h"
+#include "utils/confighandler.h"
+
+#include <QSet>
+
+#include <algorithm>
+
+ToolRegistry::ToolRegistry()
+{
+    QSet<QString> knownIds;
+    for (const CaptureTool::Type type : builtInTypes()) {
+        ToolDescriptor descriptor;
+        descriptor.id = builtInId(type);
+        descriptor.legacyType = type;
+        descriptor.order = builtInPriority(type) * 10;
+        m_tools.append(descriptor);
+        knownIds.insert(descriptor.id);
+    }
+
+    const QList<ActionPlugin> plugins = ActionPluginLoader::discover(
+      ActionPluginLoader::pluginRoots(), &m_pluginErrors);
+    ConfigHandler config;
+    for (const ActionPlugin& plugin : plugins) {
+        if (knownIds.contains(plugin.id)) {
+            m_pluginErrors.append(
+              QStringLiteral("%1: plugin id collides with a built-in tool")
+                .arg(plugin.id));
+            continue;
+        }
+        knownIds.insert(plugin.id);
+        ToolDescriptor descriptor;
+        descriptor.id = plugin.id;
+        descriptor.provider = ToolDescriptor::Provider::ExternalAction;
+        descriptor.legacyType = CaptureTool::TYPE_PLUGIN;
+        descriptor.order = plugin.toolbarOrder;
+        descriptor.toolbarVisible =
+          config.pluginEnabled(plugin.id, plugin.toolbarVisible);
+        descriptor.shortcut = config.pluginShortcut(plugin.id, plugin.shortcut);
+        descriptor.actionPlugin = plugin;
+        m_tools.append(descriptor);
+    }
+
+    std::stable_sort(
+      m_tools.begin(),
+      m_tools.end(),
+      [](const ToolDescriptor& left, const ToolDescriptor& right) {
+          if (left.order != right.order) {
+              return left.order < right.order;
+          }
+          return left.id < right.id;
+      });
+}
+
+const QList<ToolDescriptor>& ToolRegistry::tools() const
+{
+    return m_tools;
+}
+
+const QStringList& ToolRegistry::pluginErrors() const
+{
+    return m_pluginErrors;
+}
+
+CaptureTool* ToolRegistry::createTool(const ToolDescriptor& descriptor,
+                                      QObject* parent)
+{
+    if (descriptor.provider == ToolDescriptor::Provider::ExternalAction) {
+        return new PluginActionTool(descriptor.actionPlugin, parent);
+    }
+    return ToolFactory().CreateTool(descriptor.legacyType, parent);
+}
+
+const QList<CaptureTool::Type>& ToolRegistry::builtInTypes()
+{
+    static const QList<CaptureTool::Type> types = {
+        CaptureTool::TYPE_PENCIL,        CaptureTool::TYPE_DRAWER,
+        CaptureTool::TYPE_ARROW,         CaptureTool::TYPE_SELECTION,
+        CaptureTool::TYPE_RECTANGLE,     CaptureTool::TYPE_CIRCLE,
+        CaptureTool::TYPE_MARKER,        CaptureTool::TYPE_TEXT,
+        CaptureTool::TYPE_CIRCLECOUNT,   CaptureTool::TYPE_PIXELATE,
+        CaptureTool::TYPE_INVERT,        CaptureTool::TYPE_MOVESELECTION,
+        CaptureTool::TYPE_UNDO,          CaptureTool::TYPE_REDO,
+        CaptureTool::TYPE_COPY,          CaptureTool::TYPE_SAVE,
+        CaptureTool::TYPE_EXIT,
+#ifdef ENABLE_IMGUR
+        CaptureTool::TYPE_IMAGEUPLOADER,
+#endif
+#if !defined(Q_OS_MACOS)
+        CaptureTool::TYPE_OPEN_APP,
+#endif
+        CaptureTool::TYPE_PIN,           CaptureTool::TYPE_SIZEINCREASE,
+        CaptureTool::TYPE_SIZEDECREASE,  CaptureTool::TYPE_ACCEPT,
+    };
+    return types;
+}
+
+int ToolRegistry::builtInPriority(CaptureTool::Type type)
+{
+    switch (type) {
+        case CaptureTool::TYPE_PENCIL:
+            return 0;
+        case CaptureTool::TYPE_DRAWER:
+            return 1;
+        case CaptureTool::TYPE_ARROW:
+            return 2;
+        case CaptureTool::TYPE_SELECTION:
+            return 3;
+        case CaptureTool::TYPE_RECTANGLE:
+            return 4;
+        case CaptureTool::TYPE_CIRCLE:
+            return 5;
+        case CaptureTool::TYPE_MARKER:
+            return 6;
+        case CaptureTool::TYPE_TEXT:
+            return 7;
+        case CaptureTool::TYPE_PIXELATE:
+            return 8;
+        case CaptureTool::TYPE_INVERT:
+            return 9;
+        case CaptureTool::TYPE_CIRCLECOUNT:
+            return 10;
+        case CaptureTool::TYPE_MOVESELECTION:
+            return 12;
+        case CaptureTool::TYPE_UNDO:
+            return 13;
+        case CaptureTool::TYPE_REDO:
+            return 14;
+        case CaptureTool::TYPE_COPY:
+            return 15;
+        case CaptureTool::TYPE_SAVE:
+            return 16;
+#ifdef ENABLE_IMGUR
+        case CaptureTool::TYPE_IMAGEUPLOADER:
+            return 17;
+#endif
+        case CaptureTool::TYPE_ACCEPT:
+            return 18;
+#if !defined(Q_OS_MACOS)
+        case CaptureTool::TYPE_OPEN_APP:
+            return 19;
+#endif
+        case CaptureTool::TYPE_EXIT:
+            return 20;
+        case CaptureTool::TYPE_PIN:
+            return 21;
+        case CaptureTool::TYPE_SIZEINCREASE:
+            return 22;
+        case CaptureTool::TYPE_SIZEDECREASE:
+            return 23;
+        default:
+            return 1000;
+    }
+}
+
+QString ToolRegistry::builtInId(CaptureTool::Type type)
+{
+    switch (type) {
+        case CaptureTool::TYPE_PENCIL:
+            return QStringLiteral("org.flameshot.pencil");
+        case CaptureTool::TYPE_DRAWER:
+            return QStringLiteral("org.flameshot.line");
+        case CaptureTool::TYPE_ARROW:
+            return QStringLiteral("org.flameshot.arrow");
+        case CaptureTool::TYPE_SELECTION:
+            return QStringLiteral("org.flameshot.selection");
+        case CaptureTool::TYPE_RECTANGLE:
+            return QStringLiteral("org.flameshot.rectangle");
+        case CaptureTool::TYPE_CIRCLE:
+            return QStringLiteral("org.flameshot.circle");
+        case CaptureTool::TYPE_MARKER:
+            return QStringLiteral("org.flameshot.marker");
+        case CaptureTool::TYPE_MOVESELECTION:
+            return QStringLiteral("org.flameshot.move-selection");
+        case CaptureTool::TYPE_UNDO:
+            return QStringLiteral("org.flameshot.undo");
+        case CaptureTool::TYPE_COPY:
+            return QStringLiteral("org.flameshot.copy");
+        case CaptureTool::TYPE_SAVE:
+            return QStringLiteral("org.flameshot.save");
+        case CaptureTool::TYPE_EXIT:
+            return QStringLiteral("org.flameshot.exit");
+#ifdef ENABLE_IMGUR
+        case CaptureTool::TYPE_IMAGEUPLOADER:
+            return QStringLiteral("org.flameshot.imgur-upload");
+#endif
+#if !defined(Q_OS_MACOS)
+        case CaptureTool::TYPE_OPEN_APP:
+            return QStringLiteral("org.flameshot.open-app");
+#endif
+        case CaptureTool::TYPE_PIXELATE:
+            return QStringLiteral("org.flameshot.pixelate");
+        case CaptureTool::TYPE_REDO:
+            return QStringLiteral("org.flameshot.redo");
+        case CaptureTool::TYPE_PIN:
+            return QStringLiteral("org.flameshot.pin");
+        case CaptureTool::TYPE_TEXT:
+            return QStringLiteral("org.flameshot.text");
+        case CaptureTool::TYPE_CIRCLECOUNT:
+            return QStringLiteral("org.flameshot.circle-counter");
+        case CaptureTool::TYPE_SIZEINCREASE:
+            return QStringLiteral("org.flameshot.size-increase");
+        case CaptureTool::TYPE_SIZEDECREASE:
+            return QStringLiteral("org.flameshot.size-decrease");
+        case CaptureTool::TYPE_INVERT:
+            return QStringLiteral("org.flameshot.invert");
+        case CaptureTool::TYPE_ACCEPT:
+            return QStringLiteral("org.flameshot.accept");
+        default:
+            return {};
+    }
+}

--- a/src/tools/toolregistry.h
+++ b/src/tools/toolregistry.h
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include "plugins/actionplugin.h"
+#include "tools/capturetool.h"
+
+#include <QList>
+#include <QString>
+#include <QStringList>
+
+struct ToolDescriptor
+{
+    enum class Provider
+    {
+        BuiltIn,
+        ExternalAction,
+    };
+
+    QString id;
+    Provider provider = Provider::BuiltIn;
+    CaptureTool::Type legacyType = CaptureTool::NONE;
+    int order = 0;
+    bool toolbarVisible = true;
+    QString shortcut;
+    ActionPlugin actionPlugin;
+
+    bool isExternal() const { return provider == Provider::ExternalAction; }
+};
+
+class ToolRegistry
+{
+public:
+    ToolRegistry();
+
+    const QList<ToolDescriptor>& tools() const;
+    const QStringList& pluginErrors() const;
+
+    static CaptureTool* createTool(const ToolDescriptor& descriptor,
+                                   QObject* parent = nullptr);
+    static const QList<CaptureTool::Type>& builtInTypes();
+    static int builtInPriority(CaptureTool::Type type);
+    static QString builtInId(CaptureTool::Type type);
+
+private:
+    QList<ToolDescriptor> m_tools;
+    QStringList m_pluginErrors;
+};

--- a/src/utils/confighandler.cpp
+++ b/src/utils/confighandler.cpp
@@ -173,6 +173,9 @@ static QMap<QString, QSharedPointer<KeySequence>> recognizedShortcuts = {
 #ifdef ENABLE_IMGUR
     SHORTCUT("TYPE_IMAGEUPLOADER"       ,                           ),
 #endif
+    // Legacy key from the first action-plugin prototype. External tools now
+    // keep shortcuts under Plugins/<id>/shortcut.
+    SHORTCUT("TYPE_PLUGIN"              ,                           ),
 #if !defined(Q_OS_MACOS)
     SHORTCUT("TYPE_OPEN_APP"            ,   "Ctrl+O"                ),
 #endif
@@ -398,6 +401,41 @@ int ConfigHandler::toolSize(CaptureTool::Type toolType)
         // All other tools are sharing the same size
         return drawThickness();
     }
+}
+
+bool ConfigHandler::pluginEnabled(const QString& pluginId,
+                                  bool defaultValue) const
+{
+    return m_settings
+      .value(QStringLiteral(CONFIG_GROUP_PLUGINS "/%1/enabled").arg(pluginId),
+             defaultValue)
+      .toBool();
+}
+
+void ConfigHandler::setPluginEnabled(const QString& pluginId, bool enabled)
+{
+    m_skipNextErrorCheck = true;
+    m_settings.setValue(
+      QStringLiteral(CONFIG_GROUP_PLUGINS "/%1/enabled").arg(pluginId),
+      enabled);
+}
+
+QString ConfigHandler::pluginShortcut(const QString& pluginId,
+                                      const QString& defaultValue) const
+{
+    return m_settings
+      .value(QStringLiteral(CONFIG_GROUP_PLUGINS "/%1/shortcut").arg(pluginId),
+             defaultValue)
+      .toString();
+}
+
+void ConfigHandler::setPluginShortcut(const QString& pluginId,
+                                      const QString& shortcut)
+{
+    m_skipNextErrorCheck = true;
+    m_settings.setValue(
+      QStringLiteral(CONFIG_GROUP_PLUGINS "/%1/shortcut").arg(pluginId),
+      shortcut);
 }
 
 // DEFAULTS

--- a/src/utils/confighandler.h
+++ b/src/utils/confighandler.h
@@ -12,6 +12,7 @@
 
 #define CONFIG_GROUP_GENERAL "General"
 #define CONFIG_GROUP_SHORTCUTS "Shortcuts"
+#define CONFIG_GROUP_PLUGINS "Plugins"
 
 class QFileSystemWatcher;
 class ValueHandler;
@@ -164,6 +165,11 @@ public:
     void setAllTheButtons();
     void setToolSize(CaptureTool::Type toolType, int size);
     int toolSize(CaptureTool::Type toolType);
+    bool pluginEnabled(const QString& pluginId, bool defaultValue) const;
+    void setPluginEnabled(const QString& pluginId, bool enabled);
+    QString pluginShortcut(const QString& pluginId,
+                           const QString& defaultValue) const;
+    void setPluginShortcut(const QString& pluginId, const QString& shortcut);
 
     // DEFAULTS
     QString filenamePatternDefault();

--- a/src/widgets/capture/buttonhandler.cpp
+++ b/src/widgets/capture/buttonhandler.cpp
@@ -7,6 +7,9 @@
 #include <QPoint>
 #include <QScreen>
 
+#include <algorithm>
+#include <numeric>
+
 // ButtonHandler is a handler for every active button. It makes easier to
 // manipulate the buttons as a unit.
 
@@ -67,7 +70,7 @@ size_t ButtonHandler::size() const
 // selection area. Ignores the sides blocked by the end of the screen.
 // When the selection is too small, it works on a virtual selection with
 // the original in the center.
-void ButtonHandler::updatePosition(const QRect& selection)
+void ButtonHandler::updatePosition(const QRect& selection, const QPoint& anchor)
 {
     resetRegionTrack();
     const int vecLength = m_vectorButtons.size();
@@ -80,13 +83,18 @@ void ButtonHandler::updatePosition(const QRect& selection)
     ensureSelectionMinimumSize();
     // Indicates the actual button to be moved
     int elemIndicator = 0;
+    // Collect the available slots before assigning buttons. This keeps the
+    // existing screen-edge layout while allowing primary actions to follow
+    // the pointer.
+    QVector<QPoint> buttonPositions;
+    buttonPositions.reserve(vecLength);
 
     while (elemIndicator < vecLength) {
 
         // Add them inside the area when there is no more space
         if (m_allSidesBlocked) {
             m_selection = selection;
-            positionButtonsInside(elemIndicator);
+            positionButtonsInside(elemIndicator, buttonPositions);
             break; // the while
         }
         // Number of buttons per row column
@@ -119,9 +127,10 @@ void ButtonHandler::updatePosition(const QRect& selection)
                 adjustHorizontalCenter(center);
             }
             // ElemIndicator, elemsAtCorners
-            QVector<QPoint> positions =
+            const QVector<QPoint> sidePositions =
               horizontalPoints(center, addCounter, true);
-            moveButtonsToPoints(positions, elemIndicator);
+            appendButtonPositions(
+              sidePositions, buttonPositions, elemIndicator);
         }
         // Add buttons to the right side of the selection
         if (!m_blockedRight && elemIndicator < vecLength) {
@@ -130,9 +139,10 @@ void ButtonHandler::updatePosition(const QRect& selection)
 
             QPoint center = QPoint(m_selection.right() + m_separator,
                                    m_selection.center().y());
-            QVector<QPoint> positions =
+            const QVector<QPoint> sidePositions =
               verticalPoints(center, addCounter, false);
-            moveButtonsToPoints(positions, elemIndicator);
+            appendButtonPositions(
+              sidePositions, buttonPositions, elemIndicator);
         }
         // Add buttons at the top of the selection
         if (!m_blockedTop && elemIndicator < vecLength) {
@@ -143,9 +153,10 @@ void ButtonHandler::updatePosition(const QRect& selection)
             if (addCounter == 1 + buttonsPerRow) {
                 adjustHorizontalCenter(center);
             }
-            QVector<QPoint> positions =
+            const QVector<QPoint> sidePositions =
               horizontalPoints(center, addCounter, false);
-            moveButtonsToPoints(positions, elemIndicator);
+            appendButtonPositions(
+              sidePositions, buttonPositions, elemIndicator);
         }
         // Add buttons to the left side of the selection
         if (!m_blockedLeft && elemIndicator < vecLength) {
@@ -154,9 +165,10 @@ void ButtonHandler::updatePosition(const QRect& selection)
 
             QPoint center = QPoint(m_selection.left() - m_buttonExtendedSize,
                                    m_selection.center().y());
-            QVector<QPoint> positions =
+            const QVector<QPoint> sidePositions =
               verticalPoints(center, addCounter, true);
-            moveButtonsToPoints(positions, elemIndicator);
+            appendButtonPositions(
+              sidePositions, buttonPositions, elemIndicator);
         }
         // If there are elements for the next cycle, increase the size of the
         // base area
@@ -165,6 +177,8 @@ void ButtonHandler::updatePosition(const QRect& selection)
         }
         updateBlockedSides();
     }
+
+    assignButtonsToPositions(buttonPositions, anchor);
 }
 
 int ButtonHandler::calculateShift(int elements, bool reverse) const
@@ -289,7 +303,7 @@ void ButtonHandler::expandSelection()
     m_selection = intersectWithAreas(m_selection);
 }
 
-void ButtonHandler::positionButtonsInside(int index)
+void ButtonHandler::positionButtonsInside(int index, QVector<QPoint>& positions)
 {
     // Position the buttons in the botton-center of the main but inside of the
     // selection.
@@ -305,8 +319,9 @@ void ButtonHandler::positionButtonsInside(int index)
     while (m_vectorButtons.size() > index) {
         int addCounter = buttonsPerRow;
         addCounter = qBound(0, addCounter, m_vectorButtons.size() - index);
-        QVector<QPoint> positions = horizontalPoints(center, addCounter, true);
-        moveButtonsToPoints(positions, index);
+        const QVector<QPoint> rowPositions =
+          horizontalPoints(center, addCounter, true);
+        appendButtonPositions(rowPositions, positions, index);
         center.setY(center.y() - m_buttonExtendedSize);
     }
 
@@ -334,13 +349,93 @@ void ButtonHandler::ensureSelectionMinimumSize()
     }
 }
 
-void ButtonHandler::moveButtonsToPoints(const QVector<QPoint>& points,
-                                        int& index)
+void ButtonHandler::appendButtonPositions(const QVector<QPoint>& points,
+                                          QVector<QPoint>& positions,
+                                          int& index)
 {
     for (const QPoint& p : points) {
-        auto* button = m_vectorButtons[index];
-        button->move(p);
+        positions.append(p);
         ++index;
+    }
+}
+
+void ButtonHandler::assignButtonsToPositions(const QVector<QPoint>& positions,
+                                             const QPoint& anchor)
+{
+    if (positions.isEmpty()) {
+        return;
+    }
+
+    QVector<CaptureToolButton*> primaryButtons;
+    QVector<CaptureToolButton*> remainingButtons;
+    primaryButtons.reserve(m_vectorButtons.size());
+    remainingButtons.reserve(m_vectorButtons.size());
+
+    const auto primaryRank = [](const CaptureToolButton* button) {
+        switch (button->tool()->type()) {
+            case CaptureTool::TYPE_COPY:
+            case CaptureTool::TYPE_ACCEPT:
+                return 0;
+            case CaptureTool::TYPE_SAVE:
+                return 1;
+            case CaptureTool::TYPE_PIN:
+                return 2;
+            case CaptureTool::TYPE_PLUGIN:
+                return 3;
+            default:
+                return -1;
+        }
+    };
+
+    for (CaptureToolButton* button : m_vectorButtons) {
+        if (primaryRank(button) >= 0) {
+            primaryButtons.append(button);
+        } else {
+            remainingButtons.append(button);
+        }
+    }
+    std::stable_sort(primaryButtons.begin(),
+                     primaryButtons.end(),
+                     [&primaryRank](const CaptureToolButton* left,
+                                    const CaptureToolButton* right) {
+                         return primaryRank(left) < primaryRank(right);
+                     });
+
+    // The first primary action gets the slot whose center is closest to the
+    // release point, followed by the other primary actions.
+    QVector<int> positionsByDistance(positions.size());
+    std::iota(positionsByDistance.begin(), positionsByDistance.end(), 0);
+    const QPoint buttonCenterOffset(m_buttonBaseSize / 2, m_buttonBaseSize / 2);
+    const auto distanceSquared = [&](int positionIndex) {
+        const QPoint delta =
+          positions[positionIndex] + buttonCenterOffset - anchor;
+        return static_cast<qint64>(delta.x()) * delta.x() +
+               static_cast<qint64>(delta.y()) * delta.y();
+    };
+    std::stable_sort(positionsByDistance.begin(),
+                     positionsByDistance.end(),
+                     [&distanceSquared](int left, int right) {
+                         return distanceSquared(left) < distanceSquared(right);
+                     });
+
+    QVector<bool> usedPositions(positions.size(), false);
+    int primaryIndex = 0;
+    for (; primaryIndex < primaryButtons.size() &&
+           primaryIndex < positionsByDistance.size();
+         ++primaryIndex) {
+        const int positionIndex = positionsByDistance[primaryIndex];
+        primaryButtons[primaryIndex]->move(positions[positionIndex]);
+        usedPositions[positionIndex] = true;
+    }
+
+    int remainingIndex = 0;
+    for (int positionIndex = 0; positionIndex < positions.size() &&
+                                remainingIndex < remainingButtons.size();
+         ++positionIndex) {
+        if (!usedPositions[positionIndex]) {
+            remainingButtons[remainingIndex]->move(positions[positionIndex]);
+            ++remainingIndex;
+        }
     }
 }
 
@@ -373,15 +468,15 @@ bool ButtonHandler::contains(const QPoint& p) const
     if (m_vectorButtons.isEmpty()) {
         return false;
     }
-    QPoint first(m_vectorButtons.first()->pos());
-    QPoint last(m_vectorButtons.last()->pos());
-    bool firstIsTopLeft = (first.x() <= last.x() && first.y() <= last.y());
-    QPoint topLeft = firstIsTopLeft ? first : last;
-    QPoint bottonRight = firstIsTopLeft ? last : first;
-    topLeft += QPoint(-m_separator, -m_separator);
-    bottonRight += QPoint(m_buttonExtendedSize, m_buttonExtendedSize);
-    QRegion r(QRect(topLeft, bottonRight).normalized());
-    return r.contains(p);
+
+    QRegion buttonRegion;
+    const QSize hitArea(m_buttonExtendedSize, m_buttonExtendedSize);
+    for (const CaptureToolButton* button : m_vectorButtons) {
+        const QPoint topLeft =
+          button->pos() - QPoint(m_separator, m_separator);
+        buttonRegion += QRect(topLeft, hitArea);
+    }
+    return buttonRegion.contains(p);
 }
 
 void ButtonHandler::updateScreenRegions(const QVector<QRect>& rects)

--- a/src/widgets/capture/buttonhandler.h
+++ b/src/widgets/capture/buttonhandler.h
@@ -32,7 +32,7 @@ public:
     void updateScreenRegions(const QRect& rect);
 
 public slots:
-    void updatePosition(const QRect& selection);
+    void updatePosition(const QRect& selection, const QPoint& anchor);
     void hide();
     void show();
 
@@ -72,8 +72,12 @@ private:
     void resetRegionTrack();
     void updateBlockedSides();
     void expandSelection();
-    void positionButtonsInside(int index);
+    void positionButtonsInside(int index, QVector<QPoint>& positions);
     void ensureSelectionMinimumSize();
-    void moveButtonsToPoints(const QVector<QPoint>& points, int& index);
+    void appendButtonPositions(const QVector<QPoint>& points,
+                               QVector<QPoint>& positions,
+                               int& index);
+    void assignButtonsToPositions(const QVector<QPoint>& positions,
+                                  const QPoint& anchor);
     void adjustHorizontalCenter(QPoint& center);
 };

--- a/src/widgets/capture/capturetoolbutton.cpp
+++ b/src/widgets/capture/capturetoolbutton.cpp
@@ -4,6 +4,7 @@
 #include "capturetoolbutton.h"
 #include "tools/capturetool.h"
 #include "tools/toolfactory.h"
+#include "tools/toolregistry.h"
 #include "utils/confighandler.h"
 #include "utils/globalvalues.h"
 
@@ -19,7 +20,23 @@
 CaptureToolButton::CaptureToolButton(const CaptureTool::Type t, QWidget* parent)
   : CaptureButton(parent)
   , m_buttonType(t)
+  , m_toolId(ToolRegistry::builtInId(t))
+  , m_external(false)
   , m_tool(nullptr)
+  , m_emergeAnimation(nullptr)
+{
+    initButton();
+    updateIcon();
+}
+
+CaptureToolButton::CaptureToolButton(const ToolDescriptor& descriptor,
+                                     QWidget* parent)
+  : CaptureButton(parent)
+  , m_buttonType(descriptor.legacyType)
+  , m_toolId(descriptor.id)
+  , m_shortcut(descriptor.shortcut)
+  , m_external(descriptor.isExternal())
+  , m_tool(ToolRegistry::createTool(descriptor, this))
   , m_emergeAnimation(nullptr)
 {
     initButton();
@@ -40,11 +57,9 @@ CaptureToolButton::~CaptureToolButton()
 
 void CaptureToolButton::initButton()
 {
-    if (m_tool) {
-        delete m_tool;
-        m_tool = nullptr;
+    if (!m_tool) {
+        m_tool = ToolFactory().CreateTool(m_buttonType, this);
     }
-    m_tool = ToolFactory().CreateTool(m_buttonType, this);
 
     resize(GlobalValues::buttonBaseSize(), GlobalValues::buttonBaseSize());
     setMask(QRegion(QRect(-1,
@@ -55,8 +70,11 @@ void CaptureToolButton::initButton()
 
     // Set a tooltip showing a shortcut in parentheses (if there is a shortcut)
     QString tooltip = m_tool->description();
-    QString shortcut =
-      ConfigHandler().shortcut(QVariant::fromValue(m_buttonType).toString());
+    QString shortcut = m_shortcut;
+    if (!m_external && shortcut.isNull()) {
+        shortcut = ConfigHandler().shortcut(
+          QVariant::fromValue(m_buttonType).toString());
+    }
     if (m_buttonType == CaptureTool::TYPE_COPY &&
         ConfigHandler().copyOnDoubleClick()) {
         tooltip += QStringLiteral(" (%1Left Double-Click)")
@@ -83,7 +101,7 @@ void CaptureToolButton::updateIcon()
 
 const QList<CaptureTool::Type>& CaptureToolButton::getIterableButtonTypes()
 {
-    return iterableButtonTypes;
+    return ToolRegistry::builtInTypes();
 }
 
 // get icon returns the icon for the type of button
@@ -94,7 +112,11 @@ QIcon CaptureToolButton::icon() const
 
 void CaptureToolButton::mousePressEvent(QMouseEvent* e)
 {
-    activateWindow();
+    const bool closesWindowOnPress = m_tool && m_tool->closeOnButtonPressed();
+    if (QGuiApplication::platformName() != QLatin1String("wayland") ||
+        !closesWindowOnPress) {
+        activateWindow();
+    }
     if (e->button() == Qt::LeftButton) {
         emit pressedButtonLeftClick(this);
         emit pressed();
@@ -121,6 +143,11 @@ CaptureTool* CaptureToolButton::tool() const
     return m_tool;
 }
 
+QString CaptureToolButton::toolId() const
+{
+    return m_toolId;
+}
+
 void CaptureToolButton::setColor(const QColor& c)
 {
     m_mainColor = c;
@@ -130,55 +157,7 @@ void CaptureToolButton::setColor(const QColor& c)
 
 QColor CaptureToolButton::m_mainColor;
 
-static std::map<CaptureTool::Type, int> buttonTypeOrder
-{
-    { CaptureTool::TYPE_PENCIL, 0 }, { CaptureTool::TYPE_DRAWER, 1 },
-      { CaptureTool::TYPE_ARROW, 2 }, { CaptureTool::TYPE_SELECTION, 3 },
-      { CaptureTool::TYPE_RECTANGLE, 4 }, { CaptureTool::TYPE_CIRCLE, 5 },
-      { CaptureTool::TYPE_MARKER, 6 }, { CaptureTool::TYPE_TEXT, 7 },
-      { CaptureTool::TYPE_PIXELATE, 8 }, { CaptureTool::TYPE_INVERT, 9 },
-      { CaptureTool::TYPE_CIRCLECOUNT, 10 },
-      { CaptureTool::TYPE_MOVESELECTION, 12 }, { CaptureTool::TYPE_UNDO, 13 },
-      { CaptureTool::TYPE_REDO, 14 }, { CaptureTool::TYPE_COPY, 15 },
-      { CaptureTool::TYPE_SAVE, 16 },
-#ifdef ENABLE_IMGUR
-      { CaptureTool::TYPE_IMAGEUPLOADER, 17 },
-#endif
-      { CaptureTool::TYPE_ACCEPT, 18 },
-#if !defined(Q_OS_MACOS)
-      { CaptureTool::TYPE_OPEN_APP, 19 }, { CaptureTool::TYPE_EXIT, 20 },
-      { CaptureTool::TYPE_PIN, 21 },
-#else
-      { CaptureTool::TYPE_EXIT, 19 }, { CaptureTool::TYPE_PIN, 20 },
-#endif
-
-      { CaptureTool::TYPE_SIZEINCREASE, 22 },
-      { CaptureTool::TYPE_SIZEDECREASE, 23 },
-};
-
 int CaptureToolButton::getPriorityByButton(CaptureTool::Type b)
 {
-    auto it = buttonTypeOrder.find(b);
-    return it == buttonTypeOrder.cend() ? (int)buttonTypeOrder.size()
-                                        : it->second;
+    return ToolRegistry::builtInPriority(b);
 }
-
-QList<CaptureTool::Type> CaptureToolButton::iterableButtonTypes = {
-    CaptureTool::TYPE_PENCIL,        CaptureTool::TYPE_DRAWER,
-    CaptureTool::TYPE_ARROW,         CaptureTool::TYPE_SELECTION,
-    CaptureTool::TYPE_RECTANGLE,     CaptureTool::TYPE_CIRCLE,
-    CaptureTool::TYPE_MARKER,        CaptureTool::TYPE_TEXT,
-    CaptureTool::TYPE_CIRCLECOUNT,   CaptureTool::TYPE_PIXELATE,
-    CaptureTool::TYPE_INVERT,        CaptureTool::TYPE_MOVESELECTION,
-    CaptureTool::TYPE_UNDO,          CaptureTool::TYPE_REDO,
-    CaptureTool::TYPE_COPY,          CaptureTool::TYPE_SAVE,
-    CaptureTool::TYPE_EXIT,
-#ifdef ENABLE_IMGUR
-    CaptureTool::TYPE_IMAGEUPLOADER,
-#endif
-#if !defined(Q_OS_MACOS)
-    CaptureTool::TYPE_OPEN_APP,
-#endif
-    CaptureTool::TYPE_PIN,           CaptureTool::TYPE_SIZEINCREASE,
-    CaptureTool::TYPE_SIZEDECREASE,  CaptureTool::TYPE_ACCEPT,
-};

--- a/src/widgets/capture/capturetoolbutton.h
+++ b/src/widgets/capture/capturetoolbutton.h
@@ -11,6 +11,7 @@
 
 class QWidget;
 class QPropertyAnimation;
+struct ToolDescriptor;
 
 class CaptureToolButton : public CaptureButton
 {
@@ -18,6 +19,8 @@ class CaptureToolButton : public CaptureButton
 
 public:
     explicit CaptureToolButton(const CaptureTool::Type,
+                               QWidget* parent = nullptr);
+    explicit CaptureToolButton(const ToolDescriptor& descriptor,
                                QWidget* parent = nullptr);
     ~CaptureToolButton();
 
@@ -28,15 +31,13 @@ public:
     QString description() const;
     QIcon icon() const;
     CaptureTool* tool() const;
+    QString toolId() const;
 
     void setColor(const QColor& c);
     void animatedShow();
 
 protected:
     void mousePressEvent(QMouseEvent* e) override;
-    static QList<CaptureTool::Type> iterableButtonTypes;
-
-    CaptureTool* m_tool;
 
 signals:
     void pressedButtonLeftClick(CaptureToolButton*);
@@ -45,6 +46,10 @@ signals:
 private:
     CaptureToolButton(QWidget* parent = nullptr);
     CaptureTool::Type m_buttonType;
+    QString m_toolId;
+    QString m_shortcut;
+    bool m_external;
+    CaptureTool* m_tool;
 
     QPropertyAnimation* m_emergeAnimation;
 

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -1391,7 +1391,8 @@ void CaptureWidget::initSelection()
                 m_captureDone = true;
                 close();
             }
-            m_buttonHandler->updatePosition(m_selection->geometry());
+            m_buttonHandler->updatePosition(m_selection->geometry(),
+                                            m_selection->toolbarAnchor());
             m_buttonHandler->show();
         } else {
             m_buttonHandler->hide();

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -15,6 +15,7 @@
 #include "core/flameshot.h"
 #include "core/qguiappcurrentscreen.h"
 #include "tools/copy/copytool.h"
+#include "tools/toolregistry.h"
 #include "utils/abstractlogger.h"
 #include "utils/screengrabber.h"
 #include "utils/screenshotsaver.h"
@@ -333,37 +334,57 @@ CaptureWidget::~CaptureWidget()
 
 void CaptureWidget::initButtons()
 {
-    auto allButtonTypes = CaptureToolButton::getIterableButtonTypes();
+    ToolRegistry registry;
+    for (const QString& error : registry.pluginErrors()) {
+        AbstractLogger::warning() << tr("Action plugin: %1").arg(error);
+    }
     auto visibleButtonTypes = m_config.buttons();
-    if ((m_context.request.tasks() == CaptureRequest::NO_TASK) ||
-        (m_context.request.tasks() == CaptureRequest::PRINT_GEOMETRY)) {
-        allButtonTypes.removeOne(CaptureTool::TYPE_ACCEPT);
+    const bool regularCapture =
+      (m_context.request.tasks() == CaptureRequest::NO_TASK) ||
+      (m_context.request.tasks() == CaptureRequest::PRINT_GEOMETRY);
+    if (regularCapture) {
         visibleButtonTypes.removeOne(CaptureTool::TYPE_ACCEPT);
     } else {
-        // Remove irrelevant buttons from both lists
-        for (auto* buttonList : { &allButtonTypes, &visibleButtonTypes }) {
-            buttonList->removeOne(CaptureTool::TYPE_SAVE);
-            buttonList->removeOne(CaptureTool::TYPE_COPY);
+        visibleButtonTypes.removeOne(CaptureTool::TYPE_SAVE);
+        visibleButtonTypes.removeOne(CaptureTool::TYPE_COPY);
 #ifdef ENABLE_IMGUR
-            buttonList->removeOne(CaptureTool::TYPE_IMAGEUPLOADER);
+        visibleButtonTypes.removeOne(CaptureTool::TYPE_IMAGEUPLOADER);
 #endif
-            buttonList->removeOne(CaptureTool::TYPE_OPEN_APP);
-            buttonList->removeOne(CaptureTool::TYPE_PIN);
-        }
+        visibleButtonTypes.removeOne(CaptureTool::TYPE_OPEN_APP);
+        visibleButtonTypes.removeOne(CaptureTool::TYPE_PIN);
     }
     QVector<CaptureToolButton*> vectorButtons;
 
-    // Add all buttons but hide those that were disabled in the Interface config
-    // This will allow keyboard shortcuts for those buttons to work
-    for (CaptureTool::Type t : allButtonTypes) {
-        auto* b = new CaptureToolButton(t, this);
+    // Create built-in and external tools through the same registry. Hidden
+    // entries are kept alive so their shortcuts can still be used.
+    for (const ToolDescriptor& descriptor : registry.tools()) {
+        const CaptureTool::Type type = descriptor.legacyType;
+        if (descriptor.isExternal() && !regularCapture) {
+            continue;
+        }
+        if (!descriptor.isExternal()) {
+            if (regularCapture && type == CaptureTool::TYPE_ACCEPT) {
+                continue;
+            }
+            if (!regularCapture && (type == CaptureTool::TYPE_SAVE ||
+                                    type == CaptureTool::TYPE_COPY ||
+#ifdef ENABLE_IMGUR
+                                    type == CaptureTool::TYPE_IMAGEUPLOADER ||
+#endif
+                                    type == CaptureTool::TYPE_OPEN_APP ||
+                                    type == CaptureTool::TYPE_PIN)) {
+                continue;
+            }
+        }
+
+        auto* b = new CaptureToolButton(descriptor, this);
         b->setColor(m_uiColor);
         b->hide();
         // must be enabled for SelectionWidget's eventFilter to work correctly
         b->setAttribute(Qt::WA_NoMousePropagation);
         makeChild(b);
 
-        switch (t) {
+        switch (type) {
             case CaptureTool::TYPE_UNDO:
             case CaptureTool::TYPE_REDO:
                 // nothing to do, just skip non-dynamic buttons with existing
@@ -371,8 +392,11 @@ void CaptureWidget::initButtons()
                 break;
             default:
                 // Set shortcuts for a tool
-                QString shortcut =
-                  ConfigHandler().shortcut(QVariant::fromValue(t).toString());
+                QString shortcut = descriptor.shortcut;
+                if (!descriptor.isExternal()) {
+                    shortcut = ConfigHandler().shortcut(
+                      QVariant::fromValue(type).toString());
+                }
                 if (!shortcut.isNull()) {
                     auto shortcuts = newShortcut(shortcut, this, nullptr);
                     for (auto* sc : shortcuts) {
@@ -384,14 +408,19 @@ void CaptureWidget::initButtons()
                 break;
         }
 
-        m_tools[t] = b->tool();
+        if (!descriptor.isExternal()) {
+            m_tools[type] = b->tool();
+        }
 
         connect(b->tool(),
                 &CaptureTool::requestAction,
                 this,
                 &CaptureWidget::handleToolSignal);
 
-        if (visibleButtonTypes.contains(t)) {
+        const bool visible = descriptor.isExternal()
+                               ? descriptor.toolbarVisible
+                               : visibleButtonTypes.contains(type);
+        if (visible) {
             connect(b,
                     &CaptureToolButton::pressedButtonLeftClick,
                     this,

--- a/src/widgets/capture/selectionwidget.cpp
+++ b/src/widgets/capture/selectionwidget.cpp
@@ -149,6 +149,11 @@ QRect SelectionWidget::fullGeometry() const
     return QWidget::geometry();
 }
 
+QPoint SelectionWidget::toolbarAnchor() const
+{
+    return m_hasToolbarAnchor ? m_toolbarAnchor : geometry().bottomRight();
+}
+
 QRect SelectionWidget::rect() const
 {
     return QWidget::rect() - QMargins(MARGIN, MARGIN, MARGIN, MARGIN);
@@ -184,6 +189,11 @@ void SelectionWidget::parentMousePressEvent(QMouseEvent* e)
 
 void SelectionWidget::parentMouseReleaseEvent(QMouseEvent* e)
 {
+    if (e->button() == Qt::LeftButton) {
+        m_toolbarAnchor = e->pos();
+        m_hasToolbarAnchor = true;
+    }
+
     // released outside of the selection area
     if (!getMouseSide(e->pos())) {
         hide();

--- a/src/widgets/capture/selectionwidget.h
+++ b/src/widgets/capture/selectionwidget.h
@@ -37,6 +37,7 @@ public:
     void setGeometry(const QRect& r);
     QRect geometry() const;
     QRect fullGeometry() const;
+    QPoint toolbarAnchor() const;
 
     QRect rect() const;
 
@@ -89,6 +90,8 @@ private:
     QPoint m_handleOffset;
 
     QPoint m_dragStartPos;
+    QPoint m_toolbarAnchor;
+    bool m_hasToolbarAnchor = false;
     SideType m_activeSide;
     QCursor m_idleCentralCursor;
     bool m_ignoreMouse;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,29 @@
+find_package(Qt${QT_VERSION_MAJOR} CONFIG REQUIRED Core Gui)
+
+add_executable(
+  actionplugin-manifest-test
+  actionplugin_manifest_test.cpp
+  ${CMAKE_SOURCE_DIR}/src/plugins/actionplugin.cpp
+  ${CMAKE_SOURCE_DIR}/src/plugins/actionplugin.h)
+
+target_include_directories(
+  actionplugin-manifest-test
+  PRIVATE ${CMAKE_SOURCE_DIR}/src)
+target_link_libraries(
+  actionplugin-manifest-test
+  PRIVATE Qt${QT_VERSION_MAJOR}::Core
+          Qt${QT_VERSION_MAJOR}::Gui)
+
+add_test(
+  NAME actionplugin-manifest
+  COMMAND actionplugin-manifest-test ${CMAKE_COMMAND})
+
+find_package(Python3 COMPONENTS Interpreter QUIET)
+if(Python3_Interpreter_FOUND)
+  add_test(
+    NAME plugin-cli
+    COMMAND ${Python3_EXECUTABLE}
+            ${CMAKE_CURRENT_SOURCE_DIR}/plugin_cli_test.py
+            $<TARGET_FILE:flameshot>
+            ${CMAKE_SOURCE_DIR}/sdk/flameshot-plugin)
+endif()

--- a/tests/actionplugin_manifest_test.cpp
+++ b/tests/actionplugin_manifest_test.cpp
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "plugins/actionplugin.h"
+
+#include <QCoreApplication>
+#include <QDir>
+#include <QFile>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QTemporaryDir>
+
+#include <iostream>
+
+namespace {
+
+bool writeManifest(const QString& path, const QJsonObject& manifest)
+{
+    QFile file(path);
+    return file.open(QIODevice::WriteOnly) &&
+           file.write(QJsonDocument(manifest).toJson()) > 0;
+}
+
+QJsonObject validManifest(const QString& executable)
+{
+    return {
+        { "api_version", 1 },
+        { "type", "action" },
+        { "id", "org.flameshot.test-action" },
+        { "name", "Test action" },
+        { "toolbar",
+          QJsonObject{
+            { "visible", true },
+            { "order", 175 },
+            { "shortcut", "Ctrl+Shift+T" },
+          } },
+        { "command",
+          QJsonObject{
+            { "executable", executable },
+            { "arguments", QJsonArray{ "-E", "true" } },
+            { "input", "png-stdin" },
+            { "output", "clipboard-text" },
+            { "timeout_ms", 5000 },
+          } },
+    };
+}
+
+bool expect(bool condition, const char* message)
+{
+    if (!condition) {
+        std::cerr << message << '\n';
+    }
+    return condition;
+}
+
+} // namespace
+
+int main(int argc, char* argv[])
+{
+    if (argc != 2) {
+        std::cerr << "expected path to a test executable\n";
+        return 1;
+    }
+
+    QTemporaryDir directory;
+    if (!expect(directory.isValid(), "could not create temporary directory")) {
+        return 1;
+    }
+    const QString configHome = directory.filePath("config");
+    const QString dataHome = directory.filePath("data");
+    qputenv("XDG_CONFIG_HOME", configHome.toUtf8());
+    qputenv("XDG_DATA_HOME", dataHome.toUtf8());
+    qputenv("XDG_DATA_DIRS", "/usr/local/share:/usr/share");
+
+    QCoreApplication application(argc, argv);
+    QCoreApplication::setApplicationName(QStringLiteral("flameshot"));
+    QCoreApplication::setOrganizationName(QStringLiteral("flameshot"));
+    const QString path = directory.filePath("metadata.json");
+
+    if (!expect(ActionPluginLoader::userPluginRoot() ==
+                  dataHome + QLatin1String("/flameshot/plugins"),
+                "user plugin root does not follow XDG_DATA_HOME") ||
+        !expect(ActionPluginLoader::pluginRoots().contains(
+                  dataHome + QLatin1String("/flameshot/plugins")),
+                "XDG user data root is missing") ||
+        !expect(ActionPluginLoader::pluginRoots().contains(
+                  configHome + QLatin1String("/flameshot/plugins")),
+                "legacy XDG config root is missing")) {
+        return 1;
+    }
+
+    QJsonObject manifest = validManifest(QString::fromLocal8Bit(argv[1]));
+    if (!expect(writeManifest(path, manifest), "could not write manifest")) {
+        return 1;
+    }
+
+    ActionPlugin plugin;
+    QString error;
+    if (!expect(ActionPluginLoader::loadManifest(path, &plugin, &error),
+                "valid manifest was rejected") ||
+        !expect(plugin.id == QLatin1String("org.flameshot.test-action"),
+                "plugin id was not parsed") ||
+        !expect(plugin.arguments.size() == 2,
+                "plugin arguments were not parsed") ||
+        !expect(plugin.outputMode == ActionPlugin::OutputMode::ClipboardText,
+                "plugin output mode was not parsed") ||
+        !expect(plugin.toolbarOrder == 175,
+                "plugin toolbar order was not parsed") ||
+        !expect(plugin.shortcut == QLatin1String("Ctrl+Shift+T"),
+                "plugin shortcut was not parsed")) {
+        std::cerr << error.toStdString() << '\n';
+        return 1;
+    }
+
+    const QString pluginDirectory =
+      directory.filePath("flameshot/plugins/org.flameshot.test-action");
+    if (!expect(QDir().mkpath(pluginDirectory),
+                "could not create plugin directory") ||
+        !expect(writeManifest(pluginDirectory + "/metadata.json", manifest),
+                "could not write discoverable manifest")) {
+        return 1;
+    }
+    QStringList discoveryErrors;
+    const QList<ActionPlugin> discovered = ActionPluginLoader::discover(
+      { directory.filePath("flameshot/plugins") }, &discoveryErrors);
+    if (!expect(discovered.size() == 1,
+                "plugin in the Flameshot config directory was not found")) {
+        std::cerr << discoveryErrors.join('\n').toStdString() << '\n';
+        return 1;
+    }
+
+    manifest["api_version"] = 2;
+    writeManifest(path, manifest);
+    if (!expect(!ActionPluginLoader::loadManifest(path, &plugin, &error),
+                "unsupported API version was accepted")) {
+        return 1;
+    }
+
+    manifest = validManifest(QString::fromLocal8Bit(argv[1]));
+    QJsonObject command = manifest["command"].toObject();
+    command["output"] = "arbitrary-code";
+    manifest["command"] = command;
+    writeManifest(path, manifest);
+    if (!expect(!ActionPluginLoader::loadManifest(path, &plugin, &error),
+                "unsupported output mode was accepted")) {
+        return 1;
+    }
+
+    manifest = validManifest(QString::fromLocal8Bit(argv[1]));
+    command = manifest["command"].toObject();
+    command["output"] = "json";
+    manifest["command"] = command;
+    writeManifest(path, manifest);
+    if (!expect(ActionPluginLoader::loadManifest(path, &plugin, &error),
+                "structured JSON output was rejected") ||
+        !expect(plugin.outputMode == ActionPlugin::OutputMode::Json,
+                "structured JSON output was not parsed")) {
+        return 1;
+    }
+
+    manifest = validManifest(QString::fromLocal8Bit(argv[1]));
+    QJsonObject toolbar = manifest["toolbar"].toObject();
+    toolbar["order"] = -1;
+    manifest["toolbar"] = toolbar;
+    writeManifest(path, manifest);
+    if (!expect(!ActionPluginLoader::loadManifest(path, &plugin, &error),
+                "invalid toolbar order was accepted")) {
+        return 1;
+    }
+
+    return 0;
+}

--- a/tests/plugin_cli_test.py
+++ b/tests/plugin_cli_test.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tarfile
+import tempfile
+
+
+def run(command, environment, expected=0):
+    completed = subprocess.run(
+        command,
+        env=environment,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+    if completed.returncode != expected:
+        print("command:", command, file=sys.stderr)
+        print(completed.stdout, file=sys.stderr)
+        print(completed.stderr, file=sys.stderr)
+        raise SystemExit(
+            f"expected exit {expected}, received {completed.returncode}"
+        )
+    return completed
+
+
+def main():
+    flameshot = Path(sys.argv[1]).resolve()
+    sdk = Path(sys.argv[2]).resolve()
+    with tempfile.TemporaryDirectory(prefix="flameshot-plugin-cli-") as temporary:
+        root = Path(temporary)
+        environment = os.environ.copy()
+        environment.update(
+            {
+                "XDG_DATA_HOME": str(root / "data"),
+                "XDG_CONFIG_HOME": str(root / "config"),
+                "XDG_DATA_DIRS": "/usr/local/share:/usr/share",
+                "QT_QPA_PLATFORM": "offscreen",
+                "LC_ALL": "C",
+            }
+        )
+        source = root / "org.example.cli-test"
+        package = root / "cli-test.flameshot-plugin"
+        run([str(sdk), "create", "org.example.cli-test", str(source)], environment)
+        run([str(sdk), "test", str(source)], environment)
+        run([str(sdk), "pack", str(source), "-o", str(package)], environment)
+        run([str(sdk), "validate", str(package)], environment)
+
+        installed = run(
+            [str(flameshot), "plugins", "install", str(package)], environment
+        )
+        if "org.example.cli-test" not in installed.stdout:
+            raise SystemExit("install output does not identify the plugin")
+        listed = run([str(flameshot), "plugins", "list"], environment)
+        if "enabled  org.example.cli-test" not in listed.stdout:
+            raise SystemExit("installed plugin is not listed as enabled")
+        run(
+            [str(flameshot), "plugins", "disable", "org.example.cli-test"],
+            environment,
+        )
+        listed = run([str(flameshot), "plugins", "list"], environment)
+        if "disabled org.example.cli-test" not in listed.stdout:
+            raise SystemExit("plugin was not disabled")
+        run(
+            [str(flameshot), "plugins", "enable", "org.example.cli-test"],
+            environment,
+        )
+        run([str(flameshot), "plugins", "doctor"], environment)
+        run(
+            [str(flameshot), "plugins", "remove", "org.example.cli-test"],
+            environment,
+        )
+        if (root / "data/flameshot/plugins/org.example.cli-test").exists():
+            raise SystemExit("plugin directory remains after removal")
+
+        unsafe = root / "unsafe.flameshot-plugin"
+        with tarfile.open(unsafe, "w:gz") as archive:
+            info = tarfile.TarInfo("../outside")
+            info.size = 0
+            archive.addfile(info)
+        run(
+            [str(flameshot), "plugins", "install", str(unsafe)],
+            environment,
+            expected=1,
+        )
+        if (root / "outside").exists():
+            raise SystemExit("unsafe package escaped the staging directory")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/plugin_cli_test.py
+++ b/tests/plugin_cli_test.py
@@ -43,10 +43,21 @@ def main():
             }
         )
         source = root / "org.example.cli-test"
-        package = root / "cli-test.flameshot-plugin"
+        package = root / "org.example.cli-test.flameshot-plugin"
         run([str(sdk), "create", "org.example.cli-test", str(source)], environment)
         run([str(sdk), "test", str(source)], environment)
-        run([str(sdk), "pack", str(source), "-o", str(package)], environment)
+        run([str(sdk), "pack", str(source)], environment)
+        run(
+            [
+                str(sdk),
+                "pack",
+                str(source),
+                "-o",
+                str(source / "invalid.flameshot-plugin"),
+            ],
+            environment,
+            expected=1,
+        )
         run([str(sdk), "validate", str(package)], environment)
 
         installed = run(


### PR DESCRIPTION
## Summary

This draft provides a concrete, deliberately narrow reference implementation
for the action/final-action use cases discussed in the plugin RFCs:

- https://github.com/flameshot-org/flameshot/discussions/3953
- https://github.com/flameshot-org/flameshot/discussions/2529

Instead of loading third-party C++ or Python code into the Flameshot process,
API v1 runs external action plugins as subprocesses. Flameshot sends the
selected area as PNG on standard input and applies a versioned JSON result
through host-owned services such as the clipboard and notifications.

## What this changes

- Adds a provider-based `ToolRegistry` with stable string IDs for built-in and
  external tools.
- Registers every enabled plugin as a direct toolbar action; there is no extra
  plugin chooser in the capture workflow.
- Adds manifest API v1 and structured result protocol v1.
- Runs plugins asynchronously with timeouts and bounded stdout/stderr.
- Adds XDG user/system discovery with compatibility for the prototype config
  location.
- Adds staged `.flameshot-plugin` package installation, removal, enablement,
  diagnostics, and package safety checks.
- Adds GUI install/remove controls and the `flameshot plugins` CLI.
- Adds a language-neutral SDK with schemas and Python, shell, Rust, and C++
  templates.
- Adds a local Tesseract OCR example that returns clipboard text through the
  host rather than interacting with the desktop itself.
- Keeps existing integer-based `CaptureTool::Type` settings as a compatibility
  bridge for native tools.
- Keeps Wayland clipboard and window-activation behavior in the Flameshot core.

## User flow

```text
Capture UI
    |
    v
ToolRegistry
    |-- BuiltIn provider ------> ToolFactory ------> native CaptureTool
    `-- ExternalAction provider -> PluginActionTool -> ActionPluginRunner
                                                   -> core clipboard/notification
```

Example lifecycle:

```sh
flameshot-plugin create org.example.my-tool --language python
flameshot-plugin test org.example.my-tool --image screenshot.png
flameshot-plugin pack org.example.my-tool
flameshot plugins install org.example.my-tool.flameshot-plugin
flameshot plugins doctor
```

User plugins are installed below
`${XDG_DATA_HOME:-~/.local/share}/flameshot/plugins`. The initial
`~/.config/flameshot/plugins` location remains a compatibility search root.

## Protocol boundary

API v1 intentionally supports only action plugins:

- input: PNG on stdin;
- recommended output: one UTF-8 JSON result;
- result types: `clipboard-text`, `notification`, or `none`;
- controlled errors: versioned JSON error result;
- process failures: non-zero exit plus stderr;
- timeout: 1-300 seconds, configured by the manifest;
- output limits: 1 MiB stdout and 256 KiB stderr.

The provider-based registry leaves room for later image-transform, exporter,
or interactive-tool protocols without assigning enum values to external tools.
Interactive drawing tools are explicitly out of scope for this API.

## Packaging and security

A `.flameshot-plugin` is a gzip-compressed TAR archive with `metadata.json` at
its root. Installation uses a staging directory followed by an atomic rename.
The installer rejects:

- absolute paths and parent traversal;
- symlinks and special files;
- packages over 32 MiB;
- extracted content over 64 MiB;
- archives containing more than 1000 files.

Plugins still run with the user's privileges. Subprocess isolation and package
validation are not a security sandbox, and the documentation says to install
only trusted plugins. This draft does not add a plugin catalogue, automatic
downloads, signatures, or network access.

## Compatibility

- Existing native tool enums and button settings remain supported.
- Legacy `none` and `clipboard-text` outputs remain accepted by API v1.
- Plugin configuration and installed plugin data use separate XDG locations.
- Debian and RPM metadata include the SDK runtime requirements.
- Shell completion is included for Bash, Fish, and Zsh.

## Validation performed

- CMake `RelWithDebInfo` build on Linux/Qt 6.
- `actionplugin-manifest` test for manifest parsing, invalid values, structured
  output selection, XDG roots, and discovery.
- `plugin-cli` end-to-end test covering SDK create/test/pack/validate,
  install/list/disable/enable/doctor/remove, and a traversal package rejection.
- `ctest --output-on-failure`: 2/2 tests passed.
- Manual local installation and Tesseract OCR execution with German and English
  language data on an Ubuntu Wayland session.
- Manual verification of clipboard behavior and direct toolbar activation.

## Known review points

- This is currently tested on Linux; Windows and macOS runtime/package behavior
  still needs validation.
- New user-facing strings are English only and need translation updates after
  the API/UI direction is accepted.
- The package format, process-first API, and provider boundary are intended as
  reviewable starting points and can be adjusted based on maintainer feedback.
- The branch is intentionally presented as a draft because maintainers may
  prefer this to be split into smaller dependent changes.

## Checklist

- [x] Builds successfully on the tested Linux/Qt 6 environment
- [x] Automated manifest and end-to-end CLI tests pass
- [x] Architecture, protocol, SDK, and security behavior are documented
- [x] Functional OCR example included
- [ ] Cross-platform runtime validation
- [ ] Translation catalogue updates
