### PR TITLE
Release gui mutex before clipboard keep-alive wait

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,6 +18,7 @@
 #include "utils/abstractlogger.h"
 #include "utils/confighandler.h"
 #include "utils/filenamehandler.h"
+#include "utils/guimutex.h"
 #include "utils/pathinfo.h"
 #include "utils/valuehandler.h"
 
@@ -31,7 +32,6 @@
 #include <QDir>
 #include <QLibraryInfo>
 #include <QNetworkProxyFactory>
-#include <QSharedMemory>
 #include <QTimer>
 #include <QTranslator>
 
@@ -90,23 +90,6 @@ int requestCaptureAndWait(const CaptureRequest& req)
         qApp->exit(E_ABORTED);
     });
     return qApp->exec();
-}
-
-QSharedMemory* guiMutexLock()
-{
-    QString key = "org.flameshot.Flameshot-" APP_VERSION;
-    auto* shm = new QSharedMemory(key);
-#ifdef Q_OS_UNIX
-    // Destroy shared memory if the last instance crashed on Unix
-    shm->attach();
-    delete shm;
-    shm = new QSharedMemory(key);
-#endif
-    if (!shm->create(1)) {
-        delete shm;
-        return nullptr;
-    }
-    return shm;
 }
 
 void configureTranslation(QTranslator& translator, QTranslator& qtTranslator)
@@ -472,15 +455,13 @@ int main(int argc, char* argv[])
         // Prevent multiple instances of 'flameshot gui' from running if not
         // configured to do so.
         if (!ConfigHandler().allowMultipleGuiInstances()) {
-            auto* mutex = guiMutexLock();
-            if (!mutex) {
+            if (!guiMutexLock()) {
                 return 1;
             }
-            QObject::connect(
-              qApp, &QCoreApplication::aboutToQuit, qApp, [mutex]() {
-                  mutex->detach();
-                  delete mutex;
-              });
+            QObject::connect(qApp,
+                             &QCoreApplication::aboutToQuit,
+                             qApp,
+                             &releasePendingGuiMutex);
         }
 
         // Option values

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -22,6 +22,7 @@ target_sources(
           globalvalues.cpp
           desktopfileparse.cpp
           desktopinfo.cpp
+          guimutex.cpp
           pathinfo.cpp
           colorutils.cpp
           history.cpp

--- a/src/utils/guimutex.cpp
+++ b/src/utils/guimutex.cpp
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2017-2019 Alejandro Sirgo Rica & Contributors
+
+#include "guimutex.h"
+
+#include <QSharedMemory>
+#include <QString>
+
+static QSharedMemory* g_guiMutex = nullptr;
+
+QSharedMemory* guiMutexLock()
+{
+    QString key = "org.flameshot.Flameshot-" APP_VERSION;
+    auto* shm = new QSharedMemory(key);
+#ifdef Q_OS_UNIX
+    // Destroy shared memory if the last instance crashed on Unix
+    shm->attach();
+    delete shm;
+    shm = new QSharedMemory(key);
+#endif
+    if (!shm->create(1)) {
+        delete shm;
+        return nullptr;
+    }
+    g_guiMutex = shm;
+    return shm;
+}
+
+void releasePendingGuiMutex()
+{
+    if (g_guiMutex) {
+        g_guiMutex->detach();
+        delete g_guiMutex;
+        g_guiMutex = nullptr;
+    }
+}

--- a/src/utils/guimutex.h
+++ b/src/utils/guimutex.h
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2017-2019 Alejandro Sirgo Rica & Contributors
+
+#pragma once
+
+class QSharedMemory;
+
+// Prevents multiple 'flameshot gui' instances from running at once. Returns
+// nullptr if another instance already holds the lock.
+QSharedMemory* guiMutexLock();
+
+// Releases the lock acquired by guiMutexLock(), if held. Safe to call more
+// than once, and safe to call even if guiMutexLock() was never called or
+// already returned nullptr.
+void releasePendingGuiMutex();

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -16,6 +16,7 @@
 #include "core/qguiappcurrentscreen.h"
 #include "tools/copy/copytool.h"
 #include "utils/abstractlogger.h"
+#include "utils/guimutex.h"
 #include "utils/screengrabber.h"
 #include "utils/screenshotsaver.h"
 #include "widgets/capture/colorpicker.h"
@@ -649,6 +650,11 @@ void CaptureWidget::closeEvent(QCloseEvent* event)
             AbstractLogger::info()
               << "GNOME/COSMIC Wayland detected; keeping capture window "
                  "alive until clipboard data is fetched.";
+            // The capture itself is done at this point; only the clipboard
+            // handoff remains. Release the single-instance lock now rather
+            // than at process exit, so a new 'flameshot gui' invocation
+            // isn't rejected while this one lingers to serve the clipboard.
+            releasePendingGuiMutex();
             saveToClipboardGnomeWorkaround(pixmap(), this);
             return;
         }


### PR DESCRIPTION
Follow-up to #4902, addressing a bug found in review by @cleytonmendest.

## Problem

The COSMIC/GNOME clipboard workaround keeps the capture window alive (hidden) for up to 30s while waiting for a paste consumer to fetch the clipboard data. As pointed out in [review on #4902](https://github.com/flameshot-org/flameshot/pull/4902#pullrequestreview-5003060055), that 30s wait is actually the *normal* path, not a rare fallback — the `dataChanged`-based early close only fires when something else claims clipboard ownership, which doesn't happen in an ordinary copy-then-paste. So every copy holds the process alive for the full 30 seconds.

The problem: that process still holds `flameshot gui`'s single-instance lock (`QSharedMemory`-based, `guiMutexLock()` in `main.cpp`) for the entire wait. A second `flameshot gui` invocation during that window fails to acquire the lock and exits immediately with no visible UI or error — reported independently as "Ctrl+Shift+S sometimes just does nothing" after a recent capture.

## Fix

Moves `guiMutexLock()` out of `main.cpp` into its own `utils/guimutex.{h,cpp}`, and adds `releasePendingGuiMutex()` — an idempotent release, callable both from the normal `aboutToQuit` cleanup and, now, from the clipboard workaround itself. The mutex is released as soon as we hand off to the keep-alive wait: the actual GUI portion of the capture is already done at that point (selection made, copy requested), so a new capture shouldn't be blocked by a previous one that's only lingering in the background to serve a pending clipboard read.

## Testing

Verified on Pop!_OS 24.04 with COSMIC 1.0.0, built on current `master`: rapid back-to-back `Ctrl+Shift+S` captures now both work immediately. Previously the second one silently did nothing until the first's 30s timeout (or an incidental clipboard-ownership change elsewhere) released the lock.

Doesn't address the other point raised in review (the `USE_WAYLAND_CLIPBOARD`/`KSystemClipboard` build path also going through `saveToClipboardGnomeWorkaround()`, which uses `QGuiApplication::clipboard()` unconditionally) — I don't have a way to build/test against `KF6GuiAddons` here, so left that as a known follow-up rather than guessing at a fix I can't verify.