### PR TITLE
Add option for text tool drop shadow to improve contrast

### DIFF
--- a/data/graphics.qrc
+++ b/data/graphics.qrc
@@ -25,6 +25,7 @@
         <file>img/material/black/format-text.svg</file>
         <file>img/material/black/format_bold.svg</file>
         <file>img/material/black/format_italic.svg</file>
+        <file>img/material/black/format_shadow.svg</file>
         <file>img/material/black/format_strikethrough.svg</file>
         <file>img/material/black/format_underlined.svg</file>
         <file>img/material/black/graphics.svg</file>
@@ -68,6 +69,7 @@
         <file>img/material/white/format-text.svg</file>
         <file>img/material/white/format_bold.svg</file>
         <file>img/material/white/format_italic.svg</file>
+        <file>img/material/white/format_shadow.svg</file>
         <file>img/material/white/format_strikethrough.svg</file>
         <file>img/material/white/format_underlined.svg</file>
         <file>img/material/white/graphics.svg</file>

--- a/data/img/material/black/format_shadow.svg
+++ b/data/img/material/black/format_shadow.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <path opacity="0.4" d="M11 6h8v3h-2.5v11h-3V9H11V6z" />
+  <path d="M9 4h8v3h-2.5v11h-3V7H9V4z" />
+</svg>

--- a/data/img/material/white/format_shadow.svg
+++ b/data/img/material/white/format_shadow.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <path fill="#FFF" opacity="0.4" d="M11 6h8v3h-2.5v11h-3V9H11V6z" />
+  <path fill="#FFF" d="M9 4h8v3h-2.5v11h-3V7H9V4z" />
+</svg>

--- a/src/config/generalconf.cpp
+++ b/src/config/generalconf.cpp
@@ -79,6 +79,7 @@ GeneralConf::GeneralConf(QWidget* parent)
     initSquareMagnifier();
     initJpegQuality();
     initReverseArrow();
+    initDrawTextShadow();
     // this has to be at the end
     initConfigButtons();
     updateComponents();
@@ -113,6 +114,7 @@ void GeneralConf::_updateComponents(bool allowEmptySavePath)
     m_squareMagnifier->setChecked(config.squareMagnifier());
     m_saveLastRegion->setChecked(config.saveLastRegion());
     m_reverseArrow->setChecked(config.reverseArrow());
+    m_drawTextShadow->setChecked(config.drawTextShadow());
     m_autoCloseIdleDaemon->setChecked(config.autoCloseIdleDaemon());
     m_predefinedColorPaletteLarge->setChecked(
       config.predefinedColorPaletteLarge());
@@ -918,6 +920,26 @@ void GeneralConf::setReverseArrow(bool checked)
 void GeneralConf::setInsecurePixelate(bool checked)
 {
     ConfigHandler().setInsecurePixelate(checked);
+}
+
+void GeneralConf::initDrawTextShadow()
+{
+    m_drawTextShadow = new QCheckBox(tr("Text tool shadow"), this);
+    m_drawTextShadow->setToolTip(
+      tr("Draw a shadow under text to improve readability against contrasting "
+         "backgrounds."));
+    m_drawTextShadow->setChecked(ConfigHandler().drawTextShadow());
+    m_scrollAreaLayout->addWidget(m_drawTextShadow);
+
+    connect(m_drawTextShadow,
+            &QCheckBox::clicked,
+            this,
+            &GeneralConf::setDrawTextShadow);
+}
+
+void GeneralConf::setDrawTextShadow(bool checked)
+{
+    ConfigHandler().setDrawTextShadow(checked);
 }
 
 #if !defined(Q_OS_MACOS)

--- a/src/config/generalconf.h
+++ b/src/config/generalconf.h
@@ -61,6 +61,7 @@ private slots:
     void setJpegQuality(int v);
     void setReverseArrow(bool checked);
     void setInsecurePixelate(bool checked);
+    void setDrawTextShadow(bool checked);
 #if !defined(Q_OS_MACOS)
     void captureActiveMonitorChanged(bool checked);
 #endif
@@ -108,6 +109,7 @@ private:
     void initJpegQuality();
     void initReverseArrow();
     void initInsecurePixelate();
+    void initDrawTextShadow();
 #if !defined(Q_OS_MACOS)
     void initCaptureActiveMonitor();
 #endif
@@ -165,6 +167,7 @@ private:
     QSpinBox* m_jpegQuality;
     QCheckBox* m_reverseArrow;
     QCheckBox* m_insecurePixelate;
+    QCheckBox* m_drawTextShadow;
 #if !defined(Q_OS_MACOS)
     QCheckBox* m_captureActiveMonitor;
 #endif

--- a/src/tools/text/textconfig.cpp
+++ b/src/tools/text/textconfig.cpp
@@ -19,6 +19,7 @@ TextConfig::TextConfig(QWidget* parent)
   , m_underlineButton(nullptr)
   , m_weightButton(nullptr)
   , m_italicButton(nullptr)
+  , m_shadowButton(nullptr)
   , m_leftAlignButton(nullptr)
   , m_centerAlignButton(nullptr)
   , m_rightAlignButton(nullptr)
@@ -70,6 +71,16 @@ TextConfig::TextConfig(QWidget* parent)
             this,
             &TextConfig::fontItalicChanged);
     m_italicButton->setToolTip(tr("Italic"));
+
+    m_shadowButton = new QPushButton(QIcon(iconPrefix + "format_shadow.svg"),
+                                     QLatin1String(""));
+    m_shadowButton->setCheckable(true);
+    connect(m_shadowButton,
+            &QPushButton::clicked,
+            this,
+            &TextConfig::fontShadowChanged);
+    m_shadowButton->setToolTip(tr("Shadow"));
+
     auto* modifiersLayout = new QHBoxLayout();
 
     m_leftAlignButton =
@@ -109,6 +120,7 @@ TextConfig::TextConfig(QWidget* parent)
     modifiersLayout->addWidget(m_underlineButton);
     modifiersLayout->addWidget(m_weightButton);
     modifiersLayout->addWidget(m_italicButton);
+    modifiersLayout->addWidget(m_shadowButton);
     m_layout->addLayout(modifiersLayout);
     m_layout->addLayout(alignmentLayout);
 }
@@ -138,6 +150,11 @@ void TextConfig::setWeight(const int weight)
 void TextConfig::setItalic(const bool italic)
 {
     m_italicButton->setChecked(italic);
+}
+
+void TextConfig::setShadow(const bool shadow)
+{
+    m_shadowButton->setChecked(shadow);
 }
 
 void TextConfig::weightButtonPressed(const bool weight)

--- a/src/tools/text/textconfig.h
+++ b/src/tools/text/textconfig.h
@@ -20,6 +20,7 @@ public:
     void setStrikeOut(bool strikeout);
     void setWeight(int weight);
     void setItalic(bool italic);
+    void setShadow(bool shadow);
     void setTextAlignment(Qt::AlignmentFlag alignment);
 
 signals:
@@ -28,6 +29,7 @@ signals:
     void fontStrikeOutChanged(const bool dashed);
     void fontWeightChanged(const QFont::Weight w);
     void fontItalicChanged(const bool italic);
+    void fontShadowChanged(const bool shadow);
     void alignmentChanged(Qt::AlignmentFlag alignment);
 public slots:
 
@@ -41,6 +43,7 @@ private:
     QPushButton* m_underlineButton;
     QPushButton* m_weightButton;
     QPushButton* m_italicButton;
+    QPushButton* m_shadowButton;
 
     QPushButton* m_leftAlignButton;
     QPushButton* m_centerAlignButton;

--- a/src/tools/text/texttool.cpp
+++ b/src/tools/text/texttool.cpp
@@ -4,6 +4,7 @@
 #include "texttool.h"
 #include "tools/text/textconfig.h"
 #include "tools/text/textwidget.h"
+#include "utils/colorutils.h"
 #include "utils/confighandler.h"
 
 #define BASE_POINT_SIZE 8
@@ -18,6 +19,7 @@ TextTool::TextTool(QObject* parent)
         m_font.setFamily(ConfigHandler().fontFamily());
     }
     m_alignment = Qt::AlignLeft;
+    m_shadow = ConfigHandler().drawTextShadow();
 }
 
 TextTool::~TextTool()
@@ -30,6 +32,7 @@ void TextTool::copyParams(const TextTool* from, TextTool* to)
     CaptureTool::copyParams(from, to);
     to->m_font = from->m_font;
     to->m_alignment = from->m_alignment;
+    to->m_shadow = from->m_shadow;
     to->m_text = from->m_text;
     to->m_size = from->m_size;
     to->m_color = from->m_color;
@@ -105,6 +108,7 @@ QWidget* TextTool::widget()
     m_font.setPointSize(m_size + BASE_POINT_SIZE);
     m_widget->setFont(m_font);
     m_widget->setAlignment(m_alignment);
+    m_widget->setShadow(m_shadow);
     m_widget->setText(m_text);
     m_widget->selectAll();
     connect(m_widget, &TextWidget::textUpdated, this, &TextTool::updateText);
@@ -152,6 +156,10 @@ QWidget* TextTool::configurationWidget()
             &TextConfig::fontWeightChanged,
             this,
             &TextTool::updateFontWeight);
+    connect(m_confW,
+            &TextConfig::fontShadowChanged,
+            this,
+            &TextTool::updateFontShadow);
 
     connect(
       m_confW, &TextConfig::alignmentChanged, this, &TextTool::updateAlignment);
@@ -161,6 +169,7 @@ QWidget* TextTool::configurationWidget()
     m_confW->setUnderline(m_font.underline());
     m_confW->setStrikeOut(m_font.strikeOut());
     m_confW->setWeight(m_font.weight());
+    m_confW->setShadow(m_shadow);
     m_confW->setTextAlignment(m_alignment);
     return m_confW;
 }
@@ -189,6 +198,10 @@ CaptureTool* TextTool::copy(QObject* parent)
                 &TextConfig::fontWeightChanged,
                 textTool,
                 &TextTool::updateFontWeight);
+        connect(m_confW,
+                &TextConfig::fontShadowChanged,
+                textTool,
+                &TextTool::updateFontShadow);
 
         connect(m_confW,
                 &TextConfig::alignmentChanged,
@@ -214,9 +227,36 @@ void TextTool::process(QPainter& painter, const QPixmap& pixmap)
     fontsize.setHeight(fontsize.height() + val * 2);
     m_textArea.setSize(fontsize);
     // draw text
-    painter.setFont(m_font);
-    painter.setPen(m_color);
     if (!editMode()) {
+        painter.setFont(m_font);
+        if (m_shadow) {
+            int shadowOffset = qMax(1, m_font.pointSize() / 10);
+            QRect baseRect = m_textArea + QMargins(-val, -val, val, val);
+
+            // Light halo to ensure legibility on dark or mid-grey backgrounds
+            QColor lightColor(255, 255, 255, 180);
+            painter.setPen(lightColor);
+            painter.drawText(baseRect.translated(-shadowOffset, -shadowOffset),
+                             m_alignment,
+                             m_text);
+            painter.drawText(
+              baseRect.translated(-shadowOffset, 0), m_alignment, m_text);
+            painter.drawText(
+              baseRect.translated(0, -shadowOffset), m_alignment, m_text);
+
+            // Dark drop shadow to ensure legibility on light, grey, or white
+            // backgrounds
+            QColor darkColor(0, 0, 0, 180);
+            painter.setPen(darkColor);
+            painter.drawText(baseRect.translated(shadowOffset, shadowOffset),
+                             m_alignment,
+                             m_text);
+            painter.drawText(
+              baseRect.translated(shadowOffset, 0), m_alignment, m_text);
+            painter.drawText(
+              baseRect.translated(0, shadowOffset), m_alignment, m_text);
+        }
+        painter.setPen(m_color);
         painter.drawText(
           m_textArea + QMargins(-val, -val, val, val), m_alignment, m_text);
     }
@@ -327,6 +367,17 @@ void TextTool::updateFontItalic(const bool italic)
     m_font.setItalic(italic);
     if (m_widget != nullptr) {
         m_widget->setFont(m_font);
+    }
+}
+
+void TextTool::updateFontShadow(const bool shadow)
+{
+    m_shadow = shadow;
+    if (m_textOld.isEmpty()) {
+        ConfigHandler().setDrawTextShadow(m_shadow);
+    }
+    if (m_widget != nullptr) {
+        m_widget->setShadow(m_shadow);
     }
 }
 

--- a/src/tools/text/texttool.h
+++ b/src/tools/text/texttool.h
@@ -65,6 +65,7 @@ private slots:
     void updateFontStrikeOut(bool strikeout);
     void updateFontWeight(QFont::Weight weight);
     void updateFontItalic(bool italic);
+    void updateFontShadow(bool shadow);
     void updateAlignment(Qt::AlignmentFlag alignment);
 
 private:
@@ -72,6 +73,7 @@ private:
 
     QFont m_font;
     Qt::AlignmentFlag m_alignment;
+    bool m_shadow;
     QString m_text;
     QString m_textOld;
     int m_size;

--- a/src/tools/text/textwidget.cpp
+++ b/src/tools/text/textwidget.cpp
@@ -2,8 +2,10 @@
 // SPDX-FileCopyrightText: 2017-2019 Alejandro Sirgo Rica & Contributors
 
 #include "textwidget.h"
+#include "utils/colorutils.h"
 
 #include <QEvent>
+#include <QGraphicsDropShadowEffect>
 #include <QKeyEvent>
 
 TextWidget::TextWidget(QWidget* parent)
@@ -73,9 +75,31 @@ void TextWidget::setAlignment(Qt::AlignmentFlag alignment)
 }
 void TextWidget::setTextColor(const QColor& c)
 {
+    m_textColor = c;
     QString s(
       QStringLiteral("TextWidget { background: transparent; color: %1; }"));
     setStyleSheet(s.arg(c.name()));
+    if (m_shadowEffect) {
+        m_shadowEffect->setColor(QColor(0, 0, 0, 200));
+    }
+}
+
+void TextWidget::setShadow(bool shadow)
+{
+    if (shadow) {
+        if (!m_shadowEffect) {
+            m_shadowEffect = new QGraphicsDropShadowEffect(this);
+            m_shadowEffect->setBlurRadius(4);
+            m_shadowEffect->setOffset(1.5, 1.5);
+            setGraphicsEffect(m_shadowEffect);
+        }
+        m_shadowEffect->setColor(QColor(0, 0, 0, 200));
+        m_shadowEffect->setEnabled(true);
+    } else {
+        if (m_shadowEffect) {
+            m_shadowEffect->setEnabled(false);
+        }
+    }
 }
 
 void TextWidget::adjustSize()

--- a/src/tools/text/textwidget.h
+++ b/src/tools/text/textwidget.h
@@ -7,6 +7,7 @@
 
 class QEvent;
 class QKeyEvent;
+class QGraphicsDropShadowEffect;
 
 class TextWidget : public QTextEdit
 {
@@ -30,6 +31,7 @@ signals:
 public slots:
     void setTextColor(const QColor& c);
     void setAlignment(Qt::AlignmentFlag alignment);
+    void setShadow(bool shadow);
 
 private slots:
     void emitTextUpdated();
@@ -37,4 +39,6 @@ private slots:
 private:
     QSize m_baseSize;
     QSize m_minSize;
+    QGraphicsDropShadowEffect* m_shadowEffect = nullptr;
+    QColor m_textColor = Qt::black;
 };

--- a/src/utils/confighandler.cpp
+++ b/src/utils/confighandler.cpp
@@ -117,6 +117,7 @@ static QMap<class QString, QSharedPointer<ValueHandler>>
     // drawThickness shared by Pencil, Line, Arrow, Rectangular Selection, Circle
     OPTION("drawThickness"               ,LowerBoundedInt    ( 1, 3          )),
     OPTION("drawFontSize"                ,LowerBoundedInt    ( 1, 8          )),
+    OPTION("drawTextShadow"              ,Bool               ( true          )),
     OPTION("drawCircleCounterSize"       ,LowerBoundedInt    ( 1, 1          )),
     OPTION("drawPixelateSize"            ,LowerBoundedInt    ( 1, 2          )),
     OPTION("drawRectangleSize"           ,LowerBoundedInt    ( 1, 1          )),
