### PR TITLE
Add KWin ScreenShot2 fast path for KDE Wayland

### DIFF
--- a/src/utils/screengrabber.cpp
+++ b/src/utils/screengrabber.cpp
@@ -31,9 +31,14 @@
 #include <QDBusInterface>
 #include <QDBusMessage>
 #include <QDBusReply>
+#include <QDBusUnixFileDescriptor>
 #include <QDir>
 #include <QUrl>
 #include <QUuid>
+#include <cerrno>
+#include <fcntl.h>
+#include <poll.h>
+#include <unistd.h>
 #endif
 
 bool ScreenGrabber::m_monitorSelectionActive = false;
@@ -186,6 +191,127 @@ ScreenGrabber::PortalStatus ScreenGrabber::freeDesktopPortal(
 #endif
 }
 
+#if defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)
+// KDE Wayland: capture directly from KWin's ScreenShot2 interface. KWin
+// writes the raw pixels to a pipe, so there is no PNG encode round-trip
+// through the freedesktop portal (measured ~2.8s -> ~0.3s on a 4K screen).
+// Returns a null pixmap if KWin is unavailable or rejects the request,
+// so callers can fall back to the portal.
+static QPixmap kwinScreenshot()
+{
+    auto* connectionInterface = QDBusConnection::sessionBus().interface();
+    auto service = QStringLiteral("org.kde.KWin.ScreenShot2");
+
+    if (!connectionInterface->isServiceRegistered(service)) {
+        return {};
+    }
+
+    int pipeFds[2];
+    if (pipe2(pipeFds, O_CLOEXEC | O_NONBLOCK) != 0) {
+        return {};
+    }
+
+    QVariantMap options;
+    options.insert(QStringLiteral("native-resolution"), true);
+
+    QVariantMap metadata;
+    {
+        // Keep the D-Bus message (and its pipe-fd reference) scoped: the
+        // message holds the write end open, which would otherwise prevent
+        // the read loop below from ever seeing EOF.
+        QDBusMessage message = QDBusMessage::createMethodCall(
+          service,
+          QStringLiteral("/org/kde/KWin/ScreenShot2"),
+          service,
+          QStringLiteral("CaptureWorkspace"));
+        message.setArguments(
+          { options,
+            QVariant::fromValue(QDBusUnixFileDescriptor(pipeFds[1])) });
+
+        // 5s timeout instead of the 25s D-Bus default: a healthy KWin
+        // answers in well under a second, and blocking the GUI thread for
+        // 25s with no feedback looks like a freeze.
+        // Note: the read loop below only starts after the reply arrives.
+        // This relies on KWin sending its metadata reply before (or while)
+        // streaming pixels; a KWin that wrote more than the pipe buffer
+        // before replying would deadlock here until the timeout, and we
+        // would fall back to the portal.
+        QDBusReply<QVariantMap> reply =
+          QDBusConnection::sessionBus().call(message, QDBus::Block, 5000);
+        ::close(pipeFds[1]);
+        if (!reply.isValid()) {
+            qWarning() << "kwinScreenshot failed:" << reply.error();
+            ::close(pipeFds[0]);
+            return {};
+        }
+        metadata = reply.value();
+    }
+
+    // Read the raw image bytes KWin writes to the pipe (async, so poll).
+    QByteArray content;
+    char buffer[4096];
+    pollfd pfds[1];
+    pfds[0].fd = pipeFds[0];
+    pfds[0].events = POLLIN;
+    while (true) {
+        const int ready = poll(pfds, 1, 30000);
+        if (ready < 0) {
+            if (errno != EINTR) {
+                break;
+            }
+        } else if (ready == 0) {
+            qWarning() << "kwinScreenshot: timed out reading pipe from KWin";
+            break;
+        } else if (pfds[0].revents & POLLIN) {
+            const int n = ::read(pipeFds[0], buffer, sizeof(buffer));
+            if (n < 0) {
+                if (errno == EAGAIN || errno == EWOULDBLOCK) {
+                    continue;
+                }
+                break;
+            } else if (n == 0) {
+                break;
+            } else {
+                content.append(buffer, n);
+            }
+        } else if (pfds[0].revents & POLLHUP) {
+            break;
+        } else {
+            break;
+        }
+    }
+    ::close(pipeFds[0]);
+
+    bool okW = false, okH = false, okF = false, okS = false;
+    const uint width = metadata.value(QStringLiteral("width")).toUInt(&okW);
+    const uint height = metadata.value(QStringLiteral("height")).toUInt(&okH);
+    const uint stride = metadata.value(QStringLiteral("stride")).toUInt(&okS);
+    const QImage::Format format = static_cast<QImage::Format>(
+      metadata.value(QStringLiteral("format")).toUInt(&okF));
+    if (!okW || !okH || !okF || !okS || width == 0 || height == 0 ||
+        stride == 0) {
+        return {};
+    }
+    if (content.size() < static_cast<qint64>(stride) * height) {
+        return {};
+    }
+
+    QImage image(reinterpret_cast<const uchar*>(content.constData()),
+                 static_cast<int>(width),
+                 static_cast<int>(height),
+                 static_cast<int>(stride),
+                 format);
+    if (image.isNull()) {
+        return {};
+    }
+    image = image.copy();
+
+    QPixmap res = QPixmap::fromImage(image);
+    res.setDevicePixelRatio(1.0);
+    return res;
+}
+#endif
+
 QPixmap ScreenGrabber::unixScreenshot(bool& ok)
 {
 #if defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)
@@ -198,6 +324,14 @@ QPixmap ScreenGrabber::unixScreenshot(bool& ok)
             AbstractLogger::error() << tr("Unable to capture screen");
         }
         return screenshot;
