### PR TITLE
fix: macOS brew install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,7 +386,7 @@ There are packages available in the repository of some Linux distributions:
 ```
 brew tap flameshot-org/flameshot
 brew trust --cask flameshot-org/flameshot/flameshot-org-flameshot
-brew install  flameshot-org-flameshot
+brew install flameshot-org/flameshot/flameshot-org-flameshot
 ```
 
 **Note** that because of macOS security features, you may not be able to open flameshot when installed using brew.


### PR DESCRIPTION
### Fixes wrong brew install command

```shell
❯ brew tap flameshot-org/flameshot
==> Tapping flameshot-org/flameshot
Cloning into '/opt/homebrew/Library/Taps/flameshot-org/homebrew-flameshot'...
Error: Invalid cask (macOS 27 on arm): /opt/homebrew/Library/Taps/flameshot-org/homebrew-flameshot/Casks/flameshot-org-flameshot.rb
Refusing to load cask flameshot-org/flameshot/flameshot-org-flameshot from untrusted tap flameshot-org/flameshot.
Run `brew trust --cask flameshot-org/flameshot/flameshot-org-flameshot` or `brew trust flameshot-org/flameshot` to trust it.

❯ brew trust --cask flameshot-org/flameshot/flameshot-org-flameshot
Trusted cask: flameshot-org/flameshot/flameshot-org-flameshot

❯ brew install flameshot-org-flameshot
Warning: No available formula with the name "flameshot-org-flameshot".
==> Searching for similarly named formulae and casks...
Error: No formulae or casks found for flameshot-org-flameshot.
```

### Test after fix

```shell
❯ brew tap flameshot-org/flameshot
==> Tapping flameshot-org/flameshot
Cloning into '/opt/homebrew/Library/Taps/flameshot-org/homebrew-flameshot'...
Error: Invalid cask (macOS 27 on arm): /opt/homebrew/Library/Taps/flameshot-org/homebrew-flameshot/Casks/flameshot-org-flameshot.rb
Refusing to load cask flameshot-org/flameshot/flameshot-org-flameshot from untrusted tap flameshot-org/flameshot.

❯ brew trust --cask flameshot-org/flameshot/flameshot-org-flameshot
Trusted cask: flameshot-org/flameshot/flameshot-org-flameshot

❯ brew install flameshot-org/flameshot/flameshot-org-flameshot
==> Would install 1 cask:
flameshot-org/flameshot/flameshot-org-flameshot
==> Fetching downloads for: flameshot-org/flameshot/flameshot-org-flameshot
✔︎ Cask flameshot-org-flameshot (14.0.0,14.0,git0.da6121bd)                          Downloaded   40.3MB/ 40.3MB
==> Installing Cask flameshot-org-flameshot
==> Moving App 'Flameshot.app' to '/Applications/Flameshot.app'
🍺  flameshot-org-flameshot was successfully installed!
```