### PR TITLE
Update save dialog file suffix when the format filter changes

### DIFF
--- a/src/utils/screenshotsaver.cpp
+++ b/src/utils/screenshotsaver.cpp
@@ -104,6 +104,34 @@ QString ShowSaveFileDialog(const QString& title, const QString& directory)
       QMimeDatabase().mimeTypeForFile("image." + suffix).name();
     dialog.selectMimeTypeFilter(defaultMimeType);
     dialog.setDefaultSuffix(suffix);
+    // Follow the format picked in the file type dropdown: use its suffix
+    // when the typed name has none, and swap the extension of a name that
+    // already has one (the Qt dialog does this itself, GTK's does not).
+    QObject::connect(&dialog,
+                     &QFileDialog::filterSelected,
+                     &dialog,
+                     [&dialog](const QString&) {
+                         QString newSuffix =
+                           QMimeDatabase()
+                             .mimeTypeForName(dialog.selectedMimeTypeFilter())
+                             .preferredSuffix();
+                         if (newSuffix.isEmpty()) {
+                             return;
+                         }
+                         dialog.setDefaultSuffix(newSuffix);
+                         QStringList files = dialog.selectedFiles();
+                         if (files.isEmpty()) {
+                             return;
+                         }
+                         QFileInfo info(files.constFirst());
+                         QString oldSuffix = info.suffix().toLower();
+                         if (oldSuffix != newSuffix &&
+                             QImageWriter::supportedImageFormats().contains(
+                               oldSuffix.toLatin1())) {
+                             dialog.selectFile(info.dir().filePath(
+                               info.completeBaseName() + "." + newSuffix));
+                         }
+                     });
     if (dialog.exec() == QDialog::Accepted) {
         return dialog.selectedFiles().constFirst();
     } else {


### PR DESCRIPTION
Picking another image format in the save dialog did not change the saved file. ShowSaveFileDialog in src/utils/screenshotsaver.cpp sets the default suffix once from the configured extension and never listens to QFileDialog::filterSelected, so a name without an extension got the configured suffix, and in GTK's dialog the extension in the name box stayed.

The dialog now updates the default suffix from the selected mime type on filterSelected and swaps the current name's extension when it is an offered image format. Built on Windows with Qt 6.10.1 and checked with an offscreen program against Qt's widget dialog only; flameshot never sets DontUseNativeDialog, so the native GTK and portal pickers users get, where filterSelected and selectedFiles may behave differently, are untested.

Fixes #4708
