### PR TITLE
Fix X11 multi-monitor capture on HiDPI (cut/shifted region, inflated canvas)

### DIFF
--- a/src/utils/screengrabber.cpp
+++ b/src/utils/screengrabber.cpp
@@ -870,26 +870,29 @@ QPixmap ScreenGrabber::x11LegacyScreenshot()
         return p;
     }
 
-    // Composite all screens using logical geometry.
-    // On i3 (tested) DPR is uniform so we don't need the per-screen
-    // physical pixel math that the Windows backend does. Not sure if this is
-    // true for other DE's like xmonad.
-    QRect totalGeom;
+    // Composite in device pixels. On xcb the virtual-desktop layout uses native
+    // offsets while each screen reports a logical size, so scaling the united
+    // geometry by one ratio inflates and misplaces it. grabWindow(0) returns the
+    // device-pixel pixmap and geometry().topLeft() is the native offset, so draw
+    // each pixmap at its native offset using its own size.
+    QRect totalRect;
+    QList<QPair<QRect, QPixmap>> grabs;
+    grabs.reserve(screens.size());
     for (QScreen* s : screens) {
-        totalGeom = totalGeom.united(s->geometry());
+        QPixmap p = s->grabWindow(0);
+        p.setDevicePixelRatio(1.0);
+        QRect r(s->geometry().topLeft(), p.size());
+        grabs.append({ r, p });
+        totalRect = totalRect.united(r);
     }
 
-    qreal dpr = screens.first()->devicePixelRatio();
-    QPixmap desktop(qRound(totalGeom.width() * dpr),
-                    qRound(totalGeom.height() * dpr));
-    desktop.setDevicePixelRatio(dpr);
+    QPixmap desktop(totalRect.size());
+    desktop.setDevicePixelRatio(1.0);
     desktop.fill(Qt::black);
 
     QPainter painter(&desktop);
-    for (QScreen* s : screens) {
-        QPixmap p = s->grabWindow(0);
-        QPoint offset = s->geometry().topLeft() - totalGeom.topLeft();
-        painter.drawPixmap(offset, p);
+    for (const auto& g : grabs) {
+        painter.drawPixmap(g.first.topLeft() - totalRect.topLeft(), g.second);
     }
     painter.end();
 


### PR DESCRIPTION
## Problem

On X11 with a non-1 display scale (`Xft.dpi` != 96, so Qt `devicePixelRatio` != 1) and **multiple monitors of different sizes**, `flameshot gui` / `full` capture the wrong pixels: the region the overlay selects is cut or shifted onto a neighbour monitor, and `full` produces an over-sized canvas.

Concrete repro: three monitors in an L shape, one `3264x1836` and two `3840x2160` (framebuffer `7680x3996`), `Xft.dpi 168` (ratio `1.75`), nvidia driver, awesome WM, `useX11LegacyScreenshot=true`. `flameshot full` returns a **`10560x5373`** image instead of `7680x3996`.

## Root cause

`ScreenGrabber::x11LegacyScreenshot()` builds the canvas from the united **logical** geometry multiplied by a single `devicePixelRatio`, and draws each screen at its **logical** top-left:

```cpp
QRect totalGeom;               // united logical geometry
qreal dpr = screens.first()->devicePixelRatio();
QPixmap desktop(qRound(totalGeom.width() * dpr), qRound(totalGeom.height() * dpr));
...
QPoint offset = s->geometry().topLeft() - totalGeom.topLeft();  // logical
```

On the xcb backend the virtual-desktop layout uses **native (device) pixel offsets**, while each screen reports a **logical** size (its device size divided by its ratio). Multiplying the whole union by one ratio double-counts the offsets, which both inflates the canvas and misplaces each screen. It also assumes a single uniform ratio for all screens.

## Fix

`grabWindow(0)` already returns the true device-pixel pixmap of each screen, and `geometry().topLeft()` is the native offset on xcb. So compose each pixmap at its native offset using its **own physical size**, without scaling, and size the canvas to the union of those device-pixel rectangles.

## Testing

On the setup above, capture is now **pixel-aligned to the framebuffer**: `7680x3996`, per-monitor RMSE `< 0.02` against a raw `x11grab` of each monitor (was a shifted `10560x5373` before). Single-monitor and uniform multi-monitor paths are unchanged.

I could only test the xcb/nvidia path. A check on another backend or on a fractional-scaling compositor is welcome.
