### PR TITLE
fix: reduce Wayland capture and clipboard latency

### DIFF
--- a/docs/UsageHyprlandSwayWlroots.md
+++ b/docs/UsageHyprlandSwayWlroots.md
@@ -37,6 +37,46 @@ hl.window_rule({
 ```
 
 
+## Optional faster capture and clipboard backends
+
+On compositors supported by `grim` and `wl-clipboard`, these opt-in backends
+avoid PNG compression before the editor opens and repeated image encoding
+during clipboard transfers:
+
+```sh
+FLAMESHOT_USE_GRIM=1 FLAMESHOT_USE_WL_COPY=1 flameshot gui
+```
+
+Install `grim` and `wl-clipboard` first. The normal editor stays available:
+select a region, annotate it, and press **Ctrl+C**. `--raw` is not needed.
+You can enable either backend independently. To apply the settings to captures
+started from the tray, start the Flameshot tray process with the same variables.
+
+`FLAMESHOT_USE_GRIM=1` captures an uncompressed PPM image at grim's default
+desktop scale, then uses the normal monitor selection and mixed-DPI cropping.
+If grim is missing, fails, or takes longer than three seconds, Flameshot falls
+back to the screenshot portal. PPM uses more temporary memory than compressed
+PNG; it does not reduce pixel quality. This option requires a compositor that
+implements the screen-capture protocols supported by grim.
+
+`FLAMESHOT_USE_WL_COPY=1` encodes the finished image once and gives it to
+`wl-copy`. PNG uses fast, lossless compression; the JPEG clipboard preference
+and save-after-copy setting are respected. The helper serves subsequent paste
+requests independently of Flameshot. A private temporary file is removed after
+the helper consumes it. If the helper cannot complete successfully within three
+seconds, Flameshot uses its existing clipboard backend. Compositor support for
+`wl-copy` is required; the default backends are unchanged when the variables
+are unset.
+
+For a repeatable Hyprland 0.55+ desktop test, run
+`python3 tests/wayland_performance.py build/src/flameshot --fast`.
+The test opens an 800x500 selection, sends Ctrl+C, validates PNG/JPEG dimensions,
+and checks repeated pastes after Flameshot exits. It replaces the clipboard
+and uses your current clipboard-format and save-after-copy preferences.
+Omit `--fast` for a baseline, use `--screen 1` to test a second monitor,
+`--cancel` to check Escape, and `--fail-tool grim` or `--fail-tool wl-copy`
+with `--fast` to test the fallback paths.
+
 # Sway and wlroots support
 Flameshot currently supports Sway and other wlroots based Wayland compositors through [xdg-desktop-portal-wlr](https://github.com/emersion/xdg-desktop-portal-wlr). However, due to the way dbus works, there may be some extra steps required for the integration to work properly.
 
@@ -130,4 +170,3 @@ riverctl float-filter-add "flameshot"
 Otherwise, Flameshot will not take all of the screen and tiles its window instead like a normal application.
 
 #### For more information, please refer to https://github.com/emersion/xdg-desktop-portal-wlr/wiki/%22It-doesn't-work%22-Troubleshooting-Checklist
-

--- a/src/core/flameshotdaemon.cpp
+++ b/src/core/flameshotdaemon.cpp
@@ -158,6 +158,9 @@ void FlameshotDaemon::createPin(const QPixmap& capture, QRect geometry)
 
 void FlameshotDaemon::copyToClipboard(const QPixmap& capture)
 {
+    if (tryCopyToWaylandClipboard(capture)) {
+        return;
+    }
     if (instance()) {
         instance()->attachScreenshotToClipboard(capture);
         return;

--- a/src/utils/screengrabber.cpp
+++ b/src/utils/screengrabber.cpp
@@ -18,6 +18,7 @@
 #include <QPixmap>
 #include <QProcess>
 #include <QScreen>
+#include <QStandardPaths>
 #include <QTimer>
 #include <QWidget>
 #include <algorithm>
@@ -190,6 +191,32 @@ QPixmap ScreenGrabber::unixScreenshot(bool& ok)
 {
 #if defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)
     QPixmap screenshot;
+
+    // Opt-in for wlroots compositors: avoid PNG compression on the
+    // capture path. grim keeps the same logical desktop layout as the portal,
+    // so mixed-DPI cropping below remains unchanged. Other desktops and a
+    // failed grim invocation continue through the normal portal backend.
+    if (m_info.waylandDetected() &&
+        qEnvironmentVariableIntValue("FLAMESHOT_USE_GRIM") == 1) {
+        const QString grim = QStandardPaths::findExecutable("grim");
+        if (!grim.isEmpty()) {
+            QProcess process;
+            process.start(grim, { "-t", "ppm", "-" });
+            if (process.waitForFinished(3000) &&
+                process.exitStatus() == QProcess::NormalExit &&
+                process.exitCode() == 0 &&
+                screenshot.loadFromData(process.readAllStandardOutput(),
+                                        "PPM")) {
+                ok = true;
+                return screenshot;
+            }
+            if (process.state() != QProcess::NotRunning) {
+                process.kill();
+                process.waitForFinished();
+            }
+            qWarning() << "Direct grim capture failed; using screenshot portal";
+        }
+    }
 
     if (!m_info.waylandDetected() && ConfigHandler().useX11LegacyScreenshot()) {
         screenshot = x11LegacyScreenshot();

--- a/src/utils/screenshotsaver.cpp
+++ b/src/utils/screenshotsaver.cpp
@@ -111,6 +111,72 @@ QString ShowSaveFileDialog(const QString& title, const QString& directory)
     }
 }
 
+namespace {
+void notifyAndMaybeSaveAfterCopy(const QPixmap& capture)
+{
+    // If we are able to properly save the file, save the file and copy to
+    // clipboard.
+    if ((ConfigHandler().saveAfterCopy()) &&
+        (!ConfigHandler().savePath().isEmpty())) {
+        saveToFilesystem(capture,
+                         ConfigHandler().savePath(),
+                         QObject::tr("Capture saved to clipboard."));
+    } else {
+        AbstractLogger() << QObject::tr("Capture saved to clipboard.");
+    }
+}
+} // namespace
+
+bool tryCopyToWaylandClipboard(const QPixmap& capture)
+{
+#if defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)
+    if (QGuiApplication::platformName() != "wayland" ||
+        qEnvironmentVariableIntValue("FLAMESHOT_USE_WL_COPY") != 1) {
+        return false;
+    }
+    const QString executable = QStandardPaths::findExecutable("wl-copy");
+    if (executable.isEmpty()) {
+        return false;
+    }
+
+    // Encode once, without a DBus QPixmap round trip or lazy re-encoding for
+    // every clipboard reader. The temporary file is private and is removed
+    // after wl-copy has read it and forked its persistent clipboard owner.
+    QTemporaryFile file;
+    if (!file.open()) {
+        return false;
+    }
+    const bool jpeg = ConfigHandler().useJpgForClipboard();
+    QImageWriter writer(&file, jpeg ? "JPEG" : "PNG");
+    if (jpeg) {
+        writer.setQuality(ConfigHandler().jpegQuality());
+    } else {
+        writer.setCompression(20); // PNG zlib level 1; still lossless.
+    }
+    if (!writer.write(capture.toImage()) || !file.flush()) {
+        return false;
+    }
+    QProcess process;
+    process.setStandardInputFile(file.fileName());
+    process.start(executable, { "--type", jpeg ? "image/jpeg" : "image/png" });
+    if (!process.waitForFinished(3000) ||
+        process.exitStatus() != QProcess::NormalExit ||
+        process.exitCode() != 0) {
+        if (process.state() != QProcess::NotRunning) {
+            process.kill();
+            process.waitForFinished();
+        }
+        qWarning() << "wl-copy failed; using the regular clipboard backend";
+        return false;
+    }
+    notifyAndMaybeSaveAfterCopy(capture);
+    return true;
+#else
+    Q_UNUSED(capture)
+    return false;
+#endif
+}
+
 void saveToClipboardMime(const QPixmap& capture, const QString& imageType)
 {
     QByteArray array;
@@ -163,16 +229,7 @@ void saveToClipboardMime(const QPixmap& capture, const QString& imageType)
 // dbus, the application freezes.
 void saveToClipboard(const QPixmap& capture)
 {
-    // If we are able to properly save the file, save the file and copy to
-    // clipboard.
-    if ((ConfigHandler().saveAfterCopy()) &&
-        (!ConfigHandler().savePath().isEmpty())) {
-        saveToFilesystem(capture,
-                         ConfigHandler().savePath(),
-                         QObject::tr("Capture saved to clipboard."));
-    } else {
-        AbstractLogger() << QObject::tr("Capture saved to clipboard.");
-    }
+    notifyAndMaybeSaveAfterCopy(capture);
 #if defined(Q_OS_MACOS)
     // On macOS, setPixmap uses lazy clipboard which fails when the
     // process exits ("Cannot keep promise"). Always use serialized bytes.

--- a/src/utils/screenshotsaver.h
+++ b/src/utils/screenshotsaver.h
@@ -14,6 +14,7 @@ bool saveToFilesystem(const QPixmap& capture,
 QString ShowSaveFileDialog(const QString& title, const QString& directory);
 void saveToClipboardMime(const QPixmap& capture, const QString& imageType);
 void saveToClipboard(const QPixmap& capture);
+bool tryCopyToWaylandClipboard(const QPixmap& capture);
 // GNOME Wayland: keeps the widget alive until clipboard data is fetched
 bool saveToClipboardGnomeWorkaround(const QPixmap& pixmap, QWidget* keepAlive);
 bool saveToFilesystemGUI(const QPixmap& capture);

--- a/tests/wayland_performance.py
+++ b/tests/wayland_performance.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Hyprland 0.55+ desktop integration check; temporarily replaces the clipboard.
+
+Example: python3 tests/wayland_performance.py build/src/flameshot --fast
+Use --screen 1 for a second monitor, --cancel to check Escape, or
+--fail-tool grim / --fail-tool wl-copy to exercise the fallback backends.
+"""
+
+import argparse
+import json
+import os
+from pathlib import Path
+import struct
+import subprocess
+import tempfile
+import time
+
+
+def run(*args):
+    return subprocess.run(args, check=True, capture_output=True, timeout=20).stdout
+
+
+def image_dimensions(data):
+    if data.startswith(b"\x89PNG\r\n\x1a\n"):
+        return struct.unpack(">II", data[16:24])
+    if data.startswith(b"\xff\xd8"):
+        position = 2
+        while position < len(data):
+            if data[position] != 0xFF:
+                break
+            while position < len(data) and data[position] == 0xFF:
+                position += 1
+            marker = data[position]
+            position += 1
+            if marker in (0xDA, 0xD9):
+                break
+            if marker in range(0xD0, 0xD8) or marker == 0x01:
+                continue
+            length = int.from_bytes(data[position:position + 2], "big")
+            if length < 2 or position + length > len(data):
+                break
+            if marker in (0xC0, 0xC1, 0xC2, 0xC3, 0xC5, 0xC6, 0xC7,
+                          0xC9, 0xCA, 0xCB, 0xCD, 0xCE, 0xCF):
+                height, width = struct.unpack(">HH", data[position + 3:position + 7])
+                return width, height
+            position += length
+    raise RuntimeError("Clipboard is not a supported PNG/JPEG image")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("binary", type=Path)
+    parser.add_argument("--hyprctl", default="/usr/bin/hyprctl")
+    parser.add_argument("--screen", type=int, default=0)
+    parser.add_argument("--fast", action="store_true")
+    parser.add_argument("--cancel", action="store_true")
+    parser.add_argument("--fail-tool", choices=("grim", "wl-copy"))
+    options = parser.parse_args()
+    if options.fail_tool and not options.fast:
+        parser.error("--fail-tool requires --fast")
+
+    def windows():
+        return [w for w in json.loads(run(options.hyprctl, "clients", "-j"))
+                if w["class"].lower() in ("flameshot", "org.flameshot.flameshot")]
+
+    def send_key(address, mods, key):
+        for state in ("down", "up"):
+            expression = (
+                "hl.dsp.send_key_state({mods=" + json.dumps(mods)
+                + ",key=" + json.dumps(key) + ",state=" + json.dumps(state)
+                + ",window=" + json.dumps("address:" + address) + "})"
+            )
+            result = run(options.hyprctl, "dispatch", expression)
+            if result.strip() != b"ok":
+                # Copy/Escape may destroy the editor on key-down before the
+                # compositor receives the matching release.
+                if (state == "up" and b"send_key_state: window not found" in result
+                        and not any(w["address"] == address for w in windows())):
+                    continue
+                raise RuntimeError(result.decode())
+
+    if windows():
+        raise RuntimeError("Close existing Flameshot windows before this test")
+
+    # wl-copy forks a persistent owner; do not hold its inherited stdout/stderr
+    # pipes open through subprocess.communicate().
+    marker = b"Flameshot Wayland integration test"
+    subprocess.run(["wl-copy", "--type", "text/plain"], input=marker,
+                   stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+                   check=True, timeout=3)
+    environment = os.environ.copy()
+    environment["QT_QPA_PLATFORM"] = "wayland"
+    for name in ("QT_SCALE_FACTOR", "QT_SCREEN_SCALE_FACTORS",
+                 "QT_AUTO_SCREEN_SCALE_FACTOR", "FLAMESHOT_USE_GRIM",
+                 "FLAMESHOT_USE_WL_COPY"):
+        environment.pop(name, None)
+    if options.fast:
+        environment.update(FLAMESHOT_USE_GRIM="1", FLAMESHOT_USE_WL_COPY="1")
+
+    with tempfile.TemporaryDirectory(prefix="flameshot-test-") as directory:
+        if options.fail_tool:
+            stub = Path(directory) / options.fail_tool
+            stub.write_text("#!/bin/sh\nexit 1\n")
+            stub.chmod(0o700)
+            environment["PATH"] = directory + os.pathsep + environment["PATH"]
+        with tempfile.TemporaryFile() as log:
+            start = time.monotonic()
+            process = subprocess.Popen(
+                [str(options.binary.resolve()), "screen", "--number",
+                 str(options.screen), "--edit", "--region", "800x500+100+100"],
+                env=environment, stdout=log, stderr=log,
+            )
+            address = None
+            completed = False
+            try:
+                while time.monotonic() - start < 20:
+                    owned = [w for w in windows() if w["pid"] == process.pid]
+                    if owned:
+                        address = owned[0]["address"]
+                        break
+                    if process.poll() is not None:
+                        raise RuntimeError("Flameshot exited before showing the editor")
+                    time.sleep(0.01)
+                if address is None:
+                    raise RuntimeError("No editor appeared within 20 seconds")
+                overlay_ms = round((time.monotonic() - start) * 1000)
+                run(options.hyprctl, "dispatch",
+                    "hl.dsp.focus({window=" + json.dumps("address:" + address) + "})")
+                # Allow the compositor to deliver focus before the test key.
+                time.sleep(0.1)
+                copied = time.monotonic()
+                send_key(address, "" if options.cancel else "CTRL",
+                         "Escape" if options.cancel else "c")
+                code = process.wait(timeout=10)
+                if options.cancel:
+                    if run("wl-paste", "--no-newline", "--type", "text/plain") != marker:
+                        raise RuntimeError("Escape overwrote the clipboard")
+                    result = {"overlay_ms": overlay_ms, "cancel_preserved_clipboard": True}
+                else:
+                    if code != 0:
+                        raise RuntimeError("Capture failed with exit code " + str(code))
+                    mime = None
+                    while time.monotonic() - copied < 10:
+                        types = run("wl-paste", "--list-types").splitlines()
+                        mime = next((m for m in ("image/png", "image/jpeg")
+                                     if m.encode() in types), None)
+                        if mime:
+                            break
+                        time.sleep(0.01)
+                    if mime is None:
+                        raise RuntimeError("No clipboard image arrived within 10 seconds")
+                    image = run("wl-paste", "--type", mime)
+                    copy_ms = round((time.monotonic() - copied) * 1000)
+                    if image_dimensions(image) != (800, 500):
+                        raise RuntimeError("Selection dimensions changed")
+                    if run("wl-paste", "--type", mime) != image:
+                        raise RuntimeError("Repeated paste returned different bytes")
+                    result = {"overlay_ms": overlay_ms, "clipboard_ms": copy_ms,
+                              "mime": mime, "image_bytes": len(image), "dimensions": [800, 500],
+                              "repeated_paste": True}
+                if any(w["address"] == address for w in windows()):
+                    raise RuntimeError("Editor remained open after copy/cancel")
+                completed = True
+                print(json.dumps(result))
+            finally:
+                if process.poll() is None:
+                    if address and any(w["address"] == address for w in windows()):
+                        send_key(address, "", "Escape")
+                    try:
+                        process.wait(timeout=3)
+                    except subprocess.TimeoutExpired:
+                        process.terminate()
+                        process.wait(timeout=3)
+                if not completed:
+                    log.seek(0)
+                    print(log.read().decode(errors="replace"))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
On supported Wayland compositors, opening a capture and copying it with Ctrl+C can be substantially faster while keeping the normal editor and annotation workflow. This change makes the faster capture and clipboard backends independently opt-in; existing defaults remain in place.

Enable with `FLAMESHOT_USE_GRIM=1 FLAMESHOT_USE_WL_COPY=1 flameshot gui`, with `grim` and `wl-clipboard` installed. Direct PPM capture avoids PNG compression before opening the editor. The clipboard helper encodes the image once and keeps serving it after Flameshot exits, including repeated pastes. Helper failures fall back to the existing backends, with a three-second timeout per helper.

On one Hyprland 0.56.2 desktop with Qt 6.11.2 and two monitors at scales 1 and 1.6, three interleaved runs per mode on the same monitor gave these medians for an 800×500 selection:

| Measurement | Default backends | Both options enabled |
| --- | ---: | ---: |
| Launch to editor detected | 2,834 ms | 247 ms |
| Ctrl+C to first image read | 227 ms | 33 ms |

These are a small local sample on a live desktop, not a cross-compositor benchmark. The included `tests/wayland_performance.py` script reproduces the measurement and checks the copied dimensions and repeated pastes.

PPM increases temporary memory use. The clipboard path uses a private temporary file until `wl-copy` consumes it and preserves the JPEG and save-after-copy preferences. Desktop testing covered Hyprland only; support elsewhere depends on the protocols provided by the compositor. Existing monitor selection and mixed-DPI cropping are retained.

Related: #3859, #4498

Validation:

- Release builds succeeded with `USE_WAYLAND_CLIPBOARD=ON` and `OFF`.
- Changed C++ files passed clang-format 11.1.0 checks.
- Ctrl+C produced an 800×500 image and identical repeated pastes after editor exit on both monitors, including fractional scaling.
- Escape preserved the previous clipboard contents.
- Injected failures of `grim` and `wl-copy` successfully used the fallback backends.

For comparison, run `python3 tests/wayland_performance.py build/src/flameshot --screen 1` with and without `--fast`. Add `--cancel` or `--fast --fail-tool grim` / `--fast --fail-tool wl-copy` for the regression checks. The test replaces the clipboard and uses the current user preferences.
