### PR TITLE
Fall back to a same-language translation for unmatched locales

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -121,6 +121,19 @@ void configureTranslation(QTranslator& translator, QTranslator& qtTranslator)
                               QStringLiteral("Internationalization"),
                               QStringLiteral("_"),
                               path);
+            if (!foundTranslation) {
+                // Neither the exact locale nor the bare language is shipped
+                // (it_CH with only it_IT available): take any translation
+                // of the same language rather than falling back to English.
+                QString language = QLocale().name().section('_', 0, 0);
+                QStringList sameLanguage = QDir(path).entryList(
+                  { QStringLiteral("Internationalization_%1_*.qm")
+                      .arg(language) },
+                  QDir::Files);
+                foundTranslation =
+                  !sameLanguage.isEmpty() &&
+                  translator.load(sameLanguage.constFirst(), path);
+            }
         } else {
             // Load language from settings
             foundTranslation =


### PR DESCRIPTION
With the UI language set to auto, configureTranslation in src/main.cpp relies on QTranslator's locale lookup. For it_CH that tries Internationalization_it_CH and Internationalization_it, but the Italian file is shipped as it_IT, so Swiss Italian users get English and the "No Flameshot translation found" warning. de_AT and de_CH miss de_DE the same way, and sv_FI misses sv_SE.

When the lookup fails, the loader now looks for any Internationalization_<lang>_*.qm in the same translations directory and loads the first one by name (so a language with several regional files, like zh, falls back to the alphabetically first), leaving the .ts file names alone since Weblate manages them. Compiled on Windows with Qt 6.10.1 and checked with a small program against the built .qm files: it_CH picks it_IT, de_AT picks de_DE, nl_BE still gets nl, an unknown language still gets nothing.

Fixes #4921