+    }
+
+    if (m_info.waylandDetected()) {
+        screenshot = kwinScreenshot();
+        if (!screenshot.isNull()) {
+            ok = true;
+            return screenshot;
+        }
     }
 
     QString portalError;


### PR DESCRIPTION
### Description

On KDE Plasma Wayland, full-desktop capture goes through the
freedesktop screenshot portal. The KDE backend encodes the frame as
PNG before returning a file URI, which dominates capture time on
large or high-DPI screens (~2.8s measured on a 4K Plasma Wayland
setup, `flameshot gui` until the overlay appears).

This adds a fast path through KWin's
`org.kde.KWin.ScreenShot2.CaptureWorkspace`: KWin writes raw pixels
to a pipe over D-Bus, so there is no PNG round-trip (~260ms on the
same screen). The request uses `native-resolution:true`.

The portal stays the fallback. KWin is tried only on Wayland and only
if `org.kde.KWin.ScreenShot2` is on the session bus. Any failure
(service missing, rejected request, timeout, short read) falls back
to the portal. GNOME, wlroots, X11, Flatpak, and Snap are unchanged.

Related to #2495 and #3165.

- #2495 moved KDE to the freedesktop portal. In that review Jeremy
  asked about using ScreenShot2; the PR took the simpler portal-only
  route. This adds that path as a fast lane, with the portal as
  fallback.
- #3165 used the same interface for the half-resolution (DPR) bug and
  was dropped in favor of the smaller #3166. This PR is about capture
  latency from the portal PNG encode, which that DPR fix does not
  address.

### Notes for self-built installs

KWin only authorizes callers whose executable (`/proc/PID/exe`)
matches the `Exec=` of a `.desktop` file that declares
`X-KDE-DBUS-Restricted-Interfaces=org.kde.KWin.ScreenShot2`.

The packaged `.desktop` already has that key. Distro packages are
fine. If you build with a custom prefix or run the binary out of
`build/`, either install so `Exec=` matches, or leave it: KWin
denies the call and we fall back to the portal. Capture still works,
just without the speedup.

### Testing

- KDE Plasma Wayland, 4K: ~2.8s (portal) → ~260ms (KWin)
- Service absent / `.desktop` mismatch: falls back to portal