### PR TITLE
build(windows): enable Control Flow Guard for MSVC builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,21 @@ endif()
 #Needed due to linker error with QtColorWidget
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
+# Control Flow Guard, an MSVC exploit mitigation that validates the target of
+# every indirect call at runtime. Set here, above the add_subdirectory() calls
+# below, so that it also covers the vendored dependencies that get compiled
+# into the executables.
+#
+# Both flags are needed and they do different jobs: /guard:cf instruments the
+# code, and /GUARD:CF marks the image. The mark is the part that matters most,
+# because CFG is a per-process policy read from the main image at process
+# creation -- an unmarked flameshot.exe leaves CFG off for the whole process,
+# including the checks already compiled into the Windows DLLs it loads. Setting
+# only the compile flag would pay the cost and gain nothing.
+if(MSVC)
+  add_compile_options(/guard:cf)
+  add_link_options(/GUARD:CF)
+endif()
 
 # Dependency can be fetched via flatpak builder
 if(EXISTS "${CMAKE_SOURCE_DIR}/external/Qt-Color-Widgets/CMakeLists.txt")


### PR DESCRIPTION
Fixes #4934.

Flameshot's Windows build already turns on ASLR, high-entropy ASLR and DEP. Control Flow Guard is the one Windows mitigation it is missing. CFG makes a memory-corruption bug -- in an image decoder, in Qt, anywhere in the process -- much harder to turn into code execution, because an indirect call through a corrupted pointer is stopped before it lands. Windows' own DLLs are compiled with it, but it only switches on for a process whose main executable is marked, so Flameshot gets none of it today.

The change is two MSVC flags in the top-level CMakeLists.txt: `/guard:cf` when compiling and `/GUARD:CF` when linking. Both are needed. They sit above the `add_subdirectory()` calls so the vendored Qt-Color-Widgets and KDSingleApplication builds pick them up too.

I could not build Flameshot itself here (no Qt 6.9), so I checked the construct on a minimal project with the same layout: with the flags the linked exe shows `Control Flow Guard` in `dumpbin /headers`, without them it does not. The AppVeyor MSVC build of this branch passed.