@@ -234,7 +235,7 @@ ConfigHandler::ConfigHandler()
         QObject::connect(m_configWatcher.data(),
                          &QFileSystemWatcher::fileChanged,
                          [](const QString& fileName) {
-                             emit getInstance()->fileChanged();
+                             emit getInstance() -> fileChanged();
 
                              if (QFile(fileName).exists()) {
                                  m_configWatcher->addPath(fileName);
@@ -734,12 +735,12 @@ void ConfigHandler::setErrorState(bool error) const
     if (!hadError && m_hasError) {
         QString msg = errorMessage();
         AbstractLogger::error() << msg;
-        emit getInstance()->error();
+        emit getInstance() -> error();
     } else if (hadError && !m_hasError) {
         auto msg =
           tr("You have successfully resolved the configuration error.");
         AbstractLogger::info() << msg;
-        emit getInstance()->errorResolved();
+        emit getInstance() -> errorResolved();
     }
 }
 

--- a/src/utils/confighandler.h
+++ b/src/utils/confighandler.h
@@ -93,6 +93,7 @@ public:
     CONFIG_GETTER_SETTER(disabledTrayIcon, setDisabledTrayIcon, bool)
     CONFIG_GETTER_SETTER(drawThickness, setDrawThickness, int)
     CONFIG_GETTER_SETTER(drawFontSize, setDrawFontSize, int)
+    CONFIG_GETTER_SETTER(drawTextShadow, setDrawTextShadow, bool)
     CONFIG_GETTER_SETTER(drawCircleCounterSize, setDrawCircleCounterSize, int)
     CONFIG_GETTER_SETTER(drawPixelateSize, setDrawPixelateSize, int)
     CONFIG_GETTER_SETTER(drawRectangleSize, setDrawRectangleSize, int)

--- a/tests/test_text_shadow.sh
+++ b/tests/test_text_shadow.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env sh
+
+# Automated test script for drawTextShadow configuration setting
+# Arguments:
+# 1. path to tested flameshot executable (default: ./build/src/flameshot)
+
+FLAMESHOT="$1"
+[ -z "$FLAMESHOT" ] && FLAMESHOT="./build/src/flameshot"
+
+if [ ! -x "$FLAMESHOT" ]; then
+    echo "Error: Flameshot executable not found at '$FLAMESHOT'" >&2
+    exit 1
+fi
+
+CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/flameshot"
+CONFIG_FILE="$CONFIG_DIR/flameshot.ini"
+BACKUP_FILE="$CONFIG_DIR/flameshot.ini.bak_test"
+
+# Cleanup function to restore original config on exit
+cleanup() {
+    if [ -f "$BACKUP_FILE" ]; then
+        mv "$BACKUP_FILE" "$CONFIG_FILE"
+    else
+        rm -f "$CONFIG_FILE"
+    fi
+}
+trap cleanup EXIT INT TERM
+
+mkdir -p "$CONFIG_DIR"
+if [ -f "$CONFIG_FILE" ]; then
+    cp "$CONFIG_FILE" "$BACKUP_FILE"
+fi
+
+echo "=== Test 1: Testing valid configuration 'drawTextShadow = true' ==="
+cat <<EOF > "$CONFIG_FILE"
+[General]
+drawTextShadow=true
+EOF
+
+OUT=$("$FLAMESHOT" config --check 2>&1)
+EXIT_CODE=$?
+if [ $EXIT_CODE -eq 0 ]; then
+    echo "PASS: 'drawTextShadow=true' is valid."
+else
+    echo "FAIL: 'drawTextShadow=true' check failed with output: $OUT" >&2
+    exit 1
+fi
+
+echo "=== Test 2: Testing valid configuration 'drawTextShadow = false' ==="
+cat <<EOF > "$CONFIG_FILE"
+[General]
+drawTextShadow=false
+EOF
+
+OUT=$("$FLAMESHOT" config --check 2>&1)
+EXIT_CODE=$?
+if [ $EXIT_CODE -eq 0 ]; then
+    echo "PASS: 'drawTextShadow=false' is valid."
+else
+    echo "FAIL: 'drawTextShadow=false' check failed with output: $OUT" >&2
+    exit 1
+fi
+
+echo "=== Test 3: Testing invalid configuration 'drawTextShadow = invalid_value' ==="
+cat <<EOF > "$CONFIG_FILE"
+[General]
+drawTextShadow=invalid_value
+EOF
+
+OUT=$("$FLAMESHOT" config --check 2>&1)
+EXIT_CODE=$?
+if [ $EXIT_CODE -ne 0 ] || echo "$OUT" | grep -q "error"; then
+    echo "PASS: Invalid value was correctly detected."
+else
+    echo "FAIL: Invalid value was unexpectedly accepted." >&2
+    exit 1
+fi
+
+echo "All tests passed successfully!"


### PR DESCRIPTION
Introduced a configurable text shadow option for the text tool to make text 
clearly legible against light, dark, and grey backgrounds.

- Add 'drawTextShadow' option to ConfigHandler (default: true)
- Add toggle checkbox in General Settings configuration window
- Add shadow toggle button and icons to Text tool configuration panel
- Apply high-contrast drop shadow in TextWidget live editor
- Render dual light/dark shadow outline in TextTool process painter
- Add test script tests/test_text_shadow.sh to validate config handling